### PR TITLE
Use result of computation for ineffassign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 
 .PHONY: nuke regenerate tests clean install gofmt vet contributors
 
-all: clean install regenerate install tests errcheck vet
+all: clean install regenerate install tests errcheck vet ineffassign
 
 buildserverall: clean install regenerate install tests vet
 
@@ -98,6 +98,10 @@ regenerate:
 tests:
 	go build ./test/enumprefix
 	go test ./...
+
+ineffassign:
+	go get -u github.com/gordonklaus/ineffassign
+	ineffassign .
 
 vet:
 	go vet ./...

--- a/plugin/unmarshal/unmarshal.go
+++ b/plugin/unmarshal/unmarshal.go
@@ -236,6 +236,7 @@ func (p *unmarshal) decodeVarint(varName string, typName string) {
 	p.P(`}`)
 	p.Out()
 	p.P(`}`)
+	p.P(`_ = `, varName) // satisfy ineffassign
 }
 
 func (p *unmarshal) decodeFixed32(varName string, typeName string) {

--- a/test/asymetric-issue125/asym.pb.go
+++ b/test/asymetric-issue125/asym.pb.go
@@ -381,6 +381,7 @@ func (m *M) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -409,6 +410,7 @@ func (m *M) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthAsym
 			}
@@ -464,6 +466,7 @@ func (m *MyType) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {

--- a/test/casttype/combos/both/casttype.pb.go
+++ b/test/casttype/combos/both/casttype.pb.go
@@ -2534,6 +2534,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2562,6 +2563,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32Ptr = &v
 		case 2:
 			if wireType != 0 {
@@ -2582,6 +2584,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int32
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyUint64Ptr", wireType)
@@ -2601,6 +2604,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64Ptr = &v
 		case 4:
 			if wireType != 0 {
@@ -2621,6 +2625,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.MyUint64
 		case 5:
 			if wireType != 5 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyFloat32Ptr", wireType)
@@ -2706,6 +2711,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2737,6 +2743,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2768,6 +2775,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64S = append(m.MyUint64S, v)
 		case 12:
 			if wireType != 2 {
@@ -2788,6 +2796,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2810,6 +2819,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2825,6 +2835,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttype
@@ -2850,6 +2861,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2865,6 +2877,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyMap == nil {
 				m.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
 			}
@@ -2889,6 +2902,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2911,6 +2925,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2926,6 +2941,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttype
@@ -2951,6 +2967,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2966,6 +2983,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyCustomMap == nil {
 				m.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
 			}
@@ -2990,6 +3008,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -3012,6 +3031,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3027,6 +3047,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3042,6 +3063,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3057,6 +3079,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -3096,6 +3119,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -3118,6 +3142,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3133,6 +3158,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3148,6 +3174,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3163,6 +3190,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -3225,6 +3253,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3253,6 +3282,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/casttype/combos/unmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unmarshaler/casttype.pb.go
@@ -2330,6 +2330,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2358,6 +2359,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32Ptr = &v
 		case 2:
 			if wireType != 0 {
@@ -2378,6 +2380,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int32
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyUint64Ptr", wireType)
@@ -2397,6 +2400,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64Ptr = &v
 		case 4:
 			if wireType != 0 {
@@ -2417,6 +2421,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.MyUint64
 		case 5:
 			if wireType != 5 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyFloat32Ptr", wireType)
@@ -2502,6 +2507,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2533,6 +2539,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2564,6 +2571,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64S = append(m.MyUint64S, v)
 		case 12:
 			if wireType != 2 {
@@ -2584,6 +2592,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2606,6 +2615,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2621,6 +2631,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttype
@@ -2646,6 +2657,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2661,6 +2673,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyMap == nil {
 				m.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
 			}
@@ -2685,6 +2698,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2707,6 +2721,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2722,6 +2737,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttype
@@ -2747,6 +2763,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2762,6 +2779,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyCustomMap == nil {
 				m.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
 			}
@@ -2786,6 +2804,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2808,6 +2827,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2823,6 +2843,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2838,6 +2859,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2853,6 +2875,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2892,6 +2915,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -2914,6 +2938,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2929,6 +2954,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2944,6 +2970,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2959,6 +2986,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttype
 			}
@@ -3021,6 +3049,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3049,6 +3078,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/casttype/combos/unsafeboth/casttype.pb.go
+++ b/test/casttype/combos/unsafeboth/casttype.pb.go
@@ -2534,6 +2534,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2562,6 +2563,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32Ptr = &v
 		case 2:
 			if wireType != 0 {
@@ -2582,6 +2584,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int32
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyUint64Ptr", wireType)
@@ -2601,6 +2604,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64Ptr = &v
 		case 4:
 			if wireType != 0 {
@@ -2621,6 +2625,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.MyUint64
 		case 5:
 			if wireType != 5 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyFloat32Ptr", wireType)
@@ -2706,6 +2711,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2737,6 +2743,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2768,6 +2775,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64S = append(m.MyUint64S, v)
 		case 12:
 			if wireType != 2 {
@@ -2788,6 +2796,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2810,6 +2819,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2825,6 +2835,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
@@ -2850,6 +2861,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2865,6 +2877,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyMap == nil {
 				m.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
 			}
@@ -2889,6 +2902,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2911,6 +2925,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2926,6 +2941,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
@@ -2951,6 +2967,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2966,6 +2983,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyCustomMap == nil {
 				m.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
 			}
@@ -2990,6 +3008,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -3012,6 +3031,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3027,6 +3047,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3042,6 +3063,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3057,6 +3079,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -3096,6 +3119,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -3118,6 +3142,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3133,6 +3158,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3148,6 +3174,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3163,6 +3190,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -3225,6 +3253,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3253,6 +3282,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/casttype/combos/unsafeunmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unsafeunmarshaler/casttype.pb.go
@@ -2330,6 +2330,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2358,6 +2359,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32Ptr = &v
 		case 2:
 			if wireType != 0 {
@@ -2378,6 +2380,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int32
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyUint64Ptr", wireType)
@@ -2397,6 +2400,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64Ptr = &v
 		case 4:
 			if wireType != 0 {
@@ -2417,6 +2421,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.MyUint64
 		case 5:
 			if wireType != 5 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MyFloat32Ptr", wireType)
@@ -2502,6 +2507,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2533,6 +2539,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2564,6 +2571,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MyUint64S = append(m.MyUint64S, v)
 		case 12:
 			if wireType != 2 {
@@ -2584,6 +2592,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2606,6 +2615,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2621,6 +2631,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
@@ -2646,6 +2657,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2661,6 +2673,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyMap == nil {
 				m.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
 			}
@@ -2685,6 +2698,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2707,6 +2721,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2722,6 +2737,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
@@ -2747,6 +2763,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2762,6 +2779,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.MyCustomMap == nil {
 				m.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
 			}
@@ -2786,6 +2804,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2808,6 +2827,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2823,6 +2843,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2838,6 +2859,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2853,6 +2875,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2892,6 +2915,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -2914,6 +2938,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2929,6 +2954,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2944,6 +2970,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2959,6 +2986,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCasttypeUnsafe
 			}
@@ -3021,6 +3049,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3049,6 +3078,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/castvalue/combos/both/castvalue.pb.go
+++ b/test/castvalue/combos/both/castvalue.pb.go
@@ -1893,6 +1893,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1921,6 +1922,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -1943,6 +1945,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1958,6 +1961,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1973,6 +1977,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1988,6 +1993,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -2027,6 +2033,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -2049,6 +2056,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2064,6 +2072,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2079,6 +2088,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2094,6 +2104,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -2156,6 +2167,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2184,6 +2196,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/castvalue/combos/unmarshaler/castvalue.pb.go
+++ b/test/castvalue/combos/unmarshaler/castvalue.pb.go
@@ -1772,6 +1772,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1800,6 +1801,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -1822,6 +1824,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1837,6 +1840,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1852,6 +1856,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1867,6 +1872,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -1906,6 +1912,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -1928,6 +1935,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1943,6 +1951,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1958,6 +1967,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1973,6 +1983,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalue
 			}
@@ -2035,6 +2046,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2063,6 +2075,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/castvalue/combos/unsafeboth/castvalue.pb.go
+++ b/test/castvalue/combos/unsafeboth/castvalue.pb.go
@@ -1893,6 +1893,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1921,6 +1922,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -1943,6 +1945,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1958,6 +1961,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1973,6 +1977,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1988,6 +1993,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -2027,6 +2033,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -2049,6 +2056,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2064,6 +2072,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2079,6 +2088,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -2094,6 +2104,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -2156,6 +2167,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2184,6 +2196,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/castvalue/combos/unsafeunmarshaler/castvalue.pb.go
+++ b/test/castvalue/combos/unsafeunmarshaler/castvalue.pb.go
@@ -1772,6 +1772,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1800,6 +1801,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -1822,6 +1824,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1837,6 +1840,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1852,6 +1856,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1867,6 +1872,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -1906,6 +1912,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -1928,6 +1935,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1943,6 +1951,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1958,6 +1967,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -1973,6 +1983,7 @@ func (m *Castaway) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthCastvalueUnsafe
 			}
@@ -2035,6 +2046,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2063,6 +2075,7 @@ func (m *Wilson) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		default:
 			iNdEx = preIndex

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -26314,6 +26314,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26374,6 +26375,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field3
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -26393,6 +26395,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field4
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -26412,6 +26415,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field5
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -26431,6 +26435,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -26450,6 +26455,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -26471,6 +26477,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = int64(v)
 		case 9:
@@ -26552,6 +26559,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -26572,6 +26580,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -26601,6 +26610,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26655,6 +26665,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26717,6 +26728,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -26737,6 +26749,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -26757,6 +26770,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -26777,6 +26791,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -26797,6 +26812,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -26818,6 +26834,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -26904,6 +26921,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -26925,6 +26943,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -26955,6 +26974,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27009,6 +27029,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27071,6 +27092,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -27091,6 +27113,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -27111,6 +27134,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -27131,6 +27155,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -27151,6 +27176,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -27172,6 +27198,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -27257,6 +27284,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -27277,6 +27305,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -27306,6 +27335,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27358,6 +27388,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27420,6 +27451,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -27440,6 +27472,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -27460,6 +27493,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -27480,6 +27514,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -27500,6 +27535,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -27521,6 +27557,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -27606,6 +27643,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -27626,6 +27664,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -27655,6 +27694,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27707,6 +27747,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27733,6 +27774,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -27793,6 +27835,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -27845,6 +27888,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -27868,6 +27912,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -27886,6 +27931,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -27907,6 +27953,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -27930,6 +27977,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -27948,6 +27996,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -27969,6 +28018,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -27992,6 +28042,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -28010,6 +28061,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -28031,6 +28083,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28054,6 +28107,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -28072,6 +28126,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -28093,6 +28148,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28116,6 +28172,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -28135,6 +28192,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -28157,6 +28215,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28180,6 +28239,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -28199,6 +28259,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -28221,6 +28282,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28271,6 +28333,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28321,6 +28384,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28379,6 +28443,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28437,6 +28502,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28460,6 +28526,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -28478,6 +28545,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -28524,6 +28592,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28550,6 +28619,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28610,6 +28680,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28662,6 +28733,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28685,6 +28757,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -28703,6 +28776,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -28724,6 +28798,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28747,6 +28822,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -28765,6 +28841,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -28786,6 +28863,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28809,6 +28887,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -28827,6 +28906,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -28848,6 +28928,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28871,6 +28952,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -28889,6 +28971,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -28910,6 +28993,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28933,6 +29017,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -28952,6 +29037,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -28974,6 +29060,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -28997,6 +29084,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -29016,6 +29104,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -29038,6 +29127,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -29088,6 +29178,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -29138,6 +29229,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -29196,6 +29288,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -29254,6 +29347,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -29277,6 +29371,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -29295,6 +29390,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -29341,6 +29437,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29401,6 +29498,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29431,6 +29529,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29461,6 +29560,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -29480,6 +29580,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -29501,6 +29602,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29531,6 +29633,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -29551,6 +29654,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -29580,6 +29684,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29634,6 +29739,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29696,6 +29802,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29729,6 +29836,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29762,6 +29870,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -29782,6 +29891,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -29803,6 +29913,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29836,6 +29947,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -29857,6 +29969,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -29887,6 +30000,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29941,6 +30055,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30003,6 +30118,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30034,6 +30150,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30065,6 +30182,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -30085,6 +30203,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -30106,6 +30225,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30137,6 +30257,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -30157,6 +30278,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -30186,6 +30308,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30238,6 +30361,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30300,6 +30424,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30331,6 +30456,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30362,6 +30488,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -30382,6 +30509,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -30403,6 +30531,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30434,6 +30563,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -30454,6 +30584,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -30483,6 +30614,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30535,6 +30667,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30563,6 +30696,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30596,6 +30730,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30626,6 +30761,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field210 = bool(v != 0)
 		default:
 			iNdEx = preIndex
@@ -30669,6 +30805,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30697,6 +30834,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30730,6 +30868,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30763,6 +30902,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -30807,6 +30947,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30835,6 +30976,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30865,6 +31007,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30919,6 +31062,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30947,6 +31091,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30980,6 +31125,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31034,6 +31180,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31062,6 +31209,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31092,6 +31240,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31145,6 +31294,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31173,6 +31323,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31228,6 +31379,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31256,6 +31408,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31288,6 +31441,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31343,6 +31497,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31371,6 +31526,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31403,6 +31559,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31458,6 +31615,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31486,6 +31644,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31518,6 +31677,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31573,6 +31733,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31635,6 +31796,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -31655,6 +31817,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -31675,6 +31838,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -31695,6 +31859,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 13:
 			if wireType != 0 {
@@ -31715,6 +31880,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -31736,6 +31902,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -31766,6 +31933,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31820,6 +31988,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31882,6 +32051,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31915,6 +32085,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31948,6 +32119,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -31968,6 +32140,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 13:
@@ -31989,6 +32162,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -32010,6 +32184,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -32040,6 +32215,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32094,6 +32270,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32122,6 +32299,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32155,6 +32333,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32188,6 +32367,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -32232,6 +32412,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32260,6 +32441,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32293,6 +32475,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32326,6 +32509,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32382,6 +32566,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32410,6 +32595,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32443,6 +32629,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32476,6 +32663,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32532,6 +32720,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32560,6 +32749,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32590,6 +32780,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32643,6 +32834,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32671,6 +32863,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32701,6 +32894,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32754,6 +32948,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32782,6 +32977,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Value
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field StrValue", wireType)
@@ -32801,6 +32997,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -32853,6 +33050,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32881,6 +33079,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32914,6 +33113,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32947,6 +33147,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33003,6 +33204,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33031,6 +33233,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33084,6 +33287,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33112,6 +33316,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33142,6 +33347,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33195,6 +33401,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33223,6 +33430,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33276,6 +33484,7 @@ func (m *Nil) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33327,6 +33536,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33355,6 +33565,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field1
 		default:
 			iNdEx = preIndex
 			skippy, err := skipThetest(data[iNdEx:])
@@ -33397,6 +33608,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33425,6 +33637,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33445,6 +33658,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -33465,6 +33679,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -33508,6 +33723,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33536,6 +33752,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -33556,6 +33773,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -33576,6 +33794,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -33619,6 +33838,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33647,6 +33867,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -33667,6 +33888,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -33687,6 +33909,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -33730,6 +33953,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33758,6 +33982,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33778,6 +34003,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -33798,6 +34024,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -33841,6 +34068,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33869,6 +34097,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33889,6 +34118,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -33909,6 +34139,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -33952,6 +34183,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33980,6 +34212,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -34000,6 +34233,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -34020,6 +34254,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -34063,6 +34298,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34125,6 +34361,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34179,6 +34416,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34207,6 +34445,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -34277,6 +34516,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34305,6 +34545,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34338,6 +34579,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 13:
 			if wireType != 0 {
@@ -34358,6 +34600,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = &v
 		default:
 			if ((fieldNum >= 14) && (fieldNum < 17)) || ((fieldNum >= 10) && (fieldNum < 13)) {
@@ -34428,6 +34671,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34456,6 +34700,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -34476,6 +34721,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.EnumField = &v
 		case 3:
 			if wireType != 2 {
@@ -34496,6 +34742,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34529,6 +34776,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34585,6 +34833,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34631,6 +34880,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34687,6 +34937,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34715,6 +34966,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -34768,6 +35020,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34796,6 +35049,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34829,6 +35083,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.B = &v
 		case 3:
 			if wireType != 2 {
@@ -34849,6 +35104,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -34905,6 +35161,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34967,6 +35224,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -34987,6 +35245,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -35007,6 +35266,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -35027,6 +35287,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -35047,6 +35308,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -35068,6 +35330,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -35154,6 +35417,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -35175,6 +35439,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -35205,6 +35470,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -35259,6 +35525,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -35287,6 +35554,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -35340,6 +35608,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -35400,6 +35669,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldC
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldD", wireType)
@@ -35419,6 +35689,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldD
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldE", wireType)
@@ -35438,6 +35709,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldE
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldF", wireType)
@@ -35457,6 +35729,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldF
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldG", wireType)
@@ -35476,6 +35749,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = v
 		case 8:
@@ -35497,6 +35771,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = int64(v)
 		case 9:
@@ -35578,6 +35853,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -35598,6 +35874,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -35627,6 +35904,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -35681,6 +35959,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -35743,6 +36022,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = &v
 		case 4:
 			if wireType != 0 {
@@ -35763,6 +36043,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = &v
 		case 5:
 			if wireType != 0 {
@@ -35783,6 +36064,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 6:
 			if wireType != 0 {
@@ -35803,6 +36085,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = &v
 		case 7:
 			if wireType != 0 {
@@ -35823,6 +36106,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = &v
 		case 8:
@@ -35844,6 +36128,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.FieldH = &v2
@@ -35930,6 +36215,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldM = &b
 		case 14:
@@ -35951,6 +36237,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -35981,6 +36268,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36035,6 +36323,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36097,6 +36386,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = append(m.FieldC, v)
 		case 4:
 			if wireType != 0 {
@@ -36117,6 +36407,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = append(m.FieldD, v)
 		case 5:
 			if wireType != 0 {
@@ -36137,6 +36428,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = append(m.FieldE, v)
 		case 6:
 			if wireType != 0 {
@@ -36157,6 +36449,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = append(m.FieldF, v)
 		case 7:
 			if wireType != 0 {
@@ -36177,6 +36470,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = append(m.FieldG, v)
 		case 8:
@@ -36198,6 +36492,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = append(m.FieldH, int64(v))
 		case 9:
@@ -36283,6 +36578,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = append(m.FieldM, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -36303,6 +36599,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -36332,6 +36629,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36384,6 +36682,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36446,6 +36745,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36479,6 +36779,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36510,6 +36811,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 7:
 			if wireType != 0 {
@@ -36530,6 +36832,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldF = &v
 		case 8:
@@ -36551,6 +36854,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36584,6 +36888,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldH = &b
 		case 14:
@@ -36605,6 +36910,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -36635,6 +36941,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36689,6 +36996,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36717,6 +37025,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36749,6 +37058,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36781,6 +37091,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36813,6 +37124,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36868,6 +37180,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36896,6 +37209,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36929,6 +37243,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -36962,6 +37277,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldB = &b
 		default:
@@ -37006,6 +37322,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37034,6 +37351,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldA = &v
 		case 2:
 			if wireType != 0 {
@@ -37054,6 +37372,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldB = append(m.FieldB, v)
 		default:
 			iNdEx = preIndex
@@ -37097,6 +37416,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37125,6 +37445,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -37192,6 +37513,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37220,6 +37542,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -37272,6 +37595,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37300,6 +37624,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -37331,6 +37656,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -37384,6 +37710,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37412,6 +37739,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -37454,6 +37782,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37482,6 +37811,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -37512,6 +37842,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -37565,6 +37896,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37593,6 +37925,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -37635,6 +37968,7 @@ func (m *Node) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -37663,6 +37997,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -37693,6 +38028,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -22194,6 +22194,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -22254,6 +22255,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field3
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -22273,6 +22275,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field4
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -22292,6 +22295,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field5
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -22311,6 +22315,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -22330,6 +22335,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -22351,6 +22357,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = int64(v)
 		case 9:
@@ -22432,6 +22439,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -22452,6 +22460,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -22481,6 +22490,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -22535,6 +22545,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -22597,6 +22608,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -22617,6 +22629,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -22637,6 +22650,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -22657,6 +22671,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -22677,6 +22692,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -22698,6 +22714,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -22784,6 +22801,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -22805,6 +22823,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -22835,6 +22854,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -22889,6 +22909,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -22951,6 +22972,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -22971,6 +22993,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -22991,6 +23014,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -23011,6 +23035,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -23031,6 +23056,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -23052,6 +23078,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -23137,6 +23164,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -23157,6 +23185,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -23186,6 +23215,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -23238,6 +23268,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -23300,6 +23331,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -23320,6 +23352,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -23340,6 +23373,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -23360,6 +23394,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -23380,6 +23415,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -23401,6 +23437,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -23486,6 +23523,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -23506,6 +23544,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -23535,6 +23574,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -23587,6 +23627,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -23613,6 +23654,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23673,6 +23715,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23725,6 +23768,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23748,6 +23792,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -23766,6 +23811,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -23787,6 +23833,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23810,6 +23857,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -23828,6 +23876,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -23849,6 +23898,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23872,6 +23922,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -23890,6 +23941,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -23911,6 +23963,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23934,6 +23987,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -23952,6 +24006,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -23973,6 +24028,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -23996,6 +24052,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -24015,6 +24072,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -24037,6 +24095,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24060,6 +24119,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -24079,6 +24139,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -24101,6 +24162,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24151,6 +24213,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24201,6 +24264,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24259,6 +24323,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24317,6 +24382,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24340,6 +24406,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -24358,6 +24425,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -24404,6 +24472,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -24430,6 +24499,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24490,6 +24560,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24542,6 +24613,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24565,6 +24637,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -24583,6 +24656,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -24604,6 +24678,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24627,6 +24702,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -24645,6 +24721,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -24666,6 +24743,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24689,6 +24767,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -24707,6 +24786,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -24728,6 +24808,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24751,6 +24832,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -24769,6 +24851,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -24790,6 +24873,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24813,6 +24897,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -24832,6 +24917,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -24854,6 +24940,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24877,6 +24964,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -24896,6 +24984,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -24918,6 +25007,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -24968,6 +25058,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -25018,6 +25109,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -25076,6 +25168,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -25134,6 +25227,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetest
 				}
@@ -25157,6 +25251,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -25175,6 +25270,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -25221,6 +25317,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25281,6 +25378,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25311,6 +25409,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25341,6 +25440,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -25360,6 +25460,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -25381,6 +25482,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25411,6 +25513,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -25431,6 +25534,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -25460,6 +25564,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25514,6 +25619,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25576,6 +25682,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25609,6 +25716,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25642,6 +25750,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -25662,6 +25771,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -25683,6 +25793,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25716,6 +25827,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -25737,6 +25849,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -25767,6 +25880,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25821,6 +25935,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25883,6 +25998,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25914,6 +26030,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -25945,6 +26062,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -25965,6 +26083,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -25986,6 +26105,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26017,6 +26137,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -26037,6 +26158,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -26066,6 +26188,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26118,6 +26241,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26180,6 +26304,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26211,6 +26336,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26242,6 +26368,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -26262,6 +26389,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -26283,6 +26411,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26314,6 +26443,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -26334,6 +26464,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -26363,6 +26494,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26415,6 +26547,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26443,6 +26576,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26476,6 +26610,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26506,6 +26641,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field210 = bool(v != 0)
 		default:
 			iNdEx = preIndex
@@ -26549,6 +26685,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26577,6 +26714,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26610,6 +26748,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26643,6 +26782,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -26687,6 +26827,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26715,6 +26856,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26745,6 +26887,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26799,6 +26942,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26827,6 +26971,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26860,6 +27005,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26914,6 +27060,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26942,6 +27089,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -26972,6 +27120,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27025,6 +27174,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27053,6 +27203,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27108,6 +27259,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27136,6 +27288,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27168,6 +27321,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27223,6 +27377,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27251,6 +27406,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27283,6 +27439,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27338,6 +27495,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27366,6 +27524,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27398,6 +27557,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27453,6 +27613,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27515,6 +27676,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -27535,6 +27697,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -27555,6 +27718,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -27575,6 +27739,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 13:
 			if wireType != 0 {
@@ -27595,6 +27760,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -27616,6 +27782,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -27646,6 +27813,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27700,6 +27868,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27762,6 +27931,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27795,6 +27965,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27828,6 +27999,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -27848,6 +28020,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 13:
@@ -27869,6 +28042,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -27890,6 +28064,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -27920,6 +28095,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -27974,6 +28150,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28002,6 +28179,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28035,6 +28213,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28068,6 +28247,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -28112,6 +28292,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28140,6 +28321,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28173,6 +28355,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28206,6 +28389,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28262,6 +28446,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28290,6 +28475,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28323,6 +28509,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28356,6 +28543,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28412,6 +28600,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28440,6 +28629,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28470,6 +28660,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28523,6 +28714,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28551,6 +28743,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28581,6 +28774,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28634,6 +28828,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28662,6 +28857,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Value
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field StrValue", wireType)
@@ -28681,6 +28877,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -28733,6 +28930,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28761,6 +28959,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28794,6 +28993,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28827,6 +29027,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28883,6 +29084,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28911,6 +29113,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -28964,6 +29167,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28992,6 +29196,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29022,6 +29227,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29075,6 +29281,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29103,6 +29310,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -29156,6 +29364,7 @@ func (m *Nil) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29207,6 +29416,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29235,6 +29445,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field1
 		default:
 			iNdEx = preIndex
 			skippy, err := skipThetest(data[iNdEx:])
@@ -29277,6 +29488,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29305,6 +29517,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29325,6 +29538,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29345,6 +29559,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29388,6 +29603,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29416,6 +29632,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -29436,6 +29653,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -29456,6 +29674,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -29499,6 +29718,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29527,6 +29747,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -29547,6 +29768,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -29567,6 +29789,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -29610,6 +29833,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29638,6 +29862,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29658,6 +29883,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29678,6 +29904,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29721,6 +29948,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29749,6 +29977,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29769,6 +29998,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29789,6 +30019,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29832,6 +30063,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29860,6 +30092,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29880,6 +30113,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29900,6 +30134,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29943,6 +30178,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30005,6 +30241,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30059,6 +30296,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30087,6 +30325,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -30157,6 +30396,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30185,6 +30425,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 13:
 			if wireType != 0 {
@@ -30205,6 +30446,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = &v
 		case 1:
 			if wireType != 2 {
@@ -30225,6 +30467,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30308,6 +30551,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30336,6 +30580,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -30356,6 +30601,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.EnumField = &v
 		case 3:
 			if wireType != 2 {
@@ -30376,6 +30622,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30409,6 +30656,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30465,6 +30713,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30511,6 +30760,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30567,6 +30817,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30595,6 +30846,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -30648,6 +30900,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30676,6 +30929,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30709,6 +30963,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.B = &v
 		case 3:
 			if wireType != 2 {
@@ -30729,6 +30984,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -30785,6 +31041,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30847,6 +31104,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -30867,6 +31125,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -30887,6 +31146,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -30907,6 +31167,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -30927,6 +31188,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -30948,6 +31210,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -31034,6 +31297,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -31055,6 +31319,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -31085,6 +31350,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31139,6 +31405,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31167,6 +31434,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31220,6 +31488,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31280,6 +31549,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldC
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldD", wireType)
@@ -31299,6 +31569,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldD
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldE", wireType)
@@ -31318,6 +31589,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldE
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldF", wireType)
@@ -31337,6 +31609,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldF
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldG", wireType)
@@ -31356,6 +31629,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = v
 		case 8:
@@ -31377,6 +31651,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = int64(v)
 		case 9:
@@ -31458,6 +31733,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -31478,6 +31754,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -31507,6 +31784,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31561,6 +31839,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31623,6 +31902,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = &v
 		case 4:
 			if wireType != 0 {
@@ -31643,6 +31923,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = &v
 		case 5:
 			if wireType != 0 {
@@ -31663,6 +31944,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 6:
 			if wireType != 0 {
@@ -31683,6 +31965,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = &v
 		case 7:
 			if wireType != 0 {
@@ -31703,6 +31986,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = &v
 		case 8:
@@ -31724,6 +32008,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.FieldH = &v2
@@ -31810,6 +32095,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldM = &b
 		case 14:
@@ -31831,6 +32117,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -31861,6 +32148,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -31915,6 +32203,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31977,6 +32266,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = append(m.FieldC, v)
 		case 4:
 			if wireType != 0 {
@@ -31997,6 +32287,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = append(m.FieldD, v)
 		case 5:
 			if wireType != 0 {
@@ -32017,6 +32308,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = append(m.FieldE, v)
 		case 6:
 			if wireType != 0 {
@@ -32037,6 +32329,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = append(m.FieldF, v)
 		case 7:
 			if wireType != 0 {
@@ -32057,6 +32350,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = append(m.FieldG, v)
 		case 8:
@@ -32078,6 +32372,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = append(m.FieldH, int64(v))
 		case 9:
@@ -32163,6 +32458,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = append(m.FieldM, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -32183,6 +32479,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -32212,6 +32509,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32264,6 +32562,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32326,6 +32625,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32359,6 +32659,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32390,6 +32691,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 7:
 			if wireType != 0 {
@@ -32410,6 +32712,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldF = &v
 		case 8:
@@ -32431,6 +32734,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32464,6 +32768,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldH = &b
 		case 14:
@@ -32485,6 +32790,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -32515,6 +32821,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32569,6 +32876,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32597,6 +32905,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32629,6 +32938,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32661,6 +32971,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32693,6 +33004,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32748,6 +33060,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32776,6 +33089,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32809,6 +33123,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -32842,6 +33157,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldB = &b
 		default:
@@ -32886,6 +33202,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32914,6 +33231,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldA = &v
 		case 2:
 			if wireType != 0 {
@@ -32934,6 +33252,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldB = append(m.FieldB, v)
 		default:
 			iNdEx = preIndex
@@ -32977,6 +33296,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33005,6 +33325,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -33072,6 +33393,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33100,6 +33422,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -33152,6 +33475,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33180,6 +33504,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33211,6 +33536,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -33264,6 +33590,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33292,6 +33619,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -33334,6 +33662,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33362,6 +33691,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}
@@ -33392,6 +33722,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -33445,6 +33776,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33473,6 +33805,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -33515,6 +33848,7 @@ func (m *Node) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33543,6 +33877,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetest
@@ -33573,6 +33908,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetest
 			}

--- a/test/combos/unsafeboth/thetest.pb.go
+++ b/test/combos/unsafeboth/thetest.pb.go
@@ -26005,6 +26005,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26051,6 +26052,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field3
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -26070,6 +26072,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field4
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -26089,6 +26092,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field5
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -26108,6 +26112,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -26127,6 +26132,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -26148,6 +26154,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = int64(v)
 		case 9:
@@ -26205,6 +26212,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -26225,6 +26233,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -26254,6 +26263,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26308,6 +26318,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26358,6 +26369,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -26378,6 +26390,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -26398,6 +26411,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -26418,6 +26432,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -26438,6 +26453,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -26459,6 +26475,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -26525,6 +26542,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -26546,6 +26564,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -26576,6 +26595,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26630,6 +26650,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26680,6 +26701,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -26700,6 +26722,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -26720,6 +26743,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -26740,6 +26764,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -26760,6 +26785,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -26781,6 +26807,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -26846,6 +26873,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -26866,6 +26894,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -26895,6 +26924,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26947,6 +26977,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26997,6 +27028,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -27017,6 +27049,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -27037,6 +27070,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -27057,6 +27091,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -27077,6 +27112,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -27098,6 +27134,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -27163,6 +27200,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -27183,6 +27221,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -27212,6 +27251,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27264,6 +27304,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27290,6 +27331,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27334,6 +27376,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27378,6 +27421,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27401,6 +27445,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -27419,6 +27464,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -27440,6 +27486,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27463,6 +27510,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -27481,6 +27529,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -27502,6 +27551,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27525,6 +27575,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -27543,6 +27594,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -27564,6 +27616,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27587,6 +27640,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -27605,6 +27659,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -27626,6 +27681,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27649,6 +27705,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -27668,6 +27725,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -27690,6 +27748,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27713,6 +27772,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -27732,6 +27792,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -27754,6 +27815,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27798,6 +27860,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27842,6 +27905,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27886,6 +27950,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27930,6 +27995,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -27953,6 +28019,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -27971,6 +28038,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -28017,6 +28085,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28043,6 +28112,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28087,6 +28157,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28131,6 +28202,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28154,6 +28226,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -28172,6 +28245,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -28193,6 +28267,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28216,6 +28291,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -28234,6 +28310,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -28255,6 +28332,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28278,6 +28356,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -28296,6 +28375,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -28317,6 +28397,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28340,6 +28421,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -28358,6 +28440,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -28379,6 +28462,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28402,6 +28486,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -28421,6 +28506,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -28443,6 +28529,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28466,6 +28553,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -28485,6 +28573,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -28507,6 +28596,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28551,6 +28641,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28595,6 +28686,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28639,6 +28731,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28683,6 +28776,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -28706,6 +28800,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -28724,6 +28819,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -28770,6 +28866,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28816,6 +28913,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28846,6 +28944,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28876,6 +28975,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -28895,6 +28995,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -28916,6 +29017,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28946,6 +29048,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -28966,6 +29069,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -28995,6 +29099,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29049,6 +29154,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29099,6 +29205,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29132,6 +29239,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29165,6 +29273,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -29185,6 +29294,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -29206,6 +29316,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29239,6 +29350,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -29260,6 +29372,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -29290,6 +29403,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29344,6 +29458,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29394,6 +29509,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29425,6 +29541,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29456,6 +29573,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -29476,6 +29594,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -29497,6 +29616,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29528,6 +29648,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -29548,6 +29669,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -29577,6 +29699,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29629,6 +29752,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29679,6 +29803,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29710,6 +29835,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29741,6 +29867,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -29761,6 +29888,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -29782,6 +29910,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29813,6 +29942,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -29833,6 +29963,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -29862,6 +29993,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29914,6 +30046,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29942,6 +30075,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29975,6 +30109,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30005,6 +30140,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field210 = bool(v != 0)
 		default:
 			iNdEx = preIndex
@@ -30048,6 +30184,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30076,6 +30213,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30109,6 +30247,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30142,6 +30281,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -30186,6 +30326,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30214,6 +30355,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30244,6 +30386,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30298,6 +30441,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30326,6 +30470,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30359,6 +30504,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30413,6 +30559,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30441,6 +30588,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30471,6 +30619,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30524,6 +30673,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30552,6 +30702,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30607,6 +30758,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30635,6 +30787,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30667,6 +30820,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30722,6 +30876,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30750,6 +30905,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30782,6 +30938,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30837,6 +30994,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30865,6 +31023,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30897,6 +31056,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30952,6 +31112,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31002,6 +31163,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -31022,6 +31184,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -31042,6 +31205,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -31062,6 +31226,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 13:
 			if wireType != 0 {
@@ -31082,6 +31247,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -31103,6 +31269,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -31133,6 +31300,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31187,6 +31355,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31237,6 +31406,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31270,6 +31440,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31303,6 +31474,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -31323,6 +31495,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 13:
@@ -31344,6 +31517,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -31365,6 +31539,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -31395,6 +31570,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31449,6 +31625,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31477,6 +31654,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31510,6 +31688,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31543,6 +31722,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -31587,6 +31767,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31615,6 +31796,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31648,6 +31830,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31681,6 +31864,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31737,6 +31921,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31765,6 +31950,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31798,6 +31984,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31831,6 +32018,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31887,6 +32075,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31915,6 +32104,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31945,6 +32135,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31998,6 +32189,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32026,6 +32218,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32056,6 +32249,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32109,6 +32303,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32137,6 +32332,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Value
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field StrValue", wireType)
@@ -32156,6 +32352,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -32208,6 +32405,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32236,6 +32434,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32269,6 +32468,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32302,6 +32502,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32358,6 +32559,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32386,6 +32588,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32439,6 +32642,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32467,6 +32671,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32497,6 +32702,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32550,6 +32756,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32578,6 +32785,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32631,6 +32839,7 @@ func (m *Nil) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32682,6 +32891,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32710,6 +32920,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field1
 		default:
 			iNdEx = preIndex
 			skippy, err := skipThetestUnsafe(data[iNdEx:])
@@ -32752,6 +32963,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32780,6 +32992,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -32800,6 +33013,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -32820,6 +33034,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -32863,6 +33078,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32891,6 +33107,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -32911,6 +33128,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -32931,6 +33149,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -32974,6 +33193,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33002,6 +33222,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -33022,6 +33243,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -33042,6 +33264,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -33085,6 +33308,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33113,6 +33337,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33133,6 +33358,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -33153,6 +33379,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -33196,6 +33423,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33224,6 +33452,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33244,6 +33473,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -33264,6 +33494,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -33307,6 +33538,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33335,6 +33567,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33355,6 +33588,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -33375,6 +33609,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -33418,6 +33653,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33464,6 +33700,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -33518,6 +33755,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33546,6 +33784,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -33616,6 +33855,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33644,6 +33884,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -33677,6 +33918,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 13:
 			if wireType != 0 {
@@ -33697,6 +33939,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = &v
 		default:
 			if ((fieldNum >= 14) && (fieldNum < 17)) || ((fieldNum >= 10) && (fieldNum < 13)) {
@@ -33767,6 +34010,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33795,6 +34039,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -33815,6 +34060,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.EnumField = &v
 		case 3:
 			if wireType != 2 {
@@ -33835,6 +34081,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -33868,6 +34115,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -33924,6 +34172,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33963,6 +34212,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -34019,6 +34269,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34047,6 +34298,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -34100,6 +34352,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34128,6 +34381,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -34161,6 +34415,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.B = &v
 		case 3:
 			if wireType != 2 {
@@ -34181,6 +34436,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -34237,6 +34493,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34287,6 +34544,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -34307,6 +34565,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -34327,6 +34586,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -34347,6 +34607,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -34367,6 +34628,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -34388,6 +34650,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -34454,6 +34717,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -34475,6 +34739,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -34505,6 +34770,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -34559,6 +34825,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34587,6 +34854,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -34640,6 +34908,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34686,6 +34955,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldC
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldD", wireType)
@@ -34705,6 +34975,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldD
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldE", wireType)
@@ -34724,6 +34995,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldE
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldF", wireType)
@@ -34743,6 +35015,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldF
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldG", wireType)
@@ -34762,6 +35035,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = v
 		case 8:
@@ -34783,6 +35057,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = int64(v)
 		case 9:
@@ -34840,6 +35115,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -34860,6 +35136,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -34889,6 +35166,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -34943,6 +35221,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -34993,6 +35272,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = &v
 		case 4:
 			if wireType != 0 {
@@ -35013,6 +35293,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = &v
 		case 5:
 			if wireType != 0 {
@@ -35033,6 +35314,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 6:
 			if wireType != 0 {
@@ -35053,6 +35335,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = &v
 		case 7:
 			if wireType != 0 {
@@ -35073,6 +35356,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = &v
 		case 8:
@@ -35094,6 +35378,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.FieldH = &v2
@@ -35160,6 +35445,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldM = &b
 		case 14:
@@ -35181,6 +35467,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -35211,6 +35498,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35265,6 +35553,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -35315,6 +35604,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = append(m.FieldC, v)
 		case 4:
 			if wireType != 0 {
@@ -35335,6 +35625,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = append(m.FieldD, v)
 		case 5:
 			if wireType != 0 {
@@ -35355,6 +35646,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = append(m.FieldE, v)
 		case 6:
 			if wireType != 0 {
@@ -35375,6 +35667,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = append(m.FieldF, v)
 		case 7:
 			if wireType != 0 {
@@ -35395,6 +35688,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = append(m.FieldG, v)
 		case 8:
@@ -35416,6 +35710,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = append(m.FieldH, int64(v))
 		case 9:
@@ -35481,6 +35776,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = append(m.FieldM, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -35501,6 +35797,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -35530,6 +35827,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35582,6 +35880,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -35632,6 +35931,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35665,6 +35965,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35696,6 +35997,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 7:
 			if wireType != 0 {
@@ -35716,6 +36018,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldF = &v
 		case 8:
@@ -35737,6 +36040,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35770,6 +36074,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldH = &b
 		case 14:
@@ -35791,6 +36096,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -35821,6 +36127,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35875,6 +36182,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -35903,6 +36211,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35935,6 +36244,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35967,6 +36277,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -35999,6 +36310,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -36054,6 +36366,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36082,6 +36395,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -36115,6 +36429,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -36148,6 +36463,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldB = &b
 		default:
@@ -36192,6 +36508,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36220,6 +36537,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldA = &v
 		case 2:
 			if wireType != 0 {
@@ -36240,6 +36558,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldB = append(m.FieldB, v)
 		default:
 			iNdEx = preIndex
@@ -36283,6 +36602,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36311,6 +36631,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -36378,6 +36699,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36406,6 +36728,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -36458,6 +36781,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36486,6 +36810,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -36517,6 +36842,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -36570,6 +36896,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36598,6 +36925,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -36640,6 +36968,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36668,6 +36997,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -36698,6 +37028,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -36751,6 +37082,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36779,6 +37111,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -36821,6 +37154,7 @@ func (m *Node) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -36849,6 +37183,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -36879,6 +37214,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}

--- a/test/combos/unsafeunmarshaler/thetest.pb.go
+++ b/test/combos/unsafeunmarshaler/thetest.pb.go
@@ -22195,6 +22195,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -22241,6 +22242,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field3
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -22260,6 +22262,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field4
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -22279,6 +22282,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field5
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -22298,6 +22302,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -22317,6 +22322,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -22338,6 +22344,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = int64(v)
 		case 9:
@@ -22395,6 +22402,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -22415,6 +22423,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -22444,6 +22453,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -22498,6 +22508,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -22548,6 +22559,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -22568,6 +22580,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -22588,6 +22601,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -22608,6 +22622,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -22628,6 +22643,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -22649,6 +22665,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -22715,6 +22732,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -22736,6 +22754,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -22766,6 +22785,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -22820,6 +22840,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -22870,6 +22891,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -22890,6 +22912,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -22910,6 +22933,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -22930,6 +22954,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -22950,6 +22975,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -22971,6 +22997,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -23036,6 +23063,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -23056,6 +23084,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -23085,6 +23114,7 @@ func (m *NidRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -23137,6 +23167,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -23187,6 +23218,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -23207,6 +23239,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -23227,6 +23260,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -23247,6 +23281,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -23267,6 +23302,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -23288,6 +23324,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -23353,6 +23390,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -23373,6 +23411,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -23402,6 +23441,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -23454,6 +23494,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -23480,6 +23521,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23524,6 +23566,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23568,6 +23611,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23591,6 +23635,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -23609,6 +23654,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -23630,6 +23676,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23653,6 +23700,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -23671,6 +23719,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -23692,6 +23741,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23715,6 +23765,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -23733,6 +23784,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -23754,6 +23806,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23777,6 +23830,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -23795,6 +23849,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -23816,6 +23871,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23839,6 +23895,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -23858,6 +23915,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -23880,6 +23938,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23903,6 +23962,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -23922,6 +23982,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -23944,6 +24005,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -23988,6 +24050,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24032,6 +24095,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24076,6 +24140,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24120,6 +24185,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24143,6 +24209,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -24161,6 +24228,7 @@ func (m *NidRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -24207,6 +24275,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -24233,6 +24302,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24277,6 +24347,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24321,6 +24392,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24344,6 +24416,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -24362,6 +24435,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -24383,6 +24457,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24406,6 +24481,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -24424,6 +24500,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -24445,6 +24522,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24468,6 +24546,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -24486,6 +24565,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -24507,6 +24587,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24530,6 +24611,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -24548,6 +24630,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -24569,6 +24652,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24592,6 +24676,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -24611,6 +24696,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -24633,6 +24719,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24656,6 +24743,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -24675,6 +24763,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -24697,6 +24786,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24741,6 +24831,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24785,6 +24876,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24829,6 +24921,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24873,6 +24966,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthThetestUnsafe
 				}
@@ -24896,6 +24990,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -24914,6 +25009,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -24960,6 +25056,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25006,6 +25103,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25036,6 +25134,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25066,6 +25165,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field7", wireType)
@@ -25085,6 +25185,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 		case 8:
@@ -25106,6 +25207,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25136,6 +25238,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -25156,6 +25259,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -25185,6 +25289,7 @@ func (m *NidOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25239,6 +25344,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25289,6 +25395,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25322,6 +25429,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25355,6 +25463,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -25375,6 +25484,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -25396,6 +25506,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25429,6 +25540,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -25450,6 +25562,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -25480,6 +25593,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25534,6 +25648,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25584,6 +25699,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25615,6 +25731,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25646,6 +25763,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -25666,6 +25784,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -25687,6 +25806,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25718,6 +25838,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -25738,6 +25859,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -25767,6 +25889,7 @@ func (m *NidRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25819,6 +25942,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -25869,6 +25993,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25900,6 +26025,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -25931,6 +26057,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -25951,6 +26078,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -25972,6 +26100,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26003,6 +26132,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -26023,6 +26153,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -26052,6 +26183,7 @@ func (m *NinRepStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26104,6 +26236,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26132,6 +26265,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26165,6 +26299,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26195,6 +26330,7 @@ func (m *NidEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field210 = bool(v != 0)
 		default:
 			iNdEx = preIndex
@@ -26238,6 +26374,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26266,6 +26403,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26299,6 +26437,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26332,6 +26471,7 @@ func (m *NinEmbeddedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -26376,6 +26516,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26404,6 +26545,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26434,6 +26576,7 @@ func (m *NidNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26488,6 +26631,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26516,6 +26660,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26549,6 +26694,7 @@ func (m *NinNestedStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26603,6 +26749,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26631,6 +26778,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26661,6 +26809,7 @@ func (m *NidOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26714,6 +26863,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26742,6 +26892,7 @@ func (m *CustomDash) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26797,6 +26948,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26825,6 +26977,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26857,6 +27010,7 @@ func (m *NinOptCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26912,6 +27066,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -26940,6 +27095,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -26972,6 +27128,7 @@ func (m *NidRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27027,6 +27184,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27055,6 +27213,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27087,6 +27246,7 @@ func (m *NinRepCustom) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27142,6 +27302,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27192,6 +27353,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -27212,6 +27374,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -27232,6 +27395,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -27252,6 +27416,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 13:
 			if wireType != 0 {
@@ -27272,6 +27437,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -27293,6 +27459,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -27323,6 +27490,7 @@ func (m *NinOptNativeUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27377,6 +27545,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27427,6 +27596,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27460,6 +27630,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27493,6 +27664,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -27513,6 +27685,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 13:
@@ -27534,6 +27707,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -27555,6 +27729,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -27585,6 +27760,7 @@ func (m *NinOptStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27639,6 +27815,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27667,6 +27844,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27700,6 +27878,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27733,6 +27912,7 @@ func (m *NinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field210 = &b
 		default:
@@ -27777,6 +27957,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27805,6 +27986,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27838,6 +28020,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27871,6 +28054,7 @@ func (m *NinNestedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27927,6 +28111,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -27955,6 +28140,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -27988,6 +28174,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28021,6 +28208,7 @@ func (m *Tree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28077,6 +28265,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28105,6 +28294,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28135,6 +28325,7 @@ func (m *OrBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28188,6 +28379,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28216,6 +28408,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28246,6 +28439,7 @@ func (m *AndBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28299,6 +28493,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28327,6 +28522,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Value
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field StrValue", wireType)
@@ -28346,6 +28542,7 @@ func (m *Leaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -28398,6 +28595,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28426,6 +28624,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28459,6 +28658,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28492,6 +28692,7 @@ func (m *DeepTree) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28548,6 +28749,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28576,6 +28778,7 @@ func (m *ADeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28629,6 +28832,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28657,6 +28861,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28687,6 +28892,7 @@ func (m *AndDeepBranch) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28740,6 +28946,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28768,6 +28975,7 @@ func (m *DeepLeaf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -28821,6 +29029,7 @@ func (m *Nil) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28872,6 +29081,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28900,6 +29110,7 @@ func (m *NidOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field1
 		default:
 			iNdEx = preIndex
 			skippy, err := skipThetestUnsafe(data[iNdEx:])
@@ -28942,6 +29153,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -28970,6 +29182,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -28990,6 +29203,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29010,6 +29224,7 @@ func (m *NinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29053,6 +29268,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29081,6 +29297,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -29101,6 +29318,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -29121,6 +29339,7 @@ func (m *NidRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -29164,6 +29383,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29192,6 +29412,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = append(m.Field1, v)
 		case 2:
 			if wireType != 0 {
@@ -29212,6 +29433,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = append(m.Field2, v)
 		case 3:
 			if wireType != 0 {
@@ -29232,6 +29454,7 @@ func (m *NinRepEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		default:
 			iNdEx = preIndex
@@ -29275,6 +29498,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29303,6 +29527,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29323,6 +29548,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29343,6 +29569,7 @@ func (m *NinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29386,6 +29613,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29414,6 +29642,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29434,6 +29663,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29454,6 +29684,7 @@ func (m *AnotherNinOptEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29497,6 +29728,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29525,6 +29757,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -29545,6 +29778,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 3:
 			if wireType != 0 {
@@ -29565,6 +29799,7 @@ func (m *AnotherNinOptEnumDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -29608,6 +29843,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29654,6 +29890,7 @@ func (m *Timer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29708,6 +29945,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29736,6 +29974,7 @@ func (m *MyExtendable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -29806,6 +30045,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29834,6 +30074,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field2 = &v
 		case 13:
 			if wireType != 0 {
@@ -29854,6 +30095,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = &v
 		case 1:
 			if wireType != 2 {
@@ -29874,6 +30116,7 @@ func (m *OtherExtenable) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -29957,6 +30200,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -29985,6 +30229,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 0 {
@@ -30005,6 +30250,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.EnumField = &v
 		case 3:
 			if wireType != 2 {
@@ -30025,6 +30271,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30058,6 +30305,7 @@ func (m *NestedDefinition) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30114,6 +30362,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30153,6 +30402,7 @@ func (m *NestedDefinition_NestedMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30209,6 +30459,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30237,6 +30488,7 @@ func (m *NestedDefinition_NestedMessage_NestedNestedMsg) Unmarshal(data []byte) 
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -30290,6 +30542,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30318,6 +30571,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30351,6 +30605,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.B = &v
 		case 3:
 			if wireType != 2 {
@@ -30371,6 +30626,7 @@ func (m *NestedScope) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30427,6 +30683,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30477,6 +30734,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -30497,6 +30755,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -30517,6 +30776,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -30537,6 +30797,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -30557,6 +30818,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -30578,6 +30840,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -30644,6 +30907,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -30665,6 +30929,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -30695,6 +30960,7 @@ func (m *NinOptNativeDefault) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30749,6 +31015,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30777,6 +31044,7 @@ func (m *CustomContainer) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -30830,6 +31098,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -30876,6 +31145,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldC
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldD", wireType)
@@ -30895,6 +31165,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldD
 		case 5:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldE", wireType)
@@ -30914,6 +31185,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldE
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldF", wireType)
@@ -30933,6 +31205,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.FieldF
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FieldG", wireType)
@@ -30952,6 +31225,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = v
 		case 8:
@@ -30973,6 +31247,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = int64(v)
 		case 9:
@@ -31030,6 +31305,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = bool(v != 0)
 		case 14:
 			if wireType != 2 {
@@ -31050,6 +31326,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -31079,6 +31356,7 @@ func (m *CustomNameNidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31133,6 +31411,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31183,6 +31462,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = &v
 		case 4:
 			if wireType != 0 {
@@ -31203,6 +31483,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = &v
 		case 5:
 			if wireType != 0 {
@@ -31223,6 +31504,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 6:
 			if wireType != 0 {
@@ -31243,6 +31525,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = &v
 		case 7:
 			if wireType != 0 {
@@ -31263,6 +31546,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = &v
 		case 8:
@@ -31284,6 +31568,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.FieldH = &v2
@@ -31350,6 +31635,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldM = &b
 		case 14:
@@ -31371,6 +31657,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -31401,6 +31688,7 @@ func (m *CustomNameNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31455,6 +31743,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31505,6 +31794,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldC = append(m.FieldC, v)
 		case 4:
 			if wireType != 0 {
@@ -31525,6 +31815,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldD = append(m.FieldD, v)
 		case 5:
 			if wireType != 0 {
@@ -31545,6 +31836,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = append(m.FieldE, v)
 		case 6:
 			if wireType != 0 {
@@ -31565,6 +31857,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldF = append(m.FieldF, v)
 		case 7:
 			if wireType != 0 {
@@ -31585,6 +31878,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldG = append(m.FieldG, v)
 		case 8:
@@ -31606,6 +31900,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.FieldH = append(m.FieldH, int64(v))
 		case 9:
@@ -31671,6 +31966,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldM = append(m.FieldM, bool(v != 0))
 		case 14:
 			if wireType != 2 {
@@ -31691,6 +31987,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -31720,6 +32017,7 @@ func (m *CustomNameNinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31772,6 +32070,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -31822,6 +32121,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31855,6 +32155,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31886,6 +32187,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldE = &v
 		case 7:
 			if wireType != 0 {
@@ -31906,6 +32208,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.FieldF = &v
 		case 8:
@@ -31927,6 +32230,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -31960,6 +32264,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldH = &b
 		case 14:
@@ -31981,6 +32286,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -32011,6 +32317,7 @@ func (m *CustomNameNinStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32065,6 +32372,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32093,6 +32401,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32125,6 +32434,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32157,6 +32467,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32189,6 +32500,7 @@ func (m *CustomNameCustomType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32244,6 +32556,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32272,6 +32585,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32305,6 +32619,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32338,6 +32653,7 @@ func (m *CustomNameNinEmbeddedStructUnion) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.FieldB = &b
 		default:
@@ -32382,6 +32698,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32410,6 +32727,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldA = &v
 		case 2:
 			if wireType != 0 {
@@ -32430,6 +32748,7 @@ func (m *CustomNameEnum) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.FieldB = append(m.FieldB, v)
 		default:
 			iNdEx = preIndex
@@ -32473,6 +32792,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32501,6 +32821,7 @@ func (m *NoExtensionsMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			if (fieldNum >= 100) && (fieldNum < 200) {
@@ -32568,6 +32889,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32596,6 +32918,7 @@ func (m *Unrecognized) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -32648,6 +32971,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32676,6 +33000,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32707,6 +33032,7 @@ func (m *UnrecognizedWithInner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -32760,6 +33086,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32788,6 +33115,7 @@ func (m *UnrecognizedWithInner_Inner) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -32830,6 +33158,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32858,6 +33187,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}
@@ -32888,6 +33218,7 @@ func (m *UnrecognizedWithEmbed) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -32941,6 +33272,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -32969,6 +33301,7 @@ func (m *UnrecognizedWithEmbed_Embedded) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -33011,6 +33344,7 @@ func (m *Node) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -33039,6 +33373,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthThetestUnsafe
@@ -33069,6 +33404,7 @@ func (m *Node) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthThetestUnsafe
 			}

--- a/test/custombytesnonstruct/proto.pb.go
+++ b/test/custombytesnonstruct/proto.pb.go
@@ -58,6 +58,7 @@ func (m *Object) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -86,6 +87,7 @@ func (m *Object) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthProto
 			}
@@ -118,6 +120,7 @@ func (m *Object) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthProto
 			}

--- a/test/empty-issue70/empty.pb.go
+++ b/test/empty-issue70/empty.pb.go
@@ -56,6 +56,7 @@ func (m *TestRequest) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {

--- a/test/example/example.pb.go
+++ b/test/example/example.pb.go
@@ -2700,6 +2700,7 @@ func (m *A) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2728,6 +2729,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthExample
@@ -2757,6 +2759,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Number
 		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
@@ -2776,6 +2779,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthExample
 			}
@@ -2829,6 +2833,7 @@ func (m *B) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2857,6 +2862,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthExample
 			}
@@ -2887,6 +2893,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthExample
 			}
@@ -2942,6 +2949,7 @@ func (m *C) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2970,6 +2978,7 @@ func (m *C) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.MySize = &v
 		default:
 			iNdEx = preIndex
@@ -3013,6 +3022,7 @@ func (m *U) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3041,6 +3051,7 @@ func (m *U) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthExample
 			}
@@ -3074,6 +3085,7 @@ func (m *U) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthExample
 			}
@@ -3130,6 +3142,7 @@ func (m *E) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3205,6 +3218,7 @@ func (m *R) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3233,6 +3247,7 @@ func (m *R) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Recognized = &v
 		default:
 			iNdEx = preIndex
@@ -3275,6 +3290,7 @@ func (m *CastType) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3303,6 +3319,7 @@ func (m *CastType) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32 = &v
 		default:
 			iNdEx = preIndex

--- a/test/fuzztests/fuzz.pb.go
+++ b/test/fuzztests/fuzz.pb.go
@@ -1277,6 +1277,7 @@ func (m *Nil) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1328,6 +1329,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1354,6 +1356,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1414,6 +1417,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1466,6 +1470,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1489,6 +1494,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -1507,6 +1513,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -1528,6 +1535,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1551,6 +1559,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -1569,6 +1578,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -1590,6 +1600,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1613,6 +1624,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -1631,6 +1643,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -1652,6 +1665,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1675,6 +1689,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -1693,6 +1708,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -1714,6 +1730,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1737,6 +1754,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -1756,6 +1774,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -1778,6 +1797,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1801,6 +1821,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -1820,6 +1841,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -1842,6 +1864,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1892,6 +1915,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -1942,6 +1966,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -2000,6 +2025,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -2058,6 +2084,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthFuzz
 				}
@@ -2081,6 +2108,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -2099,6 +2127,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -2145,6 +2174,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2207,6 +2237,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		case 4:
 			if wireType != 0 {
@@ -2227,6 +2258,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 		case 5:
 			if wireType != 0 {
@@ -2247,6 +2279,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 		case 6:
 			if wireType != 0 {
@@ -2267,6 +2300,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -2287,6 +2321,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -2308,6 +2343,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -2394,6 +2430,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -2415,6 +2452,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthFuzz
@@ -2445,6 +2483,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthFuzz
 			}
@@ -2499,6 +2538,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2561,6 +2601,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthFuzz
 			}
@@ -2594,6 +2635,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthFuzz
 			}
@@ -2627,6 +2669,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 0 {
@@ -2647,6 +2690,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 		case 8:
@@ -2668,6 +2712,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthFuzz
 			}
@@ -2701,6 +2746,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 		case 14:
@@ -2722,6 +2768,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthFuzz
@@ -2752,6 +2799,7 @@ func (m *NinOptStruct) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthFuzz
 			}

--- a/test/indeximport-issue72/index/index.pb.go
+++ b/test/indeximport-issue72/index/index.pb.go
@@ -300,6 +300,7 @@ func (m *IndexQuery) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -328,6 +329,7 @@ func (m *IndexQuery) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthIndex
@@ -358,6 +360,7 @@ func (m *IndexQuery) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthIndex

--- a/test/indeximport-issue72/indeximport.pb.go
+++ b/test/indeximport-issue72/indeximport.pb.go
@@ -280,6 +280,7 @@ func (m *IndexQueries) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -308,6 +309,7 @@ func (m *IndexQueries) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthIndeximport
 			}

--- a/test/issue34/proto.pb.go
+++ b/test/issue34/proto.pb.go
@@ -82,6 +82,7 @@ func (m *Foo) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -110,6 +111,7 @@ func (m *Foo) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthProto
 			}
@@ -164,6 +166,7 @@ func (m *FooWithRepeated) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -192,6 +195,7 @@ func (m *FooWithRepeated) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthProto
 			}

--- a/test/issue42order/issue42.pb.go
+++ b/test/issue42order/issue42.pb.go
@@ -340,6 +340,7 @@ func (m *UnorderedFields) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -386,6 +387,7 @@ func (m *UnorderedFields) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.A = &v
 		default:
 			iNdEx = preIndex
@@ -429,6 +431,7 @@ func (m *OrderedFields) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -475,6 +478,7 @@ func (m *OrderedFields) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.A = &v
 		default:
 			iNdEx = preIndex

--- a/test/issue8/proto.pb.go
+++ b/test/issue8/proto.pb.go
@@ -189,6 +189,7 @@ func (m *Foo) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -217,6 +218,7 @@ func (m *Foo) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Bar = &v
 			hasFields[0] |= uint64(0x00000001)
 		default:

--- a/test/mapsproto2/combos/both/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/both/mapsproto2.pb.go
@@ -3464,6 +3464,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3534,6 +3535,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3562,6 +3564,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3584,6 +3587,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3599,6 +3603,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -3624,6 +3629,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -3662,6 +3668,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3684,6 +3691,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3699,6 +3707,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -3724,6 +3733,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -3758,6 +3768,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3780,6 +3791,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3795,6 +3807,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3810,6 +3823,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3825,6 +3839,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -3849,6 +3864,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3871,6 +3887,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3886,6 +3903,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3901,6 +3919,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3916,6 +3935,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -3940,6 +3960,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3962,6 +3983,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3977,6 +3999,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3992,6 +4015,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4007,6 +4031,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -4031,6 +4056,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4053,6 +4079,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4068,6 +4095,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4083,6 +4111,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4098,6 +4127,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -4122,6 +4152,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4144,6 +4175,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4159,6 +4191,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -4176,6 +4209,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4191,6 +4225,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -4217,6 +4252,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4239,6 +4275,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4254,6 +4291,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -4271,6 +4309,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4286,6 +4325,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -4312,6 +4352,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4334,6 +4375,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4358,6 +4400,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4391,6 +4434,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4413,6 +4457,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4437,6 +4482,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4470,6 +4516,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4492,6 +4539,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4520,6 +4568,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4557,6 +4606,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4579,6 +4629,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4607,6 +4658,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4644,6 +4696,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4666,6 +4719,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4681,6 +4735,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -4697,6 +4752,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4712,6 +4768,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -4737,6 +4794,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4759,6 +4817,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4774,6 +4833,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4799,6 +4859,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4814,6 +4875,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4848,6 +4910,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4870,6 +4933,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4885,6 +4949,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4910,6 +4975,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4925,6 +4991,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4960,6 +5027,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4982,6 +5050,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4997,6 +5066,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -5022,6 +5092,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -5037,6 +5108,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -5061,6 +5133,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -5083,6 +5156,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -5098,6 +5172,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -5123,6 +5198,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -5138,6 +5214,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}

--- a/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
@@ -3102,6 +3102,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3172,6 +3173,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3200,6 +3202,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3222,6 +3225,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3237,6 +3241,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -3262,6 +3267,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -3300,6 +3306,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3322,6 +3329,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3337,6 +3345,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -3362,6 +3371,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -3396,6 +3406,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3418,6 +3429,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3433,6 +3445,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3448,6 +3461,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3463,6 +3477,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -3487,6 +3502,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3509,6 +3525,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3524,6 +3541,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3539,6 +3557,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3554,6 +3573,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -3578,6 +3598,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3600,6 +3621,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3615,6 +3637,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3630,6 +3653,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3645,6 +3669,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -3669,6 +3694,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3691,6 +3717,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3706,6 +3733,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3721,6 +3749,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3736,6 +3765,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -3760,6 +3790,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3782,6 +3813,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3797,6 +3829,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -3814,6 +3847,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3829,6 +3863,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -3855,6 +3890,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3877,6 +3913,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3892,6 +3929,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -3909,6 +3947,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3924,6 +3963,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -3950,6 +3990,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -3972,6 +4013,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -3996,6 +4038,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4029,6 +4072,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4051,6 +4095,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4075,6 +4120,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4108,6 +4154,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4130,6 +4177,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4158,6 +4206,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4195,6 +4244,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4217,6 +4267,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4245,6 +4296,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4282,6 +4334,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4304,6 +4357,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4319,6 +4373,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -4335,6 +4390,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4350,6 +4406,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -4375,6 +4432,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4397,6 +4455,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4412,6 +4471,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4437,6 +4497,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4452,6 +4513,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4486,6 +4548,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4508,6 +4571,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4523,6 +4587,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4548,6 +4613,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4563,6 +4629,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4598,6 +4665,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4620,6 +4688,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4635,6 +4704,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4660,6 +4730,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4675,6 +4746,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -4699,6 +4771,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}
@@ -4721,6 +4794,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4736,6 +4810,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2
@@ -4761,6 +4836,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4776,6 +4852,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthMapsproto2
 			}

--- a/test/mapsproto2/combos/unsafeboth/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unsafeboth/mapsproto2.pb.go
@@ -3466,6 +3466,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3528,6 +3529,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3556,6 +3558,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3578,6 +3581,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3593,6 +3597,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -3618,6 +3623,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -3656,6 +3662,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3678,6 +3685,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3693,6 +3701,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -3718,6 +3727,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -3752,6 +3762,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3774,6 +3785,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3789,6 +3801,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3804,6 +3817,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3819,6 +3833,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -3843,6 +3858,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3865,6 +3881,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3880,6 +3897,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3895,6 +3913,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3910,6 +3929,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -3934,6 +3954,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3956,6 +3977,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3971,6 +3993,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3986,6 +4009,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4001,6 +4025,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -4025,6 +4050,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4047,6 +4073,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4062,6 +4089,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4077,6 +4105,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4092,6 +4121,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -4116,6 +4146,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4138,6 +4169,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4153,6 +4185,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -4170,6 +4203,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4185,6 +4219,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -4211,6 +4246,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4233,6 +4269,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4248,6 +4285,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -4265,6 +4303,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4280,6 +4319,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -4306,6 +4346,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4328,6 +4369,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4352,6 +4394,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4385,6 +4428,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4407,6 +4451,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4431,6 +4476,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4464,6 +4510,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4486,6 +4533,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4514,6 +4562,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4551,6 +4600,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4573,6 +4623,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4601,6 +4652,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4638,6 +4690,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4660,6 +4713,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4675,6 +4729,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -4691,6 +4746,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4706,6 +4762,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -4731,6 +4788,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4753,6 +4811,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4768,6 +4827,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4793,6 +4853,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4808,6 +4869,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4842,6 +4904,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4864,6 +4927,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4879,6 +4943,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4904,6 +4969,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4919,6 +4985,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4954,6 +5021,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4976,6 +5044,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4991,6 +5060,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -5016,6 +5086,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -5031,6 +5102,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -5055,6 +5127,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -5077,6 +5150,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -5092,6 +5166,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -5117,6 +5192,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -5132,6 +5208,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}

--- a/test/mapsproto2/combos/unsafeunmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unsafeunmarshaler/mapsproto2.pb.go
@@ -3103,6 +3103,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3165,6 +3166,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3193,6 +3195,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3215,6 +3218,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3230,6 +3234,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -3255,6 +3260,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -3293,6 +3299,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3315,6 +3322,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3330,6 +3338,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -3355,6 +3364,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -3389,6 +3399,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3411,6 +3422,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3426,6 +3438,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3441,6 +3454,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3456,6 +3470,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -3480,6 +3495,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3502,6 +3518,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3517,6 +3534,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3532,6 +3550,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3547,6 +3566,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -3571,6 +3591,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3593,6 +3614,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3608,6 +3630,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3623,6 +3646,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3638,6 +3662,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -3662,6 +3687,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3684,6 +3710,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3699,6 +3726,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3714,6 +3742,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3729,6 +3758,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -3753,6 +3783,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3775,6 +3806,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3790,6 +3822,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -3807,6 +3840,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3822,6 +3856,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -3848,6 +3883,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3870,6 +3906,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3885,6 +3922,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -3902,6 +3940,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -3917,6 +3956,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -3943,6 +3983,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -3965,6 +4006,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -3989,6 +4031,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4022,6 +4065,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4044,6 +4088,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4068,6 +4113,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -4101,6 +4147,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4123,6 +4170,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4151,6 +4199,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4188,6 +4237,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4210,6 +4260,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4238,6 +4289,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -4275,6 +4327,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4297,6 +4350,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4312,6 +4366,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -4328,6 +4383,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4343,6 +4399,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -4368,6 +4425,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4390,6 +4448,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4405,6 +4464,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4430,6 +4490,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4445,6 +4506,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4479,6 +4541,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4501,6 +4564,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4516,6 +4580,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4541,6 +4606,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4556,6 +4622,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4591,6 +4658,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4613,6 +4681,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4628,6 +4697,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4653,6 +4723,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4668,6 +4739,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -4692,6 +4764,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}
@@ -4714,6 +4787,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4729,6 +4803,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
@@ -4754,6 +4829,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -4769,6 +4845,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthMapsproto2Unsafe
 			}

--- a/test/oneof/combos/both/one.pb.go
+++ b/test/oneof/combos/both/one.pb.go
@@ -5617,6 +5617,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5645,6 +5646,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -5698,6 +5700,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5758,6 +5761,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -5778,6 +5782,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -5798,6 +5803,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -5818,6 +5824,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -5838,6 +5845,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &AllTypesOneOf_Field7{v}
 		case 8:
@@ -5859,6 +5867,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &AllTypesOneOf_Field8{int64(v)}
 		case 9:
@@ -5944,6 +5953,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &AllTypesOneOf_Field13{b}
 		case 14:
@@ -5965,6 +5975,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -5994,6 +6005,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -6024,6 +6036,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -6079,6 +6092,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6139,6 +6153,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.One = &TwoOneofs_Field3{v}
 		case 34:
 			if wireType != 2 {
@@ -6159,6 +6174,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -6188,6 +6204,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -6218,6 +6235,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -6273,6 +6291,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6301,6 +6320,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -6330,6 +6350,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -6363,6 +6384,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_CastType{v}
 		case 37:
 			if wireType != 0 {
@@ -6383,6 +6405,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_MyCustomName{v}
 		default:
 			iNdEx = preIndex

--- a/test/oneof/combos/unmarshaler/one.pb.go
+++ b/test/oneof/combos/unmarshaler/one.pb.go
@@ -5237,6 +5237,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5265,6 +5266,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -5318,6 +5320,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5378,6 +5381,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -5398,6 +5402,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -5418,6 +5423,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -5438,6 +5444,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -5458,6 +5465,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &AllTypesOneOf_Field7{v}
 		case 8:
@@ -5479,6 +5487,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &AllTypesOneOf_Field8{int64(v)}
 		case 9:
@@ -5564,6 +5573,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &AllTypesOneOf_Field13{b}
 		case 14:
@@ -5585,6 +5595,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -5614,6 +5625,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -5644,6 +5656,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -5699,6 +5712,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5759,6 +5773,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.One = &TwoOneofs_Field3{v}
 		case 34:
 			if wireType != 2 {
@@ -5779,6 +5794,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -5808,6 +5824,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -5838,6 +5855,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -5893,6 +5911,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5921,6 +5940,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -5950,6 +5970,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -5983,6 +6004,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_CastType{v}
 		case 37:
 			if wireType != 0 {
@@ -6003,6 +6025,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_MyCustomName{v}
 		default:
 			iNdEx = preIndex

--- a/test/oneof/combos/unsafeboth/one.pb.go
+++ b/test/oneof/combos/unsafeboth/one.pb.go
@@ -5627,6 +5627,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5655,6 +5656,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -5708,6 +5710,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5758,6 +5761,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -5778,6 +5782,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -5798,6 +5803,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -5818,6 +5824,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -5838,6 +5845,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &AllTypesOneOf_Field7{v}
 		case 8:
@@ -5859,6 +5867,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &AllTypesOneOf_Field8{int64(v)}
 		case 9:
@@ -5924,6 +5933,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &AllTypesOneOf_Field13{b}
 		case 14:
@@ -5945,6 +5955,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -5974,6 +5985,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -6004,6 +6016,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -6059,6 +6072,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6109,6 +6123,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.One = &TwoOneofs_Field3{v}
 		case 34:
 			if wireType != 2 {
@@ -6129,6 +6144,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -6158,6 +6174,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -6188,6 +6205,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -6243,6 +6261,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6271,6 +6290,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -6300,6 +6320,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -6333,6 +6354,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_CastType{v}
 		case 37:
 			if wireType != 0 {
@@ -6353,6 +6375,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_MyCustomName{v}
 		default:
 			iNdEx = preIndex

--- a/test/oneof/combos/unsafeunmarshaler/one.pb.go
+++ b/test/oneof/combos/unsafeunmarshaler/one.pb.go
@@ -5238,6 +5238,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5266,6 +5267,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -5319,6 +5321,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5369,6 +5372,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -5389,6 +5393,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -5409,6 +5414,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -5429,6 +5435,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &AllTypesOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -5449,6 +5456,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &AllTypesOneOf_Field7{v}
 		case 8:
@@ -5470,6 +5478,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &AllTypesOneOf_Field8{int64(v)}
 		case 9:
@@ -5535,6 +5544,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &AllTypesOneOf_Field13{b}
 		case 14:
@@ -5556,6 +5566,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -5585,6 +5596,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -5615,6 +5627,7 @@ func (m *AllTypesOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -5670,6 +5683,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5720,6 +5734,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.One = &TwoOneofs_Field3{v}
 		case 34:
 			if wireType != 2 {
@@ -5740,6 +5755,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -5769,6 +5785,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -5799,6 +5816,7 @@ func (m *TwoOneofs) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -5854,6 +5872,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -5882,6 +5901,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -5911,6 +5931,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -5944,6 +5965,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_CastType{v}
 		case 37:
 			if wireType != 0 {
@@ -5964,6 +5986,7 @@ func (m *CustomOneof) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Custom = &CustomOneof_MyCustomName{v}
 		default:
 			iNdEx = preIndex

--- a/test/oneof3/combos/both/one.pb.go
+++ b/test/oneof3/combos/both/one.pb.go
@@ -3741,6 +3741,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3769,6 +3770,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -3820,6 +3822,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3880,6 +3883,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -3900,6 +3904,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -3920,6 +3925,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -3940,6 +3946,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -3960,6 +3967,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &SampleOneOf_Field7{v}
 		case 8:
@@ -3981,6 +3989,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &SampleOneOf_Field8{int64(v)}
 		case 9:
@@ -4066,6 +4075,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &SampleOneOf_Field13{b}
 		case 14:
@@ -4087,6 +4097,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -4116,6 +4127,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -4146,6 +4158,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOne
 			}

--- a/test/oneof3/combos/unmarshaler/one.pb.go
+++ b/test/oneof3/combos/unmarshaler/one.pb.go
@@ -3534,6 +3534,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3562,6 +3563,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -3613,6 +3615,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3673,6 +3676,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -3693,6 +3697,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -3713,6 +3718,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -3733,6 +3739,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -3753,6 +3760,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &SampleOneOf_Field7{v}
 		case 8:
@@ -3774,6 +3782,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &SampleOneOf_Field8{int64(v)}
 		case 9:
@@ -3859,6 +3868,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &SampleOneOf_Field13{b}
 		case 14:
@@ -3880,6 +3890,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOne
@@ -3909,6 +3920,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOne
 			}
@@ -3939,6 +3951,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOne
 			}

--- a/test/oneof3/combos/unsafeboth/one.pb.go
+++ b/test/oneof3/combos/unsafeboth/one.pb.go
@@ -3749,6 +3749,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3777,6 +3778,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -3828,6 +3830,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3878,6 +3881,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -3898,6 +3902,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -3918,6 +3923,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -3938,6 +3944,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -3958,6 +3965,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &SampleOneOf_Field7{v}
 		case 8:
@@ -3979,6 +3987,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &SampleOneOf_Field8{int64(v)}
 		case 9:
@@ -4044,6 +4053,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &SampleOneOf_Field13{b}
 		case 14:
@@ -4065,6 +4075,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -4094,6 +4105,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -4124,6 +4136,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}

--- a/test/oneof3/combos/unsafeunmarshaler/one.pb.go
+++ b/test/oneof3/combos/unsafeunmarshaler/one.pb.go
@@ -3535,6 +3535,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3563,6 +3564,7 @@ func (m *Subby) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -3614,6 +3616,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3664,6 +3667,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field3{v}
 		case 4:
 			if wireType != 0 {
@@ -3684,6 +3688,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field4{v}
 		case 5:
 			if wireType != 0 {
@@ -3704,6 +3709,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field5{v}
 		case 6:
 			if wireType != 0 {
@@ -3724,6 +3730,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TestOneof = &SampleOneOf_Field6{v}
 		case 7:
 			if wireType != 0 {
@@ -3744,6 +3751,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.TestOneof = &SampleOneOf_Field7{v}
 		case 8:
@@ -3765,6 +3773,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.TestOneof = &SampleOneOf_Field8{int64(v)}
 		case 9:
@@ -3830,6 +3839,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.TestOneof = &SampleOneOf_Field13{b}
 		case 14:
@@ -3851,6 +3861,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthOneUnsafe
@@ -3880,6 +3891,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}
@@ -3910,6 +3922,7 @@ func (m *SampleOneOf) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthOneUnsafe
 			}

--- a/test/packed/packed.pb.go
+++ b/test/packed/packed.pb.go
@@ -1068,6 +1068,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1130,6 +1131,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -1150,6 +1152,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -1170,6 +1173,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -1190,6 +1194,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -1210,6 +1215,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -1231,6 +1237,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -1316,6 +1323,7 @@ func (m *NinRepNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		default:
 			iNdEx = preIndex
@@ -1359,6 +1367,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1385,6 +1394,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1445,6 +1455,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1497,6 +1508,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1520,6 +1532,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -1538,6 +1551,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -1559,6 +1573,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1582,6 +1597,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -1600,6 +1616,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -1621,6 +1638,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1644,6 +1662,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -1662,6 +1681,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -1683,6 +1703,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1706,6 +1727,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -1724,6 +1746,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -1745,6 +1768,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1768,6 +1792,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -1787,6 +1812,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -1809,6 +1835,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1832,6 +1859,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -1851,6 +1879,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -1873,6 +1902,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1923,6 +1953,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -1973,6 +2004,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -2031,6 +2063,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -2089,6 +2122,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPacked
 				}
@@ -2112,6 +2146,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -2130,6 +2165,7 @@ func (m *NinRepPackedNative) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)
@@ -2281,6 +2317,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2331,6 +2368,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = append(m.Field3, v)
 		case 4:
 			if wireType != 0 {
@@ -2351,6 +2389,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = append(m.Field4, v)
 		case 5:
 			if wireType != 0 {
@@ -2371,6 +2410,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = append(m.Field5, v)
 		case 6:
 			if wireType != 0 {
@@ -2391,6 +2431,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = append(m.Field6, v)
 		case 7:
 			if wireType != 0 {
@@ -2411,6 +2452,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = append(m.Field7, v)
 		case 8:
@@ -2432,6 +2474,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = append(m.Field8, int64(v))
 		case 9:
@@ -2497,6 +2540,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = append(m.Field13, bool(v != 0))
 		default:
 			iNdEx = preIndex
@@ -2540,6 +2584,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2566,6 +2611,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2610,6 +2656,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2654,6 +2701,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2677,6 +2725,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field3 = append(m.Field3, v)
 				}
 			} else if wireType == 0 {
@@ -2695,6 +2744,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field3 = append(m.Field3, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field3", wireType)
@@ -2716,6 +2766,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2739,6 +2790,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field4 = append(m.Field4, v)
 				}
 			} else if wireType == 0 {
@@ -2757,6 +2809,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field4 = append(m.Field4, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field4", wireType)
@@ -2778,6 +2831,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2801,6 +2855,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field5 = append(m.Field5, v)
 				}
 			} else if wireType == 0 {
@@ -2819,6 +2874,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field5 = append(m.Field5, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field5", wireType)
@@ -2840,6 +2896,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2863,6 +2920,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field6 = append(m.Field6, v)
 				}
 			} else if wireType == 0 {
@@ -2881,6 +2939,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field6 = append(m.Field6, v)
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field6", wireType)
@@ -2902,6 +2961,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2925,6 +2985,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 					m.Field7 = append(m.Field7, v)
 				}
@@ -2944,6 +3005,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 				m.Field7 = append(m.Field7, v)
 			} else {
@@ -2966,6 +3028,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -2989,6 +3052,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 					m.Field8 = append(m.Field8, int64(v))
 				}
@@ -3008,6 +3072,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 				m.Field8 = append(m.Field8, int64(v))
 			} else {
@@ -3030,6 +3095,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -3074,6 +3140,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -3118,6 +3185,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -3162,6 +3230,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -3206,6 +3275,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = packedLen
 				if packedLen < 0 {
 					return ErrInvalidLengthPackedUnsafe
 				}
@@ -3229,6 +3299,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 							break
 						}
 					}
+					_ = v
 					m.Field13 = append(m.Field13, bool(v != 0))
 				}
 			} else if wireType == 0 {
@@ -3247,6 +3318,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(data []byte) error {
 						break
 					}
 				}
+				_ = v
 				m.Field13 = append(m.Field13, bool(v != 0))
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field Field13", wireType)

--- a/test/protosize/protosize.pb.go
+++ b/test/protosize/protosize.pb.go
@@ -367,6 +367,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -395,6 +396,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Size = &v
 		case 2:
 			if wireType != 0 {
@@ -415,6 +417,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.ProtoSize_ = &v
 		case 3:
 			if wireType != 0 {
@@ -435,6 +438,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Equal_ = &b
 		case 4:
@@ -456,6 +460,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthProtosize

--- a/test/required/requiredexample.pb.go
+++ b/test/required/requiredexample.pb.go
@@ -1038,6 +1038,7 @@ func (m *RequiredExample) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1066,6 +1067,7 @@ func (m *RequiredExample) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthRequiredexample
@@ -1097,6 +1099,7 @@ func (m *RequiredExample) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthRequiredexample
@@ -1127,6 +1130,7 @@ func (m *RequiredExample) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthRequiredexample
@@ -1183,6 +1187,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1245,6 +1250,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field3
 			hasFields[0] |= uint64(0x00000004)
 		case 4:
 			if wireType != 0 {
@@ -1265,6 +1271,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field4
 			hasFields[0] |= uint64(0x00000008)
 		case 5:
 			if wireType != 0 {
@@ -1285,6 +1292,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field5
 			hasFields[0] |= uint64(0x00000010)
 		case 6:
 			if wireType != 0 {
@@ -1305,6 +1313,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Field6
 			hasFields[0] |= uint64(0x00000020)
 		case 7:
 			if wireType != 0 {
@@ -1325,6 +1334,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = v
 			hasFields[0] |= uint64(0x00000040)
@@ -1347,6 +1357,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Field8 = int64(v)
 			hasFields[0] |= uint64(0x00000080)
@@ -1433,6 +1444,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field13 = bool(v != 0)
 			hasFields[0] |= uint64(0x00001000)
 		case 14:
@@ -1454,6 +1466,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthRequiredexample
@@ -1484,6 +1497,7 @@ func (m *NidOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthRequiredexample
 			}
@@ -1585,6 +1599,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1649,6 +1664,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 			hasFields[0] |= uint64(0x00000004)
 		case 4:
@@ -1670,6 +1686,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field4 = &v
 			hasFields[0] |= uint64(0x00000008)
 		case 5:
@@ -1691,6 +1708,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field5 = &v
 			hasFields[0] |= uint64(0x00000010)
 		case 6:
@@ -1712,6 +1730,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 			hasFields[0] |= uint64(0x00000020)
 		case 7:
@@ -1733,6 +1752,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Field7 = &v
 			hasFields[0] |= uint64(0x00000040)
@@ -1755,6 +1775,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			v2 := int64(v)
 			m.Field8 = &v2
@@ -1846,6 +1867,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Field13 = &b
 			hasFields[0] |= uint64(0x00001000)
@@ -1868,6 +1890,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthRequiredexample
@@ -1899,6 +1922,7 @@ func (m *NinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthRequiredexample
 			}
@@ -1999,6 +2023,7 @@ func (m *NestedNinOptNative) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2027,6 +2052,7 @@ func (m *NestedNinOptNative) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthRequiredexample
 			}

--- a/test/sizeunderscore/sizeunderscore.pb.go
+++ b/test/sizeunderscore/sizeunderscore.pb.go
@@ -335,6 +335,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -363,6 +364,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Size_ = &v
 		case 2:
 			if wireType != 0 {
@@ -383,6 +385,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			b := bool(v != 0)
 			m.Equal_ = &b
 		case 3:
@@ -404,6 +407,7 @@ func (m *SizeMessage) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthSizeunderscore

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -7092,6 +7092,7 @@ func (m *Message) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7120,6 +7121,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7149,6 +7151,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Hilarity
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HeightInCm", wireType)
@@ -7168,6 +7171,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.HeightInCm
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
@@ -7187,6 +7191,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7218,6 +7223,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Key = append(m.Key, v)
 		case 6:
 			if wireType != 2 {
@@ -7238,6 +7244,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7271,6 +7278,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.ResultCount
 		case 8:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TrueScotsman", wireType)
@@ -7290,6 +7298,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TrueScotsman = bool(v != 0)
 		case 9:
 			if wireType != 5 {
@@ -7324,6 +7333,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7346,6 +7356,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7361,6 +7372,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7376,6 +7388,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7391,6 +7404,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7430,6 +7444,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7463,6 +7478,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7485,6 +7501,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7500,6 +7517,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7515,6 +7533,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7530,6 +7549,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7591,6 +7611,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7619,6 +7640,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7670,6 +7692,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7698,6 +7721,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7720,6 +7744,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7735,6 +7760,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7760,6 +7786,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -7798,6 +7825,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7820,6 +7848,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7835,6 +7864,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7860,6 +7890,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7894,6 +7925,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7916,6 +7948,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7931,6 +7964,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7946,6 +7980,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7961,6 +7996,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -7985,6 +8021,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8007,6 +8044,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8022,6 +8060,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8037,6 +8076,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8052,6 +8092,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -8076,6 +8117,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8098,6 +8140,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8113,6 +8156,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8128,6 +8172,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8143,6 +8188,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -8167,6 +8213,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8189,6 +8236,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8204,6 +8252,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8219,6 +8268,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8234,6 +8284,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -8258,6 +8309,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8280,6 +8332,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8295,6 +8348,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -8312,6 +8366,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8327,6 +8382,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -8353,6 +8409,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8375,6 +8432,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8390,6 +8448,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -8407,6 +8466,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8422,6 +8482,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -8448,6 +8509,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8470,6 +8532,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8494,6 +8557,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8527,6 +8591,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8549,6 +8614,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8573,6 +8639,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8606,6 +8673,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8628,6 +8696,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8656,6 +8725,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8693,6 +8763,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8715,6 +8786,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8743,6 +8815,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8780,6 +8853,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8802,6 +8876,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8817,6 +8892,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8833,6 +8909,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8848,6 +8925,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -8873,6 +8951,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8895,6 +8974,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8910,6 +8990,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8935,6 +9016,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8950,6 +9032,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8984,6 +9067,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9006,6 +9090,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9021,6 +9106,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9046,6 +9132,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9061,6 +9148,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9096,6 +9184,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9118,6 +9207,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9133,6 +9223,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9158,6 +9249,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9173,6 +9265,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -9197,6 +9290,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9219,6 +9313,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9234,6 +9329,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9259,6 +9355,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9274,6 +9371,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9335,6 +9433,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9363,6 +9462,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9385,6 +9485,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9400,6 +9501,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9415,6 +9517,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9430,6 +9533,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9464,6 +9568,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9486,6 +9591,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9501,6 +9607,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -9518,6 +9625,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9533,6 +9641,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9572,6 +9681,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9594,6 +9704,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9609,6 +9720,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -9625,6 +9737,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9640,6 +9753,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9697,6 +9811,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9765,6 +9880,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9793,6 +9909,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9823,6 +9940,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3
 			}

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -6462,6 +6462,7 @@ func (m *Message) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6490,6 +6491,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -6519,6 +6521,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Hilarity
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HeightInCm", wireType)
@@ -6538,6 +6541,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.HeightInCm
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
@@ -6557,6 +6561,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6588,6 +6593,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.ResultCount
 		case 8:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TrueScotsman", wireType)
@@ -6607,6 +6613,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TrueScotsman = bool(v != 0)
 		case 9:
 			if wireType != 5 {
@@ -6641,6 +6648,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Key = append(m.Key, v)
 		case 6:
 			if wireType != 2 {
@@ -6661,6 +6669,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6694,6 +6703,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6716,6 +6726,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6731,6 +6742,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6746,6 +6758,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6761,6 +6774,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6800,6 +6814,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6833,6 +6848,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6855,6 +6871,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6870,6 +6887,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6885,6 +6903,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6900,6 +6919,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -6961,6 +6981,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6989,6 +7010,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7040,6 +7062,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7068,6 +7091,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7090,6 +7114,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7105,6 +7130,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7130,6 +7156,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -7168,6 +7195,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7190,6 +7218,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7205,6 +7234,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -7230,6 +7260,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7264,6 +7295,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7286,6 +7318,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7301,6 +7334,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7316,6 +7350,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7331,6 +7366,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -7355,6 +7391,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7377,6 +7414,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7392,6 +7430,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7407,6 +7446,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7422,6 +7462,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -7446,6 +7487,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7468,6 +7510,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7483,6 +7526,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7498,6 +7542,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7513,6 +7558,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -7537,6 +7583,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7559,6 +7606,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7574,6 +7622,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7589,6 +7638,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7604,6 +7654,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -7628,6 +7679,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7650,6 +7702,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7665,6 +7718,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -7682,6 +7736,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7697,6 +7752,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -7723,6 +7779,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7745,6 +7802,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7760,6 +7818,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -7777,6 +7836,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7792,6 +7852,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -7818,6 +7879,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7840,6 +7902,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7864,6 +7927,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7897,6 +7961,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7919,6 +7984,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7943,6 +8009,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7976,6 +8043,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -7998,6 +8066,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8026,6 +8095,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8063,6 +8133,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8085,6 +8156,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8113,6 +8185,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8150,6 +8223,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8172,6 +8246,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8187,6 +8262,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8203,6 +8279,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8218,6 +8295,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -8243,6 +8321,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8265,6 +8344,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8280,6 +8360,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8305,6 +8386,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8320,6 +8402,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8354,6 +8437,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8376,6 +8460,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8391,6 +8476,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8416,6 +8502,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8431,6 +8518,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8466,6 +8554,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8488,6 +8577,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8503,6 +8593,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8528,6 +8619,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8543,6 +8635,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -8567,6 +8660,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8589,6 +8683,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8604,6 +8699,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8629,6 +8725,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8644,6 +8741,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8705,6 +8803,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -8733,6 +8832,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8755,6 +8855,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8770,6 +8871,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8785,6 +8887,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8800,6 +8903,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3
@@ -8834,6 +8938,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8856,6 +8961,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8871,6 +8977,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -8888,6 +8995,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8903,6 +9011,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8942,6 +9051,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -8964,6 +9074,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8979,6 +9090,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8995,6 +9107,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9010,6 +9123,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3
@@ -9067,6 +9181,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9135,6 +9250,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9163,6 +9279,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3
 			}
@@ -9193,6 +9310,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3
 			}

--- a/test/theproto3/combos/unsafeboth/theproto3.pb.go
+++ b/test/theproto3/combos/unsafeboth/theproto3.pb.go
@@ -7095,6 +7095,7 @@ func (m *Message) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7123,6 +7124,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7152,6 +7154,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Hilarity
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HeightInCm", wireType)
@@ -7171,6 +7174,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.HeightInCm
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
@@ -7190,6 +7194,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7221,6 +7226,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Key = append(m.Key, v)
 		case 6:
 			if wireType != 2 {
@@ -7241,6 +7247,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7274,6 +7281,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.ResultCount
 		case 8:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TrueScotsman", wireType)
@@ -7293,6 +7301,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TrueScotsman = bool(v != 0)
 		case 9:
 			if wireType != 5 {
@@ -7322,6 +7331,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7344,6 +7354,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7359,6 +7370,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7374,6 +7386,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7389,6 +7402,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7428,6 +7442,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7461,6 +7476,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7483,6 +7499,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7498,6 +7515,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7513,6 +7531,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7528,6 +7547,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7589,6 +7609,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7617,6 +7638,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7668,6 +7690,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7696,6 +7719,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7718,6 +7742,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7733,6 +7758,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7758,6 +7784,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -7796,6 +7823,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7818,6 +7846,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7833,6 +7862,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7858,6 +7888,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7892,6 +7923,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7914,6 +7946,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7929,6 +7962,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7944,6 +7978,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7959,6 +7994,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -7983,6 +8019,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8005,6 +8042,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8020,6 +8058,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8035,6 +8074,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8050,6 +8090,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -8074,6 +8115,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8096,6 +8138,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8111,6 +8154,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8126,6 +8170,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8141,6 +8186,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -8165,6 +8211,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8187,6 +8234,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8202,6 +8250,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8217,6 +8266,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8232,6 +8282,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -8256,6 +8307,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8278,6 +8330,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8293,6 +8346,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -8310,6 +8364,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8325,6 +8380,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -8351,6 +8407,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8373,6 +8430,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8388,6 +8446,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -8405,6 +8464,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8420,6 +8480,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -8446,6 +8507,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8468,6 +8530,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8492,6 +8555,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8525,6 +8589,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8547,6 +8612,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8571,6 +8637,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -8604,6 +8671,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8626,6 +8694,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8654,6 +8723,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8691,6 +8761,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8713,6 +8784,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8741,6 +8813,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8778,6 +8851,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8800,6 +8874,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8815,6 +8890,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8831,6 +8907,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8846,6 +8923,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -8871,6 +8949,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8893,6 +8972,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8908,6 +8988,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8933,6 +9014,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8948,6 +9030,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8982,6 +9065,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9004,6 +9088,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9019,6 +9104,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9044,6 +9130,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9059,6 +9146,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9094,6 +9182,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9116,6 +9205,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9131,6 +9221,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9156,6 +9247,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9171,6 +9263,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -9195,6 +9288,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9217,6 +9311,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9232,6 +9327,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9257,6 +9353,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9272,6 +9369,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9333,6 +9431,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9361,6 +9460,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9383,6 +9483,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9398,6 +9499,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9413,6 +9515,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9428,6 +9531,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9462,6 +9566,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9484,6 +9589,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9499,6 +9605,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -9516,6 +9623,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9531,6 +9639,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9570,6 +9679,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9592,6 +9702,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9607,6 +9718,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -9623,6 +9735,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9638,6 +9751,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9695,6 +9809,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9754,6 +9869,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9782,6 +9898,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9812,6 +9929,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}

--- a/test/theproto3/combos/unsafeunmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unsafeunmarshaler/theproto3.pb.go
@@ -6463,6 +6463,7 @@ func (m *Message) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6491,6 +6492,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -6520,6 +6522,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Hilarity
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HeightInCm", wireType)
@@ -6539,6 +6542,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.HeightInCm
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
@@ -6558,6 +6562,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6589,6 +6594,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.ResultCount
 		case 8:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TrueScotsman", wireType)
@@ -6608,6 +6614,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.TrueScotsman = bool(v != 0)
 		case 9:
 			if wireType != 5 {
@@ -6637,6 +6644,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Key = append(m.Key, v)
 		case 6:
 			if wireType != 2 {
@@ -6657,6 +6665,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6690,6 +6699,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6712,6 +6722,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6727,6 +6738,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6742,6 +6754,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6757,6 +6770,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6796,6 +6810,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6829,6 +6844,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6851,6 +6867,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6866,6 +6883,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6881,6 +6899,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -6896,6 +6915,7 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -6957,6 +6977,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -6985,6 +7006,7 @@ func (m *Nested) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7036,6 +7058,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -7064,6 +7087,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7086,6 +7110,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7101,6 +7126,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7126,6 +7152,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -7164,6 +7191,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7186,6 +7214,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7201,6 +7230,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -7226,6 +7256,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7260,6 +7291,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7282,6 +7314,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7297,6 +7330,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7312,6 +7346,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7327,6 +7362,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int32Map == nil {
 				m.Int32Map = make(map[int32]int32)
 			}
@@ -7351,6 +7387,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7373,6 +7410,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7388,6 +7426,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7403,6 +7442,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7418,6 +7458,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Int64Map == nil {
 				m.Int64Map = make(map[int64]int64)
 			}
@@ -7442,6 +7483,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7464,6 +7506,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7479,6 +7522,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7494,6 +7538,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7509,6 +7554,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint32Map == nil {
 				m.Uint32Map = make(map[uint32]uint32)
 			}
@@ -7533,6 +7579,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7555,6 +7602,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7570,6 +7618,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7585,6 +7634,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7600,6 +7650,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.Uint64Map == nil {
 				m.Uint64Map = make(map[uint64]uint64)
 			}
@@ -7624,6 +7675,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7646,6 +7698,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7661,6 +7714,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = int32((uint32(mapkeytemp) >> 1) ^ uint32(((mapkeytemp&1)<<31)>>31))
 			mapkey := int32(mapkeytemp)
 			var valuekey uint64
@@ -7678,6 +7732,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7693,6 +7748,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = int32((uint32(mapvaluetemp) >> 1) ^ uint32(((mapvaluetemp&1)<<31)>>31))
 			mapvalue := int32(mapvaluetemp)
 			if m.Sint32Map == nil {
@@ -7719,6 +7775,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7741,6 +7798,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7756,6 +7814,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -7773,6 +7832,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -7788,6 +7848,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvaluetemp = (mapvaluetemp >> 1) ^ uint64((int64(mapvaluetemp&1)<<63)>>63)
 			mapvalue := int64(mapvaluetemp)
 			if m.Sint64Map == nil {
@@ -7814,6 +7875,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7836,6 +7898,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7860,6 +7923,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7893,6 +7957,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7915,6 +7980,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7939,6 +8005,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int32
 			if (iNdEx + 4) > l {
 				return io.ErrUnexpectedEOF
@@ -7972,6 +8039,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -7994,6 +8062,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8022,6 +8091,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue uint64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8059,6 +8129,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8081,6 +8152,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8109,6 +8181,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue int64
 			if (iNdEx + 8) > l {
 				return io.ErrUnexpectedEOF
@@ -8146,6 +8219,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8168,6 +8242,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8183,6 +8258,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8199,6 +8275,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvaluetemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8214,6 +8291,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvaluetemp
 			mapvalue := bool(mapvaluetemp != 0)
 			if m.BoolMap == nil {
 				m.BoolMap = make(map[bool]bool)
@@ -8239,6 +8317,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8261,6 +8340,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8276,6 +8356,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8301,6 +8382,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8316,6 +8398,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8350,6 +8433,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8372,6 +8456,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8387,6 +8472,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8412,6 +8498,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8427,6 +8514,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8462,6 +8550,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8484,6 +8573,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8499,6 +8589,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8524,6 +8615,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapvalue MapEnum
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8539,6 +8631,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapvalue
 			if m.StringToEnumMap == nil {
 				m.StringToEnumMap = make(map[string]MapEnum)
 			}
@@ -8563,6 +8656,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8585,6 +8679,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var stringLenmapkey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8600,6 +8695,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapkey
 			intStringLenmapkey := int(stringLenmapkey)
 			if intStringLenmapkey < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8625,6 +8721,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8640,6 +8737,7 @@ func (m *AllMaps) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8701,6 +8799,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -8729,6 +8828,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8751,6 +8851,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkey int32
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8766,6 +8867,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkey
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8781,6 +8883,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var stringLenmapvalue uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8796,6 +8899,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLenmapvalue
 			intStringLenmapvalue := int(stringLenmapvalue)
 			if intStringLenmapvalue < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -8830,6 +8934,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8852,6 +8957,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8867,6 +8973,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkeytemp = (mapkeytemp >> 1) ^ uint64((int64(mapkeytemp&1)<<63)>>63)
 			mapkey := int64(mapkeytemp)
 			var valuekey uint64
@@ -8884,6 +8991,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapmsglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8899,6 +9007,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapmsglen
 			if mapmsglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8938,6 +9047,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -8960,6 +9070,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = keykey
 			var mapkeytemp int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -8975,6 +9086,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapkeytemp
 			mapkey := bool(mapkeytemp != 0)
 			var valuekey uint64
 			for shift := uint(0); ; shift += 7 {
@@ -8991,6 +9103,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = valuekey
 			var mapbyteLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
@@ -9006,6 +9119,7 @@ func (m *MessageWithMap) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = mapbyteLen
 			intMapbyteLen := int(mapbyteLen)
 			if intMapbyteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
@@ -9063,6 +9177,7 @@ func (m *FloatingPoint) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9122,6 +9237,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -9150,6 +9266,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}
@@ -9180,6 +9297,7 @@ func (m *Uint128Pair) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthTheproto3Unsafe
 			}

--- a/test/unmarshalmerge/unmarshalmerge.pb.go
+++ b/test/unmarshalmerge/unmarshalmerge.pb.go
@@ -913,6 +913,7 @@ func (m *Big) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -941,6 +942,7 @@ func (m *Big) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnmarshalmerge
 			}
@@ -974,6 +976,7 @@ func (m *Big) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Number = &v
 		default:
 			iNdEx = preIndex
@@ -1017,6 +1020,7 @@ func (m *Sub) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1045,6 +1049,7 @@ func (m *Sub) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.SubNumber = &v
 		default:
 			iNdEx = preIndex
@@ -1089,6 +1094,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1117,6 +1123,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int64
 			hasFields[0] |= uint64(0x00000001)
 		case 2:
 			if wireType != 0 {
@@ -1137,6 +1144,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int32
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Sint32", wireType)
@@ -1156,6 +1164,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = int32((uint32(v) >> 1) ^ uint32(((v&1)<<31)>>31))
 			m.Sint32 = v
 			hasFields[0] |= uint64(0x00000002)
@@ -1178,6 +1187,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			v = (v >> 1) ^ uint64((int64(v&1)<<63)>>63)
 			m.Sint64 = int64(v)
 		case 5:
@@ -1199,6 +1209,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Uint64
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Uint32", wireType)
@@ -1218,6 +1229,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Uint32
 			hasFields[0] |= uint64(0x00000004)
 		case 7:
 			if wireType != 1 {
@@ -1299,6 +1311,7 @@ func (m *IntMerge) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Bool = bool(v != 0)
 		default:
 			iNdEx = preIndex
@@ -1459,6 +1472,7 @@ func (m *BigUnsafe) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -1487,6 +1501,7 @@ func (m *BigUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnmarshalmergeUnsafe
 			}
@@ -1520,6 +1535,7 @@ func (m *BigUnsafe) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Number = &v
 		default:
 			iNdEx = preIndex

--- a/test/unrecognized/unrecognized.pb.go
+++ b/test/unrecognized/unrecognized.pb.go
@@ -3907,6 +3907,7 @@ func (m *A) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -3935,6 +3936,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -3966,6 +3968,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -4008,6 +4011,7 @@ func (m *B) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4036,6 +4040,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4069,6 +4074,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4102,6 +4108,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4158,6 +4165,7 @@ func (m *D) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4186,6 +4194,7 @@ func (m *D) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -4229,6 +4238,7 @@ func (m *C) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4276,6 +4286,7 @@ func (m *C) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthUnrecognized
@@ -4325,6 +4336,7 @@ func (m *C) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = byteLen
 			if byteLen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4354,6 +4366,7 @@ func (m *C) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 5 {
@@ -4412,6 +4425,7 @@ func (m *U) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4459,6 +4473,7 @@ func (m *U) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field3 = &v
 		default:
 			iNdEx = preIndex
@@ -4501,6 +4516,7 @@ func (m *OldA) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4529,6 +4545,7 @@ func (m *OldA) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4560,6 +4577,7 @@ func (m *OldA) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		default:
 			iNdEx = preIndex
@@ -4602,6 +4620,7 @@ func (m *OldB) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4630,6 +4649,7 @@ func (m *OldB) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4663,6 +4683,7 @@ func (m *OldB) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognized
 			}
@@ -4719,6 +4740,7 @@ func (m *OldC) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4747,6 +4769,7 @@ func (m *OldC) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 2:
 			if wireType != 1 {
@@ -4786,6 +4809,7 @@ func (m *OldC) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthUnrecognized
@@ -4816,6 +4840,7 @@ func (m *OldC) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field6 = &v
 		case 7:
 			if wireType != 5 {
@@ -4874,6 +4899,7 @@ func (m *OldU) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -4902,6 +4928,7 @@ func (m *OldU) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthUnrecognized

--- a/test/unrecognizedgroup/unrecognizedgroup.pb.go
+++ b/test/unrecognizedgroup/unrecognizedgroup.pb.go
@@ -2359,6 +2359,7 @@ func (m *NewNoGroup) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2387,6 +2388,7 @@ func (m *NewNoGroup) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Field1 = &v
 		case 3:
 			if wireType != 1 {
@@ -2426,6 +2428,7 @@ func (m *NewNoGroup) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = msglen
 			if msglen < 0 {
 				return ErrInvalidLengthUnrecognizedgroup
 			}
@@ -2482,6 +2485,7 @@ func (m *A) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -2510,6 +2514,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.AField = &v
 		default:
 			iNdEx = preIndex

--- a/vanity/test/fast/gogovanity.pb.go
+++ b/vanity/test/fast/gogovanity.pb.go
@@ -178,6 +178,7 @@ func (m *B) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -206,6 +207,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthGogovanity
@@ -236,6 +238,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int64 = &v
 		case 3:
 			if wireType != 0 {
@@ -256,6 +259,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32 = &v
 		default:
 			iNdEx = preIndex

--- a/vanity/test/fast/proto3.pb.go
+++ b/vanity/test/fast/proto3.pb.go
@@ -129,6 +129,7 @@ func (m *Aproto3) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -157,6 +158,7 @@ func (m *Aproto3) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthProto3

--- a/vanity/test/fast/vanity.pb.go
+++ b/vanity/test/fast/vanity.pb.go
@@ -164,6 +164,7 @@ func (m *A) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -192,6 +193,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthVanity
@@ -222,6 +224,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int = &v
 			hasFields[0] |= uint64(0x00000001)
 		default:

--- a/vanity/test/faster/gogovanity.pb.go
+++ b/vanity/test/faster/gogovanity.pb.go
@@ -167,6 +167,7 @@ func (m *B) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -195,6 +196,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthGogovanity
@@ -225,6 +227,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int64
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Int32", wireType)
@@ -244,6 +247,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32 = &v
 		default:
 			iNdEx = preIndex

--- a/vanity/test/faster/proto3.pb.go
+++ b/vanity/test/faster/proto3.pb.go
@@ -129,6 +129,7 @@ func (m *Aproto3) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -157,6 +158,7 @@ func (m *Aproto3) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthProto3

--- a/vanity/test/faster/vanity.pb.go
+++ b/vanity/test/faster/vanity.pb.go
@@ -146,6 +146,7 @@ func (m *A) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -174,6 +175,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthVanity
@@ -203,6 +205,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int
 			hasFields[0] |= uint64(0x00000001)
 		default:
 			iNdEx = preIndex

--- a/vanity/test/slick/gogovanity.pb.go
+++ b/vanity/test/slick/gogovanity.pb.go
@@ -281,6 +281,7 @@ func (m *B) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -309,6 +310,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthGogovanity
@@ -339,6 +341,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int64
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Int32", wireType)
@@ -358,6 +361,7 @@ func (m *B) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = v
 			m.Int32 = &v
 		default:
 			iNdEx = preIndex

--- a/vanity/test/slick/proto3.pb.go
+++ b/vanity/test/slick/proto3.pb.go
@@ -217,6 +217,7 @@ func (m *Aproto3) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -245,6 +246,7 @@ func (m *Aproto3) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthProto3

--- a/vanity/test/slick/vanity.pb.go
+++ b/vanity/test/slick/vanity.pb.go
@@ -238,6 +238,7 @@ func (m *A) Unmarshal(data []byte) error {
 				break
 			}
 		}
+		_ = wire
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
@@ -266,6 +267,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = stringLen
 			intStringLen := int(stringLen)
 			if intStringLen < 0 {
 				return ErrInvalidLengthVanity
@@ -295,6 +297,7 @@ func (m *A) Unmarshal(data []byte) error {
 					break
 				}
 			}
+			_ = m.Int
 			hasFields[0] |= uint64(0x00000001)
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
This is a no-op semantically; the `ineffassign` lint will complain when using maps
otherwise.