### PR TITLE
text: allow customtype to have a Bytes() method

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -50,9 +50,9 @@ You might also find that basic structs that started their life as part of an API
 <tr><td><a href="https://github.com/gogo/protobuf/blob/master/test/types/types.proto">stdduration</a></td><td> Duration Field </td><td> bool </td><td>Changes the Well Known Duration Type to time.Duration</td><td>Duration</td></tr>
 </table>
 
-`Warning about nullable: according to the Protocol Buffer specification, you should be able to tell whether a field is set or unset. With the option nullable=false this feature is lost, since your non-nullable fields will always be set.` 
+`Warning about nullable: according to the Protocol Buffer specification, you should be able to tell whether a field is set or unset. With the option nullable=false this feature is lost, since your non-nullable fields will always be set.`
 
-# Goprotobuf Compatibility 
+# Goprotobuf Compatibility
 
 Gogoprotobuf is compatible with Goprotobuf, because it is compatible with protocol buffers (see the section on tests below).
 
@@ -118,7 +118,7 @@ Other serialization formats like xml and json typically use reflect to marshal a
 
 <a href="https://groups.google.com/forum/#!topic/gogoprotobuf/xmFnqAS6MIc">Here is a longer explanation of jsontag and moretags</a>
 
-# File Options 
+# File Options
 
 Each of the boolean message and enum extensions also have a file extension:
 
@@ -155,7 +155,7 @@ Each of these are the same as their Message Option counterparts, except they app
 
 # Tests
 
-  * The normal barrage of tests are run with: `make tests` 
+  * The normal barrage of tests are run with: `make tests`
   * A few weird tests: `make testall`
   * Tests for compatibility with [golang/protobuf](https://github.com/golang/protobuf) are handled by a different project [harmonytests](https://github.com/gogo/harmonytests), since it requires goprotobuf.
   * Cross version tests are made with [Travis CI](https://travis-ci.org/gogo/protobuf).

--- a/test/combos/both/uuid.go
+++ b/test/combos/both/uuid.go
@@ -47,6 +47,10 @@ func PutLittleEndianUint64(b []byte, offset int, v uint64) {
 
 type Uuid []byte
 
+func (uuid Uuid) Bytes() []byte {
+	return uuid
+}
+
 func (uuid Uuid) Marshal() ([]byte, error) {
 	if len(uuid) == 0 {
 		return nil, nil

--- a/test/combos/marshaler/uuid.go
+++ b/test/combos/marshaler/uuid.go
@@ -47,6 +47,10 @@ func PutLittleEndianUint64(b []byte, offset int, v uint64) {
 
 type Uuid []byte
 
+func (uuid Uuid) Bytes() []byte {
+	return uuid
+}
+
 func (uuid Uuid) Marshal() ([]byte, error) {
 	if len(uuid) == 0 {
 		return nil, nil

--- a/test/combos/unmarshaler/uuid.go
+++ b/test/combos/unmarshaler/uuid.go
@@ -47,6 +47,10 @@ func PutLittleEndianUint64(b []byte, offset int, v uint64) {
 
 type Uuid []byte
 
+func (uuid Uuid) Bytes() []byte {
+	return uuid
+}
+
 func (uuid Uuid) Marshal() ([]byte, error) {
 	if len(uuid) == 0 {
 		return nil, nil

--- a/test/uuid.go
+++ b/test/uuid.go
@@ -47,6 +47,10 @@ func PutLittleEndianUint64(b []byte, offset int, v uint64) {
 
 type Uuid []byte
 
+func (uuid Uuid) Bytes() []byte {
+	return uuid
+}
+
 func (uuid Uuid) Marshal() ([]byte, error) {
 	if len(uuid) == 0 {
 		return nil, nil


### PR DESCRIPTION
If encoding.TextMarshaler is implemented, it will be preferred.

Related to #199. @awalterschulze cc @bdarnell