### PR TITLE
grpc code generation workaround

### DIFF
--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -113,10 +113,6 @@ func (g *grpc) GenerateImports(file *generator.FileDescriptor) {
 	g.P(grpcPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, grpcPkgPath)))
 	g.P(")")
 	g.P()
-	g.P("// Reference imports to suppress errors if they are not otherwise used.")
-	g.P("var _ ", contextPkg, ".Context")
-	g.P("var _ ", grpcPkg, ".ClientConn")
-	g.P()
 }
 
 // reservedClientName records whether a client name is reserved on the client side.

--- a/test/issue83/Makefile
+++ b/test/issue83/Makefile
@@ -1,0 +1,30 @@
+# Extensions for Protocol Buffers to create more go like structures.
+#
+# Copyright (c) 2013, Vastech SA (PTY) LTD. All rights reserved.
+# http://github.com/gogo/protobuf
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+regenerate:
+	(protoc --proto_path=../../../../../:../../protobuf/:. --gogofast_out=plugins=grpc:. proto.proto)

--- a/test/issue83/proto.proto
+++ b/test/issue83/proto.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package issue83;
+service Bar {rpc Bar(Foo) returns (Foo);}
+message Foo {}


### PR DESCRIPTION
Sometimes code generation with `--gogofast_out=plugins=grpc:.` fails because the statements the grpc plugin adds to avoid "unused import" errors end up being in the middle of the import list, causing the build to fail regardless of whether the imports are used or not. This pull request fixes grpc code generation for the case where the imports are used by removing the `_ = pkg.Func` statements from grpc code generation, thus totally breaking the case where they are not used.

The issue was observed with go1.5 from Wednsday (2e4b659) and the protobufs in https://github.com/yahoo/coname/tree/master/proto.