### PR TITLE
Bump the generatedCodeVersion to 3 so generated code works with grpc.SupportPackageIsVersion3.

### DIFF
--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -48,7 +48,7 @@ import (
 // It is incremented whenever an incompatibility between the generated code and
 // the grpc package is introduced; the generated code references
 // a constant, grpc.SupportPackageIsVersionN (where N is generatedCodeVersion).
-const generatedCodeVersion = 2
+const generatedCodeVersion = 3
 
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.


### PR DESCRIPTION
Generated code was failing to build with the latest code from https://github.com/grpc/grpc-go