### PR TITLE
plugin/equal: add missing white space for VerboseEqual

### DIFF
--- a/plugin/equal/equal.go
+++ b/plugin/equal/equal.go
@@ -84,7 +84,7 @@ given to the equal plugin, will generate the following code:
 			}
 			return fmt2.Errorf("that is type *B but is nil && this != nil")
 		} else if this == nil {
-			return fmt2.Errorf("that is type *Bbut is not nil && this == nil")
+			return fmt2.Errorf("that is type *B but is not nil && this == nil")
 		}
 		if !this.A.Equal(&that1.A) {
 			return fmt2.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -279,7 +279,7 @@ func (p *plugin) generateMsgNullAndTypeCheck(ccTypeName string, verbose bool) {
 	p.P(`} else if this == nil {`)
 	p.In()
 	if verbose {
-		p.P(`return `, p.fmtPkg.Use(), `.Errorf("that is type *`, ccTypeName, `but is not nil && this == nil")`)
+		p.P(`return `, p.fmtPkg.Use(), `.Errorf("that is type *`, ccTypeName, ` but is not nil && this == nil")`)
 	} else {
 		p.P(`return false`)
 	}

--- a/test/casttype/combos/both/casttype.pb.go
+++ b/test/casttype/combos/both/casttype.pb.go
@@ -1026,7 +1026,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/casttype/combos/marshaler/casttype.pb.go
+++ b/test/casttype/combos/marshaler/casttype.pb.go
@@ -1024,7 +1024,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/casttype/combos/neither/casttype.pb.go
+++ b/test/casttype/combos/neither/casttype.pb.go
@@ -1024,7 +1024,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/casttype/combos/unmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unmarshaler/casttype.pb.go
@@ -1026,7 +1026,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/casttype/combos/unsafeboth/casttype.pb.go
+++ b/test/casttype/combos/unsafeboth/casttype.pb.go
@@ -1026,7 +1026,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/casttype/combos/unsafemarshaler/casttype.pb.go
+++ b/test/casttype/combos/unsafemarshaler/casttype.pb.go
@@ -1024,7 +1024,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/casttype/combos/unsafeunmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unsafeunmarshaler/casttype.pb.go
@@ -1026,7 +1026,7 @@ func (this *Castaway) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Castaway but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Castawaybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Castaway but is not nil && this == nil")
 	}
 	if this.Int32Ptr != nil && that1.Int32Ptr != nil {
 		if *this.Int32Ptr != *that1.Int32Ptr {

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -4060,7 +4060,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4200,7 +4200,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4508,7 +4508,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4798,7 +4798,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5088,7 +5088,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5346,7 +5346,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5604,7 +5604,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5714,7 +5714,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5896,7 +5896,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6106,7 +6106,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6316,7 +6316,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6384,7 +6384,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6464,7 +6464,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6536,7 +6536,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6608,7 +6608,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6670,7 +6670,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6734,7 +6734,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6812,7 +6812,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6894,7 +6894,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6976,7 +6976,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7176,7 +7176,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7352,7 +7352,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7432,7 +7432,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7500,7 +7500,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7568,7 +7568,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7630,7 +7630,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7692,7 +7692,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7754,7 +7754,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7822,7 +7822,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7878,7 +7878,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7940,7 +7940,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7996,7 +7996,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8046,7 +8046,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8102,7 +8102,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8170,7 +8170,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8236,7 +8236,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8302,7 +8302,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8370,7 +8370,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8438,7 +8438,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8506,7 +8506,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8574,7 +8574,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8670,7 +8670,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8790,7 +8790,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8888,7 +8888,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8962,7 +8962,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9030,7 +9030,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9110,7 +9110,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9418,7 +9418,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9474,7 +9474,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9614,7 +9614,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9922,7 +9922,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10212,7 +10212,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10404,7 +10404,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10514,7 +10514,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10594,7 +10594,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10678,7 +10678,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10752,7 +10752,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10814,7 +10814,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10898,7 +10898,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10960,7 +10960,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11034,7 +11034,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/combos/marshaler/thetest.pb.go
+++ b/test/combos/marshaler/thetest.pb.go
@@ -4058,7 +4058,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4198,7 +4198,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4506,7 +4506,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4796,7 +4796,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5086,7 +5086,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5344,7 +5344,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5602,7 +5602,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5712,7 +5712,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5894,7 +5894,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6104,7 +6104,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6314,7 +6314,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6382,7 +6382,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6462,7 +6462,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6534,7 +6534,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6606,7 +6606,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6668,7 +6668,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6732,7 +6732,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6810,7 +6810,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6892,7 +6892,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6974,7 +6974,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7174,7 +7174,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7350,7 +7350,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7430,7 +7430,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7498,7 +7498,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7566,7 +7566,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7628,7 +7628,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7690,7 +7690,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7752,7 +7752,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7820,7 +7820,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7876,7 +7876,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7938,7 +7938,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7994,7 +7994,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8044,7 +8044,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8100,7 +8100,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8168,7 +8168,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8234,7 +8234,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8300,7 +8300,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8368,7 +8368,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8436,7 +8436,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8504,7 +8504,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8572,7 +8572,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8668,7 +8668,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8788,7 +8788,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8886,7 +8886,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8960,7 +8960,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9028,7 +9028,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9108,7 +9108,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9416,7 +9416,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9472,7 +9472,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9612,7 +9612,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9920,7 +9920,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10210,7 +10210,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10402,7 +10402,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10512,7 +10512,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10592,7 +10592,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10676,7 +10676,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10750,7 +10750,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10812,7 +10812,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10896,7 +10896,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10958,7 +10958,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11032,7 +11032,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -4060,7 +4060,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4200,7 +4200,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4508,7 +4508,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4798,7 +4798,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5088,7 +5088,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5346,7 +5346,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5604,7 +5604,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5714,7 +5714,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5896,7 +5896,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6106,7 +6106,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6316,7 +6316,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6384,7 +6384,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6464,7 +6464,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6536,7 +6536,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6608,7 +6608,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6670,7 +6670,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6734,7 +6734,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6812,7 +6812,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6894,7 +6894,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6976,7 +6976,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7176,7 +7176,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7352,7 +7352,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7432,7 +7432,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7500,7 +7500,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7568,7 +7568,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7630,7 +7630,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7692,7 +7692,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7754,7 +7754,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7822,7 +7822,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7878,7 +7878,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7940,7 +7940,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7996,7 +7996,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8046,7 +8046,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8102,7 +8102,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8170,7 +8170,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8236,7 +8236,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8302,7 +8302,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8370,7 +8370,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8438,7 +8438,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8506,7 +8506,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8574,7 +8574,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8670,7 +8670,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8790,7 +8790,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8888,7 +8888,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8962,7 +8962,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9030,7 +9030,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9110,7 +9110,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9418,7 +9418,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9474,7 +9474,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9614,7 +9614,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9922,7 +9922,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10212,7 +10212,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10404,7 +10404,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10514,7 +10514,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10594,7 +10594,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10678,7 +10678,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10752,7 +10752,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10814,7 +10814,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10898,7 +10898,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10960,7 +10960,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11034,7 +11034,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/combos/unsafeboth/thetest.pb.go
+++ b/test/combos/unsafeboth/thetest.pb.go
@@ -4062,7 +4062,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4202,7 +4202,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4510,7 +4510,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4800,7 +4800,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5090,7 +5090,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5348,7 +5348,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5606,7 +5606,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5716,7 +5716,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5898,7 +5898,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6108,7 +6108,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6318,7 +6318,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6386,7 +6386,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6466,7 +6466,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6538,7 +6538,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6610,7 +6610,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6672,7 +6672,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6736,7 +6736,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6814,7 +6814,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6896,7 +6896,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6978,7 +6978,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7178,7 +7178,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7354,7 +7354,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7434,7 +7434,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7502,7 +7502,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7570,7 +7570,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7632,7 +7632,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7694,7 +7694,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7756,7 +7756,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7824,7 +7824,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7880,7 +7880,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7942,7 +7942,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7998,7 +7998,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8048,7 +8048,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8104,7 +8104,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8172,7 +8172,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8238,7 +8238,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8304,7 +8304,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8372,7 +8372,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8440,7 +8440,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8508,7 +8508,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8576,7 +8576,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8672,7 +8672,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8792,7 +8792,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8890,7 +8890,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8964,7 +8964,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9032,7 +9032,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9112,7 +9112,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9420,7 +9420,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9476,7 +9476,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9616,7 +9616,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9924,7 +9924,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10214,7 +10214,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10406,7 +10406,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10516,7 +10516,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10596,7 +10596,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10680,7 +10680,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10754,7 +10754,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10816,7 +10816,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10900,7 +10900,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10962,7 +10962,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11036,7 +11036,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/combos/unsafemarshaler/thetest.pb.go
+++ b/test/combos/unsafemarshaler/thetest.pb.go
@@ -4060,7 +4060,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4200,7 +4200,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4508,7 +4508,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4798,7 +4798,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5088,7 +5088,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5346,7 +5346,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5604,7 +5604,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5714,7 +5714,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5896,7 +5896,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6106,7 +6106,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6316,7 +6316,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6384,7 +6384,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6464,7 +6464,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6536,7 +6536,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6608,7 +6608,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6670,7 +6670,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6734,7 +6734,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6812,7 +6812,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6894,7 +6894,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6976,7 +6976,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7176,7 +7176,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7352,7 +7352,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7432,7 +7432,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7500,7 +7500,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7568,7 +7568,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7630,7 +7630,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7692,7 +7692,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7754,7 +7754,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7822,7 +7822,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7878,7 +7878,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7940,7 +7940,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7996,7 +7996,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8046,7 +8046,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8102,7 +8102,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8170,7 +8170,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8236,7 +8236,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8302,7 +8302,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8370,7 +8370,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8438,7 +8438,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8506,7 +8506,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8574,7 +8574,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8670,7 +8670,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8790,7 +8790,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8888,7 +8888,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8962,7 +8962,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9030,7 +9030,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9110,7 +9110,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9418,7 +9418,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9474,7 +9474,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9614,7 +9614,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9922,7 +9922,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10212,7 +10212,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10404,7 +10404,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10514,7 +10514,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10594,7 +10594,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10678,7 +10678,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10752,7 +10752,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10814,7 +10814,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10898,7 +10898,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10960,7 +10960,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11034,7 +11034,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/combos/unsafeunmarshaler/thetest.pb.go
+++ b/test/combos/unsafeunmarshaler/thetest.pb.go
@@ -4061,7 +4061,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4201,7 +4201,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4509,7 +4509,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4799,7 +4799,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5089,7 +5089,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5347,7 +5347,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5605,7 +5605,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5715,7 +5715,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5897,7 +5897,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6107,7 +6107,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6317,7 +6317,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6385,7 +6385,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6465,7 +6465,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6537,7 +6537,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6609,7 +6609,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6671,7 +6671,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6735,7 +6735,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6813,7 +6813,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6895,7 +6895,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6977,7 +6977,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7177,7 +7177,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7353,7 +7353,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7433,7 +7433,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7501,7 +7501,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7569,7 +7569,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7631,7 +7631,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7693,7 +7693,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7755,7 +7755,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7823,7 +7823,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7879,7 +7879,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7941,7 +7941,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7997,7 +7997,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8047,7 +8047,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8103,7 +8103,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8171,7 +8171,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8237,7 +8237,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8303,7 +8303,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8371,7 +8371,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8439,7 +8439,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8507,7 +8507,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8575,7 +8575,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8671,7 +8671,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8791,7 +8791,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8889,7 +8889,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8963,7 +8963,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9031,7 +9031,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9111,7 +9111,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9419,7 +9419,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9475,7 +9475,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9615,7 +9615,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9923,7 +9923,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10213,7 +10213,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10405,7 +10405,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10515,7 +10515,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10595,7 +10595,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10679,7 +10679,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10753,7 +10753,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10815,7 +10815,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10899,7 +10899,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10961,7 +10961,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11035,7 +11035,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/enumstringer/enumstringer.pb.go
+++ b/test/enumstringer/enumstringer.pb.go
@@ -153,7 +153,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -209,7 +209,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -277,7 +277,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -343,7 +343,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))

--- a/test/example/example.pb.go
+++ b/test/example/example.pb.go
@@ -1168,7 +1168,7 @@ func (this *A) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *A but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Abut is not nil && this == nil")
+		return fmt.Errorf("that is type *A but is not nil && this == nil")
 	}
 	if this.Description != that1.Description {
 		return fmt.Errorf("Description this(%v) Not Equal that(%v)", this.Description, that1.Description)
@@ -1236,7 +1236,7 @@ func (this *B) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *B but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Bbut is not nil && this == nil")
+		return fmt.Errorf("that is type *B but is not nil && this == nil")
 	}
 	if !this.A.Equal(&that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -1308,7 +1308,7 @@ func (this *C) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *C but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Cbut is not nil && this == nil")
+		return fmt.Errorf("that is type *C but is not nil && this == nil")
 	}
 	if this.MySize != nil && that1.MySize != nil {
 		if *this.MySize != *that1.MySize {
@@ -1376,7 +1376,7 @@ func (this *U) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *U but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Ubut is not nil && this == nil")
+		return fmt.Errorf("that is type *U but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -1438,7 +1438,7 @@ func (this *E) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *E but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Ebut is not nil && this == nil")
+		return fmt.Errorf("that is type *E but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_extensions, that1.XXX_extensions) {
 		return fmt.Errorf("XXX_extensions this(%v) Not Equal that(%v)", this.XXX_extensions, that1.XXX_extensions)
@@ -1494,7 +1494,7 @@ func (this *R) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *R but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Rbut is not nil && this == nil")
+		return fmt.Errorf("that is type *R but is not nil && this == nil")
 	}
 	if this.Recognized != nil && that1.Recognized != nil {
 		if *this.Recognized != *that1.Recognized {
@@ -1556,7 +1556,7 @@ func (this *CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CastType but is not nil && this == nil")
 	}
 	if this.Int32 != nil && that1.Int32 != nil {
 		if *this.Int32 != *that1.Int32 {

--- a/test/group/group.pb.go
+++ b/test/group/group.pb.go
@@ -1054,7 +1054,7 @@ func (this *Groups1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Groups1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Groups1but is not nil && this == nil")
+		return fmt.Errorf("that is type *Groups1 but is not nil && this == nil")
 	}
 	if len(this.G) != len(that1.G) {
 		return fmt.Errorf("G this(%v) Not Equal that(%v)", len(this.G), len(that1.G))
@@ -1120,7 +1120,7 @@ func (this *Groups1_G) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Groups1_G but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Groups1_Gbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Groups1_G but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1206,7 +1206,7 @@ func (this *Groups2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Groups2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Groups2but is not nil && this == nil")
+		return fmt.Errorf("that is type *Groups2 but is not nil && this == nil")
 	}
 	if !this.G.Equal(that1.G) {
 		return fmt.Errorf("G this(%v) Not Equal that(%v)", this.G, that1.G)
@@ -1262,7 +1262,7 @@ func (this *Groups2_G) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Groups2_G but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Groups2_Gbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Groups2_G but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/mapsproto2/combos/both/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/both/mapsproto2.pb.go
@@ -1385,7 +1385,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1453,7 +1453,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
@@ -1383,7 +1383,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1451,7 +1451,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/mapsproto2/combos/neither/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/neither/mapsproto2.pb.go
@@ -1381,7 +1381,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1449,7 +1449,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
@@ -1383,7 +1383,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1451,7 +1451,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/mapsproto2/combos/unsafeboth/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unsafeboth/mapsproto2.pb.go
@@ -1386,7 +1386,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1454,7 +1454,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/mapsproto2/combos/unsafemarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unsafemarshaler/mapsproto2.pb.go
@@ -1384,7 +1384,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1452,7 +1452,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/mapsproto2/combos/unsafeunmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unsafeunmarshaler/mapsproto2.pb.go
@@ -1384,7 +1384,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != nil && that1.F != nil {
 		if *this.F != *that1.F {
@@ -1452,7 +1452,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))

--- a/test/oneof/combos/both/one.pb.go
+++ b/test/oneof/combos/both/one.pb.go
@@ -1934,7 +1934,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -2002,7 +2002,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2036,7 +2036,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2061,7 +2061,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2086,7 +2086,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2111,7 +2111,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2136,7 +2136,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2161,7 +2161,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2186,7 +2186,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2211,7 +2211,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2236,7 +2236,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2261,7 +2261,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2286,7 +2286,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2311,7 +2311,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2336,7 +2336,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2361,7 +2361,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2386,7 +2386,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2411,7 +2411,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2870,7 +2870,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2913,7 +2913,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2938,7 +2938,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2963,7 +2963,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2988,7 +2988,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3013,7 +3013,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3038,7 +3038,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3256,7 +3256,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3290,7 +3290,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3315,7 +3315,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3340,7 +3340,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3365,7 +3365,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof/combos/marshaler/one.pb.go
+++ b/test/oneof/combos/marshaler/one.pb.go
@@ -1932,7 +1932,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -2000,7 +2000,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2034,7 +2034,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2059,7 +2059,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2084,7 +2084,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2109,7 +2109,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2134,7 +2134,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2159,7 +2159,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2184,7 +2184,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2209,7 +2209,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2234,7 +2234,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2259,7 +2259,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2284,7 +2284,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2309,7 +2309,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2334,7 +2334,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2359,7 +2359,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2384,7 +2384,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2409,7 +2409,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2868,7 +2868,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2911,7 +2911,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2936,7 +2936,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2961,7 +2961,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2986,7 +2986,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3011,7 +3011,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3036,7 +3036,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3254,7 +3254,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3288,7 +3288,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3313,7 +3313,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3338,7 +3338,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3363,7 +3363,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof/combos/neither/one.pb.go
+++ b/test/oneof/combos/neither/one.pb.go
@@ -1928,7 +1928,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -1996,7 +1996,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2030,7 +2030,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2055,7 +2055,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2080,7 +2080,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2105,7 +2105,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2130,7 +2130,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2155,7 +2155,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2180,7 +2180,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2205,7 +2205,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2230,7 +2230,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2255,7 +2255,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2280,7 +2280,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2305,7 +2305,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2330,7 +2330,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2355,7 +2355,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2380,7 +2380,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2405,7 +2405,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2864,7 +2864,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2907,7 +2907,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2932,7 +2932,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2957,7 +2957,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2982,7 +2982,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3007,7 +3007,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3032,7 +3032,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3250,7 +3250,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3284,7 +3284,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3309,7 +3309,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3334,7 +3334,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3359,7 +3359,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof/combos/unmarshaler/one.pb.go
+++ b/test/oneof/combos/unmarshaler/one.pb.go
@@ -1930,7 +1930,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -1998,7 +1998,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2032,7 +2032,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2057,7 +2057,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2082,7 +2082,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2107,7 +2107,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2132,7 +2132,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2157,7 +2157,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2182,7 +2182,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2207,7 +2207,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2232,7 +2232,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2257,7 +2257,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2282,7 +2282,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2307,7 +2307,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2332,7 +2332,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2357,7 +2357,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2382,7 +2382,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2407,7 +2407,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2866,7 +2866,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2909,7 +2909,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2934,7 +2934,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2959,7 +2959,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2984,7 +2984,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3009,7 +3009,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3034,7 +3034,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3252,7 +3252,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3286,7 +3286,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3311,7 +3311,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3336,7 +3336,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3361,7 +3361,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof/combos/unsafeboth/one.pb.go
+++ b/test/oneof/combos/unsafeboth/one.pb.go
@@ -1936,7 +1936,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -2004,7 +2004,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2038,7 +2038,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2063,7 +2063,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2088,7 +2088,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2113,7 +2113,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2138,7 +2138,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2163,7 +2163,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2188,7 +2188,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2213,7 +2213,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2238,7 +2238,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2263,7 +2263,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2288,7 +2288,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2313,7 +2313,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2338,7 +2338,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2363,7 +2363,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2388,7 +2388,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2413,7 +2413,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2872,7 +2872,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2915,7 +2915,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2940,7 +2940,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2965,7 +2965,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2990,7 +2990,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3015,7 +3015,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3040,7 +3040,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3258,7 +3258,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3292,7 +3292,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3317,7 +3317,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3342,7 +3342,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3367,7 +3367,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof/combos/unsafemarshaler/one.pb.go
+++ b/test/oneof/combos/unsafemarshaler/one.pb.go
@@ -1934,7 +1934,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -2002,7 +2002,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2036,7 +2036,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2061,7 +2061,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2086,7 +2086,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2111,7 +2111,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2136,7 +2136,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2161,7 +2161,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2186,7 +2186,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2211,7 +2211,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2236,7 +2236,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2261,7 +2261,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2286,7 +2286,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2311,7 +2311,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2336,7 +2336,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2361,7 +2361,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2386,7 +2386,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2411,7 +2411,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2870,7 +2870,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2913,7 +2913,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2938,7 +2938,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2963,7 +2963,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2988,7 +2988,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3013,7 +3013,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3038,7 +3038,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3256,7 +3256,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3290,7 +3290,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3315,7 +3315,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3340,7 +3340,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3365,7 +3365,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof/combos/unsafeunmarshaler/one.pb.go
+++ b/test/oneof/combos/unsafeunmarshaler/one.pb.go
@@ -1931,7 +1931,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != nil && that1.Sub != nil {
 		if *this.Sub != *that1.Sub {
@@ -1999,7 +1999,7 @@ func (this *AllTypesOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -2033,7 +2033,7 @@ func (this *AllTypesOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2058,7 +2058,7 @@ func (this *AllTypesOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2083,7 +2083,7 @@ func (this *AllTypesOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2108,7 +2108,7 @@ func (this *AllTypesOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -2133,7 +2133,7 @@ func (this *AllTypesOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -2158,7 +2158,7 @@ func (this *AllTypesOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -2183,7 +2183,7 @@ func (this *AllTypesOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -2208,7 +2208,7 @@ func (this *AllTypesOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -2233,7 +2233,7 @@ func (this *AllTypesOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -2258,7 +2258,7 @@ func (this *AllTypesOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -2283,7 +2283,7 @@ func (this *AllTypesOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -2308,7 +2308,7 @@ func (this *AllTypesOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -2333,7 +2333,7 @@ func (this *AllTypesOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -2358,7 +2358,7 @@ func (this *AllTypesOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -2383,7 +2383,7 @@ func (this *AllTypesOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -2408,7 +2408,7 @@ func (this *AllTypesOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllTypesOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllTypesOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)
@@ -2867,7 +2867,7 @@ func (this *TwoOneofs) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs but is not nil && this == nil")
 	}
 	if that1.One == nil {
 		if this.One != nil {
@@ -2910,7 +2910,7 @@ func (this *TwoOneofs_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -2935,7 +2935,7 @@ func (this *TwoOneofs_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -2960,7 +2960,7 @@ func (this *TwoOneofs_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -2985,7 +2985,7 @@ func (this *TwoOneofs_Field34) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field34 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field34but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field34 but is not nil && this == nil")
 	}
 	if this.Field34 != that1.Field34 {
 		return fmt.Errorf("Field34 this(%v) Not Equal that(%v)", this.Field34, that1.Field34)
@@ -3010,7 +3010,7 @@ func (this *TwoOneofs_Field35) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_Field35 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_Field35but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_Field35 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field35, that1.Field35) {
 		return fmt.Errorf("Field35 this(%v) Not Equal that(%v)", this.Field35, that1.Field35)
@@ -3035,7 +3035,7 @@ func (this *TwoOneofs_SubMessage2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *TwoOneofs_SubMessage2but is not nil && this == nil")
+		return fmt.Errorf("that is type *TwoOneofs_SubMessage2 but is not nil && this == nil")
 	}
 	if !this.SubMessage2.Equal(that1.SubMessage2) {
 		return fmt.Errorf("SubMessage2 this(%v) Not Equal that(%v)", this.SubMessage2, that1.SubMessage2)
@@ -3253,7 +3253,7 @@ func (this *CustomOneof) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneofbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof but is not nil && this == nil")
 	}
 	if that1.Custom == nil {
 		if this.Custom != nil {
@@ -3287,7 +3287,7 @@ func (this *CustomOneof_Stringy) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_Stringy but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_Stringybut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_Stringy but is not nil && this == nil")
 	}
 	if this.Stringy != that1.Stringy {
 		return fmt.Errorf("Stringy this(%v) Not Equal that(%v)", this.Stringy, that1.Stringy)
@@ -3312,7 +3312,7 @@ func (this *CustomOneof_CustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CustomType but is not nil && this == nil")
 	}
 	if !this.CustomType.Equal(that1.CustomType) {
 		return fmt.Errorf("CustomType this(%v) Not Equal that(%v)", this.CustomType, that1.CustomType)
@@ -3337,7 +3337,7 @@ func (this *CustomOneof_CastType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_CastType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_CastTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_CastType but is not nil && this == nil")
 	}
 	if this.CastType != that1.CastType {
 		return fmt.Errorf("CastType this(%v) Not Equal that(%v)", this.CastType, that1.CastType)
@@ -3362,7 +3362,7 @@ func (this *CustomOneof_MyCustomName) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomOneof_MyCustomNamebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomOneof_MyCustomName but is not nil && this == nil")
 	}
 	if this.MyCustomName != that1.MyCustomName {
 		return fmt.Errorf("MyCustomName this(%v) Not Equal that(%v)", this.MyCustomName, that1.MyCustomName)

--- a/test/oneof3/combos/both/one.pb.go
+++ b/test/oneof3/combos/both/one.pb.go
@@ -1501,7 +1501,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1551,7 +1551,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1582,7 +1582,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1607,7 +1607,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1632,7 +1632,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1657,7 +1657,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1682,7 +1682,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1707,7 +1707,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1732,7 +1732,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1757,7 +1757,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1782,7 +1782,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1807,7 +1807,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1832,7 +1832,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1857,7 +1857,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1882,7 +1882,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1907,7 +1907,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1932,7 +1932,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1957,7 +1957,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/oneof3/combos/marshaler/one.pb.go
+++ b/test/oneof3/combos/marshaler/one.pb.go
@@ -1499,7 +1499,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1549,7 +1549,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1580,7 +1580,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1605,7 +1605,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1630,7 +1630,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1655,7 +1655,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1680,7 +1680,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1705,7 +1705,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1730,7 +1730,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1755,7 +1755,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1780,7 +1780,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1805,7 +1805,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1830,7 +1830,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1855,7 +1855,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1880,7 +1880,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1905,7 +1905,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1930,7 +1930,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1955,7 +1955,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/oneof3/combos/neither/one.pb.go
+++ b/test/oneof3/combos/neither/one.pb.go
@@ -1498,7 +1498,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1548,7 +1548,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1579,7 +1579,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1604,7 +1604,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1629,7 +1629,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1654,7 +1654,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1679,7 +1679,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1704,7 +1704,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1729,7 +1729,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1754,7 +1754,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1779,7 +1779,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1804,7 +1804,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1829,7 +1829,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1854,7 +1854,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1879,7 +1879,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1904,7 +1904,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1929,7 +1929,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1954,7 +1954,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/oneof3/combos/unmarshaler/one.pb.go
+++ b/test/oneof3/combos/unmarshaler/one.pb.go
@@ -1500,7 +1500,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1550,7 +1550,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1581,7 +1581,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1606,7 +1606,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1631,7 +1631,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1656,7 +1656,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1681,7 +1681,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1706,7 +1706,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1731,7 +1731,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1756,7 +1756,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1781,7 +1781,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1806,7 +1806,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1831,7 +1831,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1856,7 +1856,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1881,7 +1881,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1906,7 +1906,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1931,7 +1931,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1956,7 +1956,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/oneof3/combos/unsafeboth/one.pb.go
+++ b/test/oneof3/combos/unsafeboth/one.pb.go
@@ -1503,7 +1503,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1553,7 +1553,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1584,7 +1584,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1609,7 +1609,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1634,7 +1634,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1659,7 +1659,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1684,7 +1684,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1709,7 +1709,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1734,7 +1734,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1759,7 +1759,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1784,7 +1784,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1809,7 +1809,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1834,7 +1834,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1859,7 +1859,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1884,7 +1884,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1909,7 +1909,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1934,7 +1934,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1959,7 +1959,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/oneof3/combos/unsafemarshaler/one.pb.go
+++ b/test/oneof3/combos/unsafemarshaler/one.pb.go
@@ -1501,7 +1501,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1551,7 +1551,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1582,7 +1582,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1607,7 +1607,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1632,7 +1632,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1657,7 +1657,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1682,7 +1682,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1707,7 +1707,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1732,7 +1732,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1757,7 +1757,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1782,7 +1782,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1807,7 +1807,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1832,7 +1832,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1857,7 +1857,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1882,7 +1882,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1907,7 +1907,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1932,7 +1932,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1957,7 +1957,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/oneof3/combos/unsafeunmarshaler/one.pb.go
+++ b/test/oneof3/combos/unsafeunmarshaler/one.pb.go
@@ -1501,7 +1501,7 @@ func (this *Subby) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Subby but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbybut is not nil && this == nil")
+		return fmt.Errorf("that is type *Subby but is not nil && this == nil")
 	}
 	if this.Sub != that1.Sub {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -1551,7 +1551,7 @@ func (this *SampleOneOf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOfbut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf but is not nil && this == nil")
 	}
 	if that1.TestOneof == nil {
 		if this.TestOneof != nil {
@@ -1582,7 +1582,7 @@ func (this *SampleOneOf_Field1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field1but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field1 but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -1607,7 +1607,7 @@ func (this *SampleOneOf_Field2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field2but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field2 but is not nil && this == nil")
 	}
 	if this.Field2 != that1.Field2 {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", this.Field2, that1.Field2)
@@ -1632,7 +1632,7 @@ func (this *SampleOneOf_Field3) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field3 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field3but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field3 but is not nil && this == nil")
 	}
 	if this.Field3 != that1.Field3 {
 		return fmt.Errorf("Field3 this(%v) Not Equal that(%v)", this.Field3, that1.Field3)
@@ -1657,7 +1657,7 @@ func (this *SampleOneOf_Field4) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field4 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field4but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field4 but is not nil && this == nil")
 	}
 	if this.Field4 != that1.Field4 {
 		return fmt.Errorf("Field4 this(%v) Not Equal that(%v)", this.Field4, that1.Field4)
@@ -1682,7 +1682,7 @@ func (this *SampleOneOf_Field5) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field5 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field5but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field5 but is not nil && this == nil")
 	}
 	if this.Field5 != that1.Field5 {
 		return fmt.Errorf("Field5 this(%v) Not Equal that(%v)", this.Field5, that1.Field5)
@@ -1707,7 +1707,7 @@ func (this *SampleOneOf_Field6) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field6 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field6but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field6 but is not nil && this == nil")
 	}
 	if this.Field6 != that1.Field6 {
 		return fmt.Errorf("Field6 this(%v) Not Equal that(%v)", this.Field6, that1.Field6)
@@ -1732,7 +1732,7 @@ func (this *SampleOneOf_Field7) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field7 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field7but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field7 but is not nil && this == nil")
 	}
 	if this.Field7 != that1.Field7 {
 		return fmt.Errorf("Field7 this(%v) Not Equal that(%v)", this.Field7, that1.Field7)
@@ -1757,7 +1757,7 @@ func (this *SampleOneOf_Field8) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field8 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field8but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field8 but is not nil && this == nil")
 	}
 	if this.Field8 != that1.Field8 {
 		return fmt.Errorf("Field8 this(%v) Not Equal that(%v)", this.Field8, that1.Field8)
@@ -1782,7 +1782,7 @@ func (this *SampleOneOf_Field9) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field9 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field9but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field9 but is not nil && this == nil")
 	}
 	if this.Field9 != that1.Field9 {
 		return fmt.Errorf("Field9 this(%v) Not Equal that(%v)", this.Field9, that1.Field9)
@@ -1807,7 +1807,7 @@ func (this *SampleOneOf_Field10) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field10 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field10but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field10 but is not nil && this == nil")
 	}
 	if this.Field10 != that1.Field10 {
 		return fmt.Errorf("Field10 this(%v) Not Equal that(%v)", this.Field10, that1.Field10)
@@ -1832,7 +1832,7 @@ func (this *SampleOneOf_Field11) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field11 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field11but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field11 but is not nil && this == nil")
 	}
 	if this.Field11 != that1.Field11 {
 		return fmt.Errorf("Field11 this(%v) Not Equal that(%v)", this.Field11, that1.Field11)
@@ -1857,7 +1857,7 @@ func (this *SampleOneOf_Field12) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field12 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field12but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field12 but is not nil && this == nil")
 	}
 	if this.Field12 != that1.Field12 {
 		return fmt.Errorf("Field12 this(%v) Not Equal that(%v)", this.Field12, that1.Field12)
@@ -1882,7 +1882,7 @@ func (this *SampleOneOf_Field13) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field13 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field13but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field13 but is not nil && this == nil")
 	}
 	if this.Field13 != that1.Field13 {
 		return fmt.Errorf("Field13 this(%v) Not Equal that(%v)", this.Field13, that1.Field13)
@@ -1907,7 +1907,7 @@ func (this *SampleOneOf_Field14) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field14 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field14but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field14 but is not nil && this == nil")
 	}
 	if this.Field14 != that1.Field14 {
 		return fmt.Errorf("Field14 this(%v) Not Equal that(%v)", this.Field14, that1.Field14)
@@ -1932,7 +1932,7 @@ func (this *SampleOneOf_Field15) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_Field15 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_Field15but is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_Field15 but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.Field15, that1.Field15) {
 		return fmt.Errorf("Field15 this(%v) Not Equal that(%v)", this.Field15, that1.Field15)
@@ -1957,7 +1957,7 @@ func (this *SampleOneOf_SubMessage) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *SampleOneOf_SubMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *SampleOneOf_SubMessage but is not nil && this == nil")
 	}
 	if !this.SubMessage.Equal(that1.SubMessage) {
 		return fmt.Errorf("SubMessage this(%v) Not Equal that(%v)", this.SubMessage, that1.SubMessage)

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -3313,7 +3313,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3459,7 +3459,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3509,7 +3509,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3825,7 +3825,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3917,7 +3917,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/theproto3/combos/marshaler/theproto3.pb.go
+++ b/test/theproto3/combos/marshaler/theproto3.pb.go
@@ -3311,7 +3311,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3457,7 +3457,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3507,7 +3507,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3823,7 +3823,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3915,7 +3915,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/theproto3/combos/neither/theproto3.pb.go
+++ b/test/theproto3/combos/neither/theproto3.pb.go
@@ -3309,7 +3309,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3455,7 +3455,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3505,7 +3505,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3821,7 +3821,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3913,7 +3913,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -3311,7 +3311,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3457,7 +3457,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3507,7 +3507,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3823,7 +3823,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3915,7 +3915,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/theproto3/combos/unsafeboth/theproto3.pb.go
+++ b/test/theproto3/combos/unsafeboth/theproto3.pb.go
@@ -3314,7 +3314,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3460,7 +3460,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3510,7 +3510,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3826,7 +3826,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3918,7 +3918,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/theproto3/combos/unsafemarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unsafemarshaler/theproto3.pb.go
@@ -3312,7 +3312,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3458,7 +3458,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3508,7 +3508,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3824,7 +3824,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3916,7 +3916,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/theproto3/combos/unsafeunmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unsafeunmarshaler/theproto3.pb.go
@@ -3312,7 +3312,7 @@ func (this *Message) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Message but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Messagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Message but is not nil && this == nil")
 	}
 	if this.Name != that1.Name {
 		return fmt.Errorf("Name this(%v) Not Equal that(%v)", this.Name, that1.Name)
@@ -3458,7 +3458,7 @@ func (this *Nested) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nested but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nestedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nested but is not nil && this == nil")
 	}
 	if this.Bunny != that1.Bunny {
 		return fmt.Errorf("Bunny this(%v) Not Equal that(%v)", this.Bunny, that1.Bunny)
@@ -3508,7 +3508,7 @@ func (this *AllMaps) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AllMaps but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AllMapsbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AllMaps but is not nil && this == nil")
 	}
 	if len(this.StringToDoubleMap) != len(that1.StringToDoubleMap) {
 		return fmt.Errorf("StringToDoubleMap this(%v) Not Equal that(%v)", len(this.StringToDoubleMap), len(that1.StringToDoubleMap))
@@ -3824,7 +3824,7 @@ func (this *MessageWithMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MessageWithMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MessageWithMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *MessageWithMap but is not nil && this == nil")
 	}
 	if len(this.NameMapping) != len(that1.NameMapping) {
 		return fmt.Errorf("NameMapping this(%v) Not Equal that(%v)", len(this.NameMapping), len(that1.NameMapping))
@@ -3916,7 +3916,7 @@ func (this *FloatingPoint) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *FloatingPoint but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *FloatingPointbut is not nil && this == nil")
+		return fmt.Errorf("that is type *FloatingPoint but is not nil && this == nil")
 	}
 	if this.F != that1.F {
 		return fmt.Errorf("F this(%v) Not Equal that(%v)", this.F, that1.F)

--- a/test/thetest.pb.go
+++ b/test/thetest.pb.go
@@ -4058,7 +4058,7 @@ func (this *NidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -4198,7 +4198,7 @@ func (this *NinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNative but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -4506,7 +4506,7 @@ func (this *NidRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -4796,7 +4796,7 @@ func (this *NinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5086,7 +5086,7 @@ func (this *NidRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5344,7 +5344,7 @@ func (this *NinRepPackedNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepPackedNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepPackedNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepPackedNative but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -5602,7 +5602,7 @@ func (this *NidOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -5712,7 +5712,7 @@ func (this *NinOptStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStruct but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -5894,7 +5894,7 @@ func (this *NidRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6104,7 +6104,7 @@ func (this *NinRepStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepStruct but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -6314,7 +6314,7 @@ func (this *NidEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6382,7 +6382,7 @@ func (this *NinEmbeddedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStruct but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -6462,7 +6462,7 @@ func (this *NidNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(&that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6534,7 +6534,7 @@ func (this *NinNestedStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStruct but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -6606,7 +6606,7 @@ func (this *NidOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptCustom but is not nil && this == nil")
 	}
 	if !this.Id.Equal(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", this.Id, that1.Id)
@@ -6668,7 +6668,7 @@ func (this *CustomDash) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomDash but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomDashbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomDash but is not nil && this == nil")
 	}
 	if that1.Value == nil {
 		if this.Value != nil {
@@ -6732,7 +6732,7 @@ func (this *NinOptCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptCustom but is not nil && this == nil")
 	}
 	if that1.Id == nil {
 		if this.Id != nil {
@@ -6810,7 +6810,7 @@ func (this *NidRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6892,7 +6892,7 @@ func (this *NinRepCustom) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepCustom but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepCustombut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepCustom but is not nil && this == nil")
 	}
 	if len(this.Id) != len(that1.Id) {
 		return fmt.Errorf("Id this(%v) Not Equal that(%v)", len(this.Id), len(that1.Id))
@@ -6974,7 +6974,7 @@ func (this *NinOptNativeUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7174,7 +7174,7 @@ func (this *NinOptStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptStructUnion but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -7350,7 +7350,7 @@ func (this *NinEmbeddedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -7430,7 +7430,7 @@ func (this *NinNestedStructUnion) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinNestedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinNestedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinNestedStructUnion but is not nil && this == nil")
 	}
 	if !this.Field1.Equal(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -7498,7 +7498,7 @@ func (this *Tree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Tree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Treebut is not nil && this == nil")
+		return fmt.Errorf("that is type *Tree but is not nil && this == nil")
 	}
 	if !this.Or.Equal(that1.Or) {
 		return fmt.Errorf("Or this(%v) Not Equal that(%v)", this.Or, that1.Or)
@@ -7566,7 +7566,7 @@ func (this *OrBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OrBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OrBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OrBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7628,7 +7628,7 @@ func (this *AndBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7690,7 +7690,7 @@ func (this *Leaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Leaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Leafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Leaf but is not nil && this == nil")
 	}
 	if this.Value != that1.Value {
 		return fmt.Errorf("Value this(%v) Not Equal that(%v)", this.Value, that1.Value)
@@ -7752,7 +7752,7 @@ func (this *DeepTree) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepTree but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepTreebut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepTree but is not nil && this == nil")
 	}
 	if !this.Down.Equal(that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7820,7 +7820,7 @@ func (this *ADeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *ADeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *ADeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *ADeepBranch but is not nil && this == nil")
 	}
 	if !this.Down.Equal(&that1.Down) {
 		return fmt.Errorf("Down this(%v) Not Equal that(%v)", this.Down, that1.Down)
@@ -7876,7 +7876,7 @@ func (this *AndDeepBranch) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AndDeepBranch but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AndDeepBranchbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AndDeepBranch but is not nil && this == nil")
 	}
 	if !this.Left.Equal(&that1.Left) {
 		return fmt.Errorf("Left this(%v) Not Equal that(%v)", this.Left, that1.Left)
@@ -7938,7 +7938,7 @@ func (this *DeepLeaf) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *DeepLeaf but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *DeepLeafbut is not nil && this == nil")
+		return fmt.Errorf("that is type *DeepLeaf but is not nil && this == nil")
 	}
 	if !this.Tree.Equal(&that1.Tree) {
 		return fmt.Errorf("Tree this(%v) Not Equal that(%v)", this.Tree, that1.Tree)
@@ -7994,7 +7994,7 @@ func (this *Nil) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Nil but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Nilbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Nil but is not nil && this == nil")
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return fmt.Errorf("XXX_unrecognized this(%v) Not Equal that(%v)", this.XXX_unrecognized, that1.XXX_unrecognized)
@@ -8044,7 +8044,7 @@ func (this *NidOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != that1.Field1 {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", this.Field1, that1.Field1)
@@ -8100,7 +8100,7 @@ func (this *NinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8168,7 +8168,7 @@ func (this *NidRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NidRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NidRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NidRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8234,7 +8234,7 @@ func (this *NinRepEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinRepEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinRepEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinRepEnum but is not nil && this == nil")
 	}
 	if len(this.Field1) != len(that1.Field1) {
 		return fmt.Errorf("Field1 this(%v) Not Equal that(%v)", len(this.Field1), len(that1.Field1))
@@ -8300,7 +8300,7 @@ func (this *NinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8368,7 +8368,7 @@ func (this *AnotherNinOptEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnum but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8436,7 +8436,7 @@ func (this *AnotherNinOptEnumDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *AnotherNinOptEnumDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *AnotherNinOptEnumDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8504,7 +8504,7 @@ func (this *Timer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Timer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Timerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Timer but is not nil && this == nil")
 	}
 	if this.Time1 != that1.Time1 {
 		return fmt.Errorf("Time1 this(%v) Not Equal that(%v)", this.Time1, that1.Time1)
@@ -8572,7 +8572,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *MyExtendable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *MyExtendablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *MyExtendable but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8668,7 +8668,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OtherExtenable but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OtherExtenablebut is not nil && this == nil")
+		return fmt.Errorf("that is type *OtherExtenable but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -8788,7 +8788,7 @@ func (this *NestedDefinition) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedDefinition but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinitionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -8886,7 +8886,7 @@ func (this *NestedDefinition_NestedMessage) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessagebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage but is not nil && this == nil")
 	}
 	if this.NestedField1 != nil && that1.NestedField1 != nil {
 		if *this.NestedField1 != *that1.NestedField1 {
@@ -8960,7 +8960,7 @@ func (this *NestedDefinition_NestedMessage_NestedNestedMsg) VerboseEqual(that in
 		}
 		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsgbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedDefinition_NestedMessage_NestedNestedMsg but is not nil && this == nil")
 	}
 	if this.NestedNestedField1 != nil && that1.NestedNestedField1 != nil {
 		if *this.NestedNestedField1 != *that1.NestedNestedField1 {
@@ -9028,7 +9028,7 @@ func (this *NestedScope) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NestedScope but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NestedScopebut is not nil && this == nil")
+		return fmt.Errorf("that is type *NestedScope but is not nil && this == nil")
 	}
 	if !this.A.Equal(that1.A) {
 		return fmt.Errorf("A this(%v) Not Equal that(%v)", this.A, that1.A)
@@ -9108,7 +9108,7 @@ func (this *NinOptNativeDefault) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NinOptNativeDefault but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NinOptNativeDefaultbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NinOptNativeDefault but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -9416,7 +9416,7 @@ func (this *CustomContainer) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomContainer but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomContainerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomContainer but is not nil && this == nil")
 	}
 	if !this.CustomStruct.Equal(&that1.CustomStruct) {
 		return fmt.Errorf("CustomStruct this(%v) Not Equal that(%v)", this.CustomStruct, that1.CustomStruct)
@@ -9472,7 +9472,7 @@ func (this *CustomNameNidOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNidOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNidOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNidOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != that1.FieldA {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", this.FieldA, that1.FieldA)
@@ -9612,7 +9612,7 @@ func (this *CustomNameNinOptNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinOptNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinOptNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinOptNative but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -9920,7 +9920,7 @@ func (this *CustomNameNinRepNative) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinRepNative but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinRepNativebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinRepNative but is not nil && this == nil")
 	}
 	if len(this.FieldA) != len(that1.FieldA) {
 		return fmt.Errorf("FieldA this(%v) Not Equal that(%v)", len(this.FieldA), len(that1.FieldA))
@@ -10210,7 +10210,7 @@ func (this *CustomNameNinStruct) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameNinStruct but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinStructbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinStruct but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10402,7 +10402,7 @@ func (this *CustomNameCustomType) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameCustomType but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameCustomTypebut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameCustomType but is not nil && this == nil")
 	}
 	if that1.FieldA == nil {
 		if this.FieldA != nil {
@@ -10512,7 +10512,7 @@ func (this *CustomNameNinEmbeddedStructUnion) VerboseEqual(that interface{}) err
 		}
 		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnionbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameNinEmbeddedStructUnion but is not nil && this == nil")
 	}
 	if !this.NidOptNative.Equal(that1.NidOptNative) {
 		return fmt.Errorf("NidOptNative this(%v) Not Equal that(%v)", this.NidOptNative, that1.NidOptNative)
@@ -10592,7 +10592,7 @@ func (this *CustomNameEnum) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *CustomNameEnum but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *CustomNameEnumbut is not nil && this == nil")
+		return fmt.Errorf("that is type *CustomNameEnum but is not nil && this == nil")
 	}
 	if this.FieldA != nil && that1.FieldA != nil {
 		if *this.FieldA != *that1.FieldA {
@@ -10676,7 +10676,7 @@ func (this *NoExtensionsMap) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NoExtensionsMap but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NoExtensionsMapbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NoExtensionsMap but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10750,7 +10750,7 @@ func (this *Unrecognized) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Unrecognized but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Unrecognizedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Unrecognized but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10812,7 +10812,7 @@ func (this *UnrecognizedWithInner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInnerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner but is not nil && this == nil")
 	}
 	if len(this.Embedded) != len(that1.Embedded) {
 		return fmt.Errorf("Embedded this(%v) Not Equal that(%v)", len(this.Embedded), len(that1.Embedded))
@@ -10896,7 +10896,7 @@ func (this *UnrecognizedWithInner_Inner) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithInner_Innerbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithInner_Inner but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -10958,7 +10958,7 @@ func (this *UnrecognizedWithEmbed) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed but is not nil && this == nil")
 	}
 	if !this.UnrecognizedWithEmbed_Embedded.Equal(&that1.UnrecognizedWithEmbed_Embedded) {
 		return fmt.Errorf("UnrecognizedWithEmbed_Embedded this(%v) Not Equal that(%v)", this.UnrecognizedWithEmbed_Embedded, that1.UnrecognizedWithEmbed_Embedded)
@@ -11032,7 +11032,7 @@ func (this *UnrecognizedWithEmbed_Embedded) VerboseEqual(that interface{}) error
 		}
 		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embeddedbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnrecognizedWithEmbed_Embedded but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/unmarshalmerge/unmarshalmerge.pb.go
+++ b/test/unmarshalmerge/unmarshalmerge.pb.go
@@ -216,7 +216,7 @@ func (this *Big) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Big but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Bigbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Big but is not nil && this == nil")
 	}
 	if !this.Sub.Equal(that1.Sub) {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -290,7 +290,7 @@ func (this *BigUnsafe) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *BigUnsafe but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *BigUnsafebut is not nil && this == nil")
+		return fmt.Errorf("that is type *BigUnsafe but is not nil && this == nil")
 	}
 	if !this.Sub.Equal(that1.Sub) {
 		return fmt.Errorf("Sub this(%v) Not Equal that(%v)", this.Sub, that1.Sub)
@@ -364,7 +364,7 @@ func (this *Sub) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *Sub but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Subbut is not nil && this == nil")
+		return fmt.Errorf("that is type *Sub but is not nil && this == nil")
 	}
 	if this.SubNumber != nil && that1.SubNumber != nil {
 		if *this.SubNumber != *that1.SubNumber {
@@ -432,7 +432,7 @@ func (this *IntMerge) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *IntMerge but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *IntMergebut is not nil && this == nil")
+		return fmt.Errorf("that is type *IntMerge but is not nil && this == nil")
 	}
 	if this.Int64 != that1.Int64 {
 		return fmt.Errorf("Int64 this(%v) Not Equal that(%v)", this.Int64, that1.Int64)

--- a/test/unrecognized/unrecognized.pb.go
+++ b/test/unrecognized/unrecognized.pb.go
@@ -1275,7 +1275,7 @@ func (this *A) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *A but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Abut is not nil && this == nil")
+		return fmt.Errorf("that is type *A but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1353,7 +1353,7 @@ func (this *B) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *B but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Bbut is not nil && this == nil")
+		return fmt.Errorf("that is type *B but is not nil && this == nil")
 	}
 	if !this.C.Equal(that1.C) {
 		return fmt.Errorf("C this(%v) Not Equal that(%v)", this.C, that1.C)
@@ -1421,7 +1421,7 @@ func (this *D) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *D but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Dbut is not nil && this == nil")
+		return fmt.Errorf("that is type *D but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1489,7 +1489,7 @@ func (this *C) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *C but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Cbut is not nil && this == nil")
+		return fmt.Errorf("that is type *C but is not nil && this == nil")
 	}
 	if this.Field2 != nil && that1.Field2 != nil {
 		if *this.Field2 != *that1.Field2 {
@@ -1643,7 +1643,7 @@ func (this *U) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *U but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Ubut is not nil && this == nil")
+		return fmt.Errorf("that is type *U but is not nil && this == nil")
 	}
 	if len(this.Field2) != len(that1.Field2) {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", len(this.Field2), len(that1.Field2))
@@ -1721,7 +1721,7 @@ func (this *UnoM) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *UnoM but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *UnoMbut is not nil && this == nil")
+		return fmt.Errorf("that is type *UnoM but is not nil && this == nil")
 	}
 	if len(this.Field2) != len(that1.Field2) {
 		return fmt.Errorf("Field2 this(%v) Not Equal that(%v)", len(this.Field2), len(that1.Field2))
@@ -1799,7 +1799,7 @@ func (this *OldA) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldA but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldAbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OldA but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1877,7 +1877,7 @@ func (this *OldB) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldB but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldBbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OldB but is not nil && this == nil")
 	}
 	if !this.C.Equal(that1.C) {
 		return fmt.Errorf("C this(%v) Not Equal that(%v)", this.C, that1.C)
@@ -1939,7 +1939,7 @@ func (this *OldC) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldC but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldCbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OldC but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -2077,7 +2077,7 @@ func (this *OldU) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldU but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldUbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OldU but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -2161,7 +2161,7 @@ func (this *OldUnoM) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldUnoM but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldUnoMbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OldUnoM but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {

--- a/test/unrecognizedgroup/unrecognizedgroup.pb.go
+++ b/test/unrecognizedgroup/unrecognizedgroup.pb.go
@@ -1107,7 +1107,7 @@ func (this *NewNoGroup) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *NewNoGroup but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *NewNoGroupbut is not nil && this == nil")
+		return fmt.Errorf("that is type *NewNoGroup but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1197,7 +1197,7 @@ func (this *A) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *A but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *Abut is not nil && this == nil")
+		return fmt.Errorf("that is type *A but is not nil && this == nil")
 	}
 	if this.AField != nil && that1.AField != nil {
 		if *this.AField != *that1.AField {
@@ -1265,7 +1265,7 @@ func (this *OldWithGroup) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldWithGroup but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldWithGroupbut is not nil && this == nil")
+		return fmt.Errorf("that is type *OldWithGroup but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1361,7 +1361,7 @@ func (this *OldWithGroup_Group1) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldWithGroup_Group1 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldWithGroup_Group1but is not nil && this == nil")
+		return fmt.Errorf("that is type *OldWithGroup_Group1 but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {
@@ -1463,7 +1463,7 @@ func (this *OldWithGroup_Group2) VerboseEqual(that interface{}) error {
 		}
 		return fmt.Errorf("that is type *OldWithGroup_Group2 but is nil && this != nil")
 	} else if this == nil {
-		return fmt.Errorf("that is type *OldWithGroup_Group2but is not nil && this == nil")
+		return fmt.Errorf("that is type *OldWithGroup_Group2 but is not nil && this == nil")
 	}
 	if this.Field1 != nil && that1.Field1 != nil {
 		if *this.Field1 != *that1.Field1 {


### PR DESCRIPTION
 Edited `plugin/equal/equal.go` and ran `make all`.