### PR TITLE
Casttype for maps

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -1850,8 +1850,13 @@ func (g *Generator) generateMessage(message *Descriptor) {
 				default:
 					valType = strings.TrimPrefix(valType, "*")
 				}
-
-				typename = fmt.Sprintf("map[%s]%s", keyType, valType)
+				_, typename, err = getCastType(field)
+				if err != nil {
+					g.Fail(err.Error())
+				}
+				if typename == "" {
+					typename = fmt.Sprintf("map[%s]%s", keyType, valType)
+				}
 				mapFieldTypes[field] = typename // record for the getter generation
 
 				tag += fmt.Sprintf(" protobuf_key:%s protobuf_val:%s", keyTag, valTag)


### PR DESCRIPTION
Hello, I have made some changes to allow to define alias for map. It is a rashly update but it works in my case. The reason was next:  
I needed the way to unmarshal json string to structures generated by gogo. But for maps like, for example, map[int]string it is necessary to implement custom marshaling, that is why aliases for map has arisen in my cases (first: type MapIntToString map[int]string, second implement interface: func (this *MapIntToString) UnmarshalJSON(b []byte) (err error) {}). Please, add quality support for casttype attribute for maps. Thanks!