### PR TITLE
proto3: Avoid marshalling nil customtype bytes fields

### DIFF
--- a/gogoproto/helper.go
+++ b/gogoproto/helper.go
@@ -37,6 +37,17 @@ func IsNullable(field *google_protobuf.FieldDescriptorProto) bool {
 	return proto.GetBoolExtension(field.Options, E_Nullable, true)
 }
 
+func NeedsNilCheck(proto3 bool, field *google_protobuf.FieldDescriptorProto) bool {
+	nullable := IsNullable(field)
+	if field.IsMessage() || IsCustomType(field) {
+		return nullable
+	}
+	if proto3 {
+		return false
+	}
+	return nullable || *field.Type == google_protobuf.FieldDescriptorProto_TYPE_BYTES
+}
+
 func IsCustomType(field *google_protobuf.FieldDescriptorProto) bool {
 	typ := GetCustomType(field)
 	if len(typ) > 0 {

--- a/plugin/marshalto/marshalto.go
+++ b/plugin/marshalto/marshalto.go
@@ -381,6 +381,7 @@ func (p *marshalto) generateField(proto3 bool, numGen NumGen, file *generator.Fi
 	required := field.IsRequired()
 
 	protoSizer := gogoproto.IsProtoSizer(file.FileDescriptorProto, message.DescriptorProto)
+	doNilCheck := gogoproto.NeedsNilCheck(proto3, field)
 	if required && nullable {
 		p.P(`if m.`, fieldname, `== nil {`)
 		p.In()
@@ -394,8 +395,7 @@ func (p *marshalto) generateField(proto3 bool, numGen NumGen, file *generator.Fi
 	} else if repeated {
 		p.P(`if len(m.`, fieldname, `) > 0 {`)
 		p.In()
-	} else if ((!proto3 || field.IsMessage()) && nullable) ||
-		(*field.Type == descriptor.FieldDescriptorProto_TYPE_BYTES && !gogoproto.IsCustomType(field)) {
+	} else if doNilCheck {
 		p.P(`if m.`, fieldname, ` != nil {`)
 		p.In()
 	}
@@ -1128,10 +1128,7 @@ func (p *marshalto) generateField(proto3 bool, numGen NumGen, file *generator.Fi
 	default:
 		panic("not implemented")
 	}
-	if (required && nullable) ||
-		((!proto3 || field.IsMessage()) && nullable) ||
-		repeated ||
-		(*field.Type == descriptor.FieldDescriptorProto_TYPE_BYTES && !gogoproto.IsCustomType(field)) {
+	if (required && nullable) || repeated || doNilCheck {
 		p.Out()
 		p.P(`}`)
 	}

--- a/plugin/size/size.go
+++ b/plugin/size/size.go
@@ -119,13 +119,14 @@ package size
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/gogo/protobuf/gogoproto"
 	"github.com/gogo/protobuf/proto"
 	descriptor "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
 	"github.com/gogo/protobuf/vanity"
-	"strconv"
-	"strings"
 )
 
 type size struct {
@@ -201,10 +202,11 @@ func (p *size) generateField(proto3 bool, file *generator.FileDescriptor, messag
 	fieldname := p.GetOneOfFieldName(message, field)
 	nullable := gogoproto.IsNullable(field)
 	repeated := field.IsRepeated()
+	doNilCheck := gogoproto.NeedsNilCheck(proto3, field)
 	if repeated {
 		p.P(`if len(m.`, fieldname, `) > 0 {`)
 		p.In()
-	} else if ((!proto3 || field.IsMessage()) && nullable) || (!gogoproto.IsCustomType(field) && *field.Type == descriptor.FieldDescriptorProto_TYPE_BYTES) {
+	} else if doNilCheck {
 		p.P(`if m.`, fieldname, ` != nil {`)
 		p.In()
 	}
@@ -488,7 +490,7 @@ func (p *size) generateField(proto3 bool, file *generator.FileDescriptor, messag
 	default:
 		panic("not implemented")
 	}
-	if ((!proto3 || field.IsMessage()) && nullable) || repeated || (!gogoproto.IsCustomType(field) && *field.Type == descriptor.FieldDescriptorProto_TYPE_BYTES) {
+	if repeated || doNilCheck {
 		p.Out()
 		p.P(`}`)
 	}

--- a/test/custom/custom.go
+++ b/test/custom/custom.go
@@ -101,7 +101,7 @@ func (u Uint128) MarshalJSON() ([]byte, error) {
 	return json.Marshal(data)
 }
 
-func (u *Uint128) Size() int {
+func (u Uint128) Size() int {
 	return 16
 }
 

--- a/test/mapsproto2/combos/both/mapsproto2.proto
+++ b/test/mapsproto2/combos/both/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/combos/marshaler/mapsproto2.proto
+++ b/test/mapsproto2/combos/marshaler/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/combos/neither/mapsproto2.proto
+++ b/test/mapsproto2/combos/neither/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/combos/unmarshaler/mapsproto2.proto
+++ b/test/mapsproto2/combos/unmarshaler/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/combos/unsafeboth/mapsproto2.proto
+++ b/test/mapsproto2/combos/unsafeboth/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/combos/unsafemarshaler/mapsproto2.proto
+++ b/test/mapsproto2/combos/unsafemarshaler/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/combos/unsafeunmarshaler/mapsproto2.proto
+++ b/test/mapsproto2/combos/unsafeunmarshaler/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/mapsproto2/mapsproto2.proto
+++ b/test/mapsproto2/mapsproto2.proto
@@ -67,9 +67,9 @@ message FloatingPoint {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/theproto3/Makefile
+++ b/test/theproto3/Makefile
@@ -32,3 +32,4 @@ regenerate:
 	cat footer.proto >> theproto3.proto
 	go install github.com/gogo/protobuf/protoc-gen-combo
 	protoc-gen-combo --version="3.0.0" --proto_path=../../../../../:../../protobuf/:. theproto3.proto
+	find combos -type d -not -name combos -exec cp proto3_test.go.in {}/proto3_test.go \;

--- a/test/theproto3/combos/both/proto3_test.go
+++ b/test/theproto3/combos/both/proto3_test.go
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/combos/both/proto3_test.go
+++ b/test/theproto3/combos/both/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -6622,13 +6622,11 @@ func (m *Message) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintTheproto3(data, i, uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		if len(m.Data) > 0 {
-			data[i] = 0x22
-			i++
-			i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
-			i += copy(data[i:], m.Data)
-		}
+	if len(m.Data) > 0 {
+		data[i] = 0x22
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
+		i += copy(data[i:], m.Data)
 	}
 	if len(m.Key) > 0 {
 		for _, num := range m.Key {
@@ -7570,14 +7568,16 @@ func (m *Uint128Pair) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n8
-	data[i] = 0x12
-	i++
-	i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
-	n9, err := m.Right.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if m.Right != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
+		n9, err := m.Right.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
 	}
-	i += n9
 	return i, nil
 }
 
@@ -8140,11 +8140,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if len(m.Key) > 0 {
 		for _, e := range m.Key {
@@ -8545,8 +8543,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 

--- a/test/theproto3/combos/both/theproto3.proto
+++ b/test/theproto3/combos/both/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/combos/marshaler/proto3_test.go
+++ b/test/theproto3/combos/marshaler/proto3_test.go
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/combos/marshaler/proto3_test.go
+++ b/test/theproto3/combos/marshaler/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/marshaler/theproto3.pb.go
+++ b/test/theproto3/combos/marshaler/theproto3.pb.go
@@ -6620,13 +6620,11 @@ func (m *Message) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintTheproto3(data, i, uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		if len(m.Data) > 0 {
-			data[i] = 0x22
-			i++
-			i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
-			i += copy(data[i:], m.Data)
-		}
+	if len(m.Data) > 0 {
+		data[i] = 0x22
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
+		i += copy(data[i:], m.Data)
 	}
 	if len(m.Key) > 0 {
 		for _, num := range m.Key {
@@ -7568,14 +7566,16 @@ func (m *Uint128Pair) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n8
-	data[i] = 0x12
-	i++
-	i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
-	n9, err := m.Right.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if m.Right != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
+		n9, err := m.Right.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
 	}
-	i += n9
 	return i, nil
 }
 
@@ -8138,11 +8138,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if len(m.Key) > 0 {
 		for _, e := range m.Key {
@@ -8543,8 +8541,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 

--- a/test/theproto3/combos/marshaler/theproto3.proto
+++ b/test/theproto3/combos/marshaler/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/combos/neither/proto3_test.go
+++ b/test/theproto3/combos/neither/proto3_test.go
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/combos/neither/proto3_test.go
+++ b/test/theproto3/combos/neither/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/neither/theproto3.pb.go
+++ b/test/theproto3/combos/neither/theproto3.pb.go
@@ -7119,11 +7119,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if m.ResultCount != 0 {
 		n += 1 + sovTheproto3(uint64(m.ResultCount))
@@ -7524,8 +7522,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 

--- a/test/theproto3/combos/neither/theproto3.proto
+++ b/test/theproto3/combos/neither/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/combos/unmarshaler/proto3_test.go
+++ b/test/theproto3/combos/unmarshaler/proto3_test.go
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/combos/unmarshaler/proto3_test.go
+++ b/test/theproto3/combos/unmarshaler/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -7121,11 +7121,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if m.ResultCount != 0 {
 		n += 1 + sovTheproto3(uint64(m.ResultCount))
@@ -7526,8 +7524,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 

--- a/test/theproto3/combos/unmarshaler/theproto3.proto
+++ b/test/theproto3/combos/unmarshaler/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/combos/unsafeboth/proto3_test.go
+++ b/test/theproto3/combos/unsafeboth/proto3_test.go
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/combos/unsafeboth/proto3_test.go
+++ b/test/theproto3/combos/unsafeboth/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/unsafeboth/theproto3.pb.go
+++ b/test/theproto3/combos/unsafeboth/theproto3.pb.go
@@ -7124,11 +7124,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if m.ResultCount != 0 {
 		n += 1 + sovTheproto3(uint64(m.ResultCount))
@@ -7529,8 +7527,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 
@@ -8092,13 +8092,11 @@ func (m *Message) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintTheproto3(data, i, uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		if len(m.Data) > 0 {
-			data[i] = 0x22
-			i++
-			i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
-			i += copy(data[i:], m.Data)
-		}
+	if len(m.Data) > 0 {
+		data[i] = 0x22
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
+		i += copy(data[i:], m.Data)
 	}
 	if len(m.Key) > 0 {
 		for _, num := range m.Key {
@@ -9042,14 +9040,16 @@ func (m *Uint128Pair) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n8
-	data[i] = 0x12
-	i++
-	i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
-	n9, err := m.Right.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if m.Right != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
+		n9, err := m.Right.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
 	}
-	i += n9
 	return i, nil
 }
 

--- a/test/theproto3/combos/unsafeboth/theproto3.proto
+++ b/test/theproto3/combos/unsafeboth/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/combos/unsafemarshaler/proto3_test.go
+++ b/test/theproto3/combos/unsafemarshaler/proto3_test.go
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/combos/unsafemarshaler/proto3_test.go
+++ b/test/theproto3/combos/unsafemarshaler/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/unsafemarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unsafemarshaler/theproto3.pb.go
@@ -7122,11 +7122,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if m.ResultCount != 0 {
 		n += 1 + sovTheproto3(uint64(m.ResultCount))
@@ -7527,8 +7525,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 
@@ -8090,13 +8090,11 @@ func (m *Message) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintTheproto3(data, i, uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		if len(m.Data) > 0 {
-			data[i] = 0x22
-			i++
-			i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
-			i += copy(data[i:], m.Data)
-		}
+	if len(m.Data) > 0 {
+		data[i] = 0x22
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(len(m.Data)))
+		i += copy(data[i:], m.Data)
 	}
 	if len(m.Key) > 0 {
 		for _, num := range m.Key {
@@ -9040,14 +9038,16 @@ func (m *Uint128Pair) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n8
-	data[i] = 0x12
-	i++
-	i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
-	n9, err := m.Right.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if m.Right != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintTheproto3(data, i, uint64(m.Right.Size()))
+		n9, err := m.Right.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
 	}
-	i += n9
 	return i, nil
 }
 

--- a/test/theproto3/combos/unsafemarshaler/theproto3.proto
+++ b/test/theproto3/combos/unsafemarshaler/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/combos/unsafeunmarshaler/proto3_test.go
+++ b/test/theproto3/combos/unsafeunmarshaler/proto3_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015, Vastech SA (PTY) LTD. All rights reserved.
+// http://github.com/gogo/protobuf/gogoproto
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package theproto3
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+func TestNilMaps(t *testing.T) {
+	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
+	if _, err := proto.Marshal(m); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/test/theproto3/combos/unsafeunmarshaler/proto3_test.go
+++ b/test/theproto3/combos/unsafeunmarshaler/proto3_test.go
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/combos/unsafeunmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unsafeunmarshaler/theproto3.pb.go
@@ -7122,11 +7122,9 @@ func (m *Message) Size() (n int) {
 	if m.HeightInCm != 0 {
 		n += 1 + sovTheproto3(uint64(m.HeightInCm))
 	}
-	if m.Data != nil {
-		l = len(m.Data)
-		if l > 0 {
-			n += 1 + l + sovTheproto3(uint64(l))
-		}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTheproto3(uint64(l))
 	}
 	if m.ResultCount != 0 {
 		n += 1 + sovTheproto3(uint64(m.ResultCount))
@@ -7527,8 +7525,10 @@ func (m *Uint128Pair) Size() (n int) {
 	_ = l
 	l = m.Left.Size()
 	n += 1 + l + sovTheproto3(uint64(l))
-	l = m.Right.Size()
-	n += 1 + l + sovTheproto3(uint64(l))
+	if m.Right != nil {
+		l = m.Right.Size()
+		n += 1 + l + sovTheproto3(uint64(l))
+	}
 	return n
 }
 

--- a/test/theproto3/combos/unsafeunmarshaler/theproto3.proto
+++ b/test/theproto3/combos/unsafeunmarshaler/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/footer.proto
+++ b/test/theproto3/footer.proto
@@ -10,6 +10,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }

--- a/test/theproto3/maps.proto
+++ b/test/theproto3/maps.proto
@@ -1,8 +1,8 @@
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {

--- a/test/theproto3/proto3_test.go.in
+++ b/test/theproto3/proto3_test.go.in
@@ -27,8 +27,9 @@
 package theproto3
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestNilMaps(t *testing.T) {

--- a/test/theproto3/proto3_test.go.in
+++ b/test/theproto3/proto3_test.go.in
@@ -27,6 +27,7 @@
 package theproto3
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -36,5 +37,25 @@ func TestNilMaps(t *testing.T) {
 	m := &AllMaps{StringToMsgMap: map[string]*FloatingPoint{"a": nil}}
 	if _, err := proto.Marshal(m); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestCustomTypeSize(t *testing.T) {
+	m := &Uint128Pair{}
+	m.Size() // Should not panic.
+}
+
+func TestCustomTypeMarshalUnmarshal(t *testing.T) {
+	m1 := &Uint128Pair{}
+	if b, err := proto.Marshal(m1); err != nil {
+		t.Fatal(err)
+	} else {
+		m2 := &Uint128Pair{}
+		if err := proto.Unmarshal(b, m2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("expected %+v, got %+v", m1, m2)
+		}
 	}
 }

--- a/test/theproto3/theproto3.proto
+++ b/test/theproto3/theproto3.proto
@@ -93,9 +93,9 @@ message Nested {
 }
 
 enum MapEnum {
-    MA = 0;
-    MB = 1;
-    MC = 2;
+  MA = 0;
+  MB = 1;
+  MC = 2;
 }
 
 message AllMaps {
@@ -151,6 +151,6 @@ message FloatingPoint {
 }
 
 message Uint128Pair {
-    bytes left = 1 [ (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
-    bytes right = 2 [ (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128" ];
+  bytes left = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
+  bytes right = 2 [(gogoproto.customtype) = "github.com/gogo/protobuf/test/custom.Uint128"];
 }


### PR DESCRIPTION
This fixes a bug that causes protos to change after marshalling and
unmarshalling.

@awalterschulze 