### PR TITLE
Fixes panic message in enumstringer plugin

### DIFF
--- a/plugin/enumstringer/enumstringer.go
+++ b/plugin/enumstringer/enumstringer.go
@@ -76,7 +76,7 @@ func (p *enumstringer) Generate(file *generator.FileDescriptor) {
 			continue
 		}
 		if gogoproto.IsGoEnumStringer(file.FileDescriptorProto, enum.EnumDescriptorProto) {
-			panic("old enum string method needs to be disabled, please use gogoproto.old_enum_stringer or gogoproto.old_enum_string_all and set it to false")
+			panic("Go enum stringer conflicts with new enumstringer plugin: please use gogoproto.goproto_enum_stringer or gogoproto.goproto_enum_string_all and set it to false")
 		}
 		p.atleastOne = true
 		ccTypeName := generator.CamelCaseSlice(enum.TypeName())


### PR DESCRIPTION
If you enable `gogoproto.enum_stringer_all`, `protoc-gen-gofast` fail with:

```
panic: old enum string method needs to be disabled, please use gogoproto.old_enum_stringer or gogoproto.old_enum_string_all and set it to false
```

But those options don't exist. I've fixed the panic message with the right name, and made it more readable.