### PR TITLE
[WIP] gogoproto: gostyle enum and custom enum name extensions

### DIFF
--- a/gogoproto/gogo.pb.go
+++ b/gogoproto/gogo.pb.go
@@ -46,6 +46,22 @@ var E_EnumStringer = &proto.ExtensionDesc{
 	Tag:           "varint,62022,opt,name=enum_stringer",
 }
 
+var E_EnumGostyle = &proto.ExtensionDesc{
+	ExtendedType:  (*google_protobuf.EnumOptions)(nil),
+	ExtensionType: (*bool)(nil),
+	Field:         62023,
+	Name:          "gogoproto.enum_gostyle",
+	Tag:           "varint,62023,opt,name=enum_gostyle",
+}
+
+var E_EnumCustomname = &proto.ExtensionDesc{
+	ExtendedType:  (*google_protobuf.EnumValueOptions)(nil),
+	ExtensionType: (*string)(nil),
+	Field:         62024,
+	Name:          "gogoproto.enum_customname",
+	Tag:           "bytes,62024,opt,name=enum_customname",
+}
+
 var E_GoprotoGettersAll = &proto.ExtensionDesc{
 	ExtendedType:  (*google_protobuf.FileOptions)(nil),
 	ExtensionType: (*bool)(nil),
@@ -228,6 +244,14 @@ var E_GogoprotoImport = &proto.ExtensionDesc{
 	Field:         63027,
 	Name:          "gogoproto.gogoproto_import",
 	Tag:           "varint,63027,opt,name=gogoproto_import",
+}
+
+var E_EnumGostyleAll = &proto.ExtensionDesc{
+	ExtendedType:  (*google_protobuf.FileOptions)(nil),
+	ExtensionType: (*bool)(nil),
+	Field:         63028,
+	Name:          "gogoproto.enum_gostyle_all",
+	Tag:           "varint,63028,opt,name=enum_gostyle_all",
 }
 
 var E_GoprotoGetters = &proto.ExtensionDesc{
@@ -458,6 +482,8 @@ func init() {
 	proto.RegisterExtension(E_GoprotoEnumPrefix)
 	proto.RegisterExtension(E_GoprotoEnumStringer)
 	proto.RegisterExtension(E_EnumStringer)
+	proto.RegisterExtension(E_EnumGostyle)
+	proto.RegisterExtension(E_EnumCustomname)
 	proto.RegisterExtension(E_GoprotoGettersAll)
 	proto.RegisterExtension(E_GoprotoEnumPrefixAll)
 	proto.RegisterExtension(E_GoprotoStringerAll)
@@ -481,6 +507,7 @@ func init() {
 	proto.RegisterExtension(E_GoprotoExtensionsMapAll)
 	proto.RegisterExtension(E_GoprotoUnrecognizedAll)
 	proto.RegisterExtension(E_GogoprotoImport)
+	proto.RegisterExtension(E_EnumGostyleAll)
 	proto.RegisterExtension(E_GoprotoGetters)
 	proto.RegisterExtension(E_GoprotoStringer)
 	proto.RegisterExtension(E_VerboseEqual)

--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -36,6 +36,11 @@ extend google.protobuf.EnumOptions {
 	optional bool goproto_enum_prefix = 62001;
 	optional bool goproto_enum_stringer = 62021;
 	optional bool enum_stringer = 62022;
+	optional bool enum_gostyle = 62023;
+}
+
+extend google.protobuf.EnumValueOptions {
+	optional string enum_customname = 62024; // TODO(stevvooe): incorrect numbering. Prefix with 66?
 }
 
 extend google.protobuf.FileOptions {
@@ -67,6 +72,8 @@ extend google.protobuf.FileOptions {
 	optional bool goproto_extensions_map_all = 63025;
 	optional bool goproto_unrecognized_all = 63026;
 	optional bool gogoproto_import = 63027;
+
+	optional bool enum_gostyle_all = 63028;
 }
 
 extend google.protobuf.MessageOptions {

--- a/gogoproto/helper.go
+++ b/gogoproto/helper.go
@@ -117,9 +117,27 @@ func IsCustomName(field *google_protobuf.FieldDescriptorProto) bool {
 	return false
 }
 
+func IsEnumCustomName(field *google_protobuf.EnumValueDescriptorProto) bool {
+	name := GetEnumCustomName(field)
+	if len(name) > 0 {
+		return true
+	}
+	return false
+}
+
 func GetCustomName(field *google_protobuf.FieldDescriptorProto) string {
 	if field.Options != nil {
 		v, err := proto.GetExtension(field.Options, E_Customname)
+		if err == nil && v.(*string) != nil {
+			return *(v.(*string))
+		}
+	}
+	return ""
+}
+
+func GetEnumCustomName(field *google_protobuf.EnumValueDescriptorProto) string {
+	if field.Options != nil {
+		v, err := proto.GetExtension(field.Options, E_EnumCustomname)
 		if err == nil && v.(*string) != nil {
 			return *(v.(*string))
 		}
@@ -151,6 +169,10 @@ type EnableFunc func(file *google_protobuf.FileDescriptorProto, message *google_
 
 func EnabledGoEnumPrefix(file *google_protobuf.FileDescriptorProto, enum *google_protobuf.EnumDescriptorProto) bool {
 	return proto.GetBoolExtension(enum.Options, E_GoprotoEnumPrefix, proto.GetBoolExtension(file.Options, E_GoprotoEnumPrefixAll, true))
+}
+
+func EnabledEnumGoStyle(file *google_protobuf.FileDescriptorProto, enum *google_protobuf.EnumDescriptorProto) bool {
+	return proto.GetBoolExtension(enum.Options, E_EnumGostyle, proto.GetBoolExtension(file.Options, E_EnumGostyleAll, false))
 }
 
 func EnabledGoStringer(file *google_protobuf.FileDescriptorProto, message *google_protobuf.DescriptorProto) bool {

--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -1415,6 +1415,7 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 	// The full type name, CamelCased.
 	ccTypeName := CamelCaseSlice(typeName)
 	ccPrefix := enum.prefix()
+	goStyle := gogoproto.EnabledEnumGoStyle(enum.file, enum.EnumDescriptorProto)
 
 	g.PrintComments(enum.path)
 	if !gogoproto.EnabledGoEnumPrefix(enum.file, enum.EnumDescriptorProto) {
@@ -1428,6 +1429,14 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 		g.PrintComments(fmt.Sprintf("%s,%d,%d", enum.path, enumValuePath, i))
 
 		name := ccPrefix + *e.Name
+		if gogoproto.IsEnumCustomName(e) {
+			name = gogoproto.GetEnumCustomName(e)
+		} else if goStyle {
+			// For go style const definitions, we trim the underscore and
+			// camelcase the target name to be more idiomatic.
+			name = ccPrefix[:len(ccPrefix)-1] + strings.Replace(CamelCase(strings.ToLower(*e.Name)), "_", "", -1)
+		}
+
 		g.P(name, " ", ccTypeName, " = ", e.Number)
 		g.file.addExport(enum, constOrVarSymbol{name, "const", ccTypeName})
 	}


### PR DESCRIPTION
This provides a minimal pass at adding support for custom enum names or just
idiomatic, Go-style const names in generated output.

If `enum_gostyle` for an enum type or `enum_gostyle_all` for a file are
enabled, the enum names will have the underscores replaced with a camelcase
variation. If that is insufficient, a custom name can be generated using the
`enum_customname` extension on `EnumValueOptions`, which works identical to the
field targeted variation.

Please evaluate the approach and I'll add unit tests and documentation if this
is acceptable.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #94