### PR TITLE
Optimize uint32writer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,4 +1,5 @@
 Anton Povarov <anton.povarov@gmail.com>
+Brian Goff <cpuguy83@gmail.com>
 Clayton Coleman <ccoleman@redhat.com>
 Denis Smirnov <denis.smirnov.91@gmail.com>
 DongYun Kang <ceram1000@gmail.com>

--- a/io/uint32_test.go
+++ b/io/uint32_test.go
@@ -1,0 +1,38 @@
+package io_test
+
+import (
+	"encoding/binary"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/test"
+	example "github.com/gogo/protobuf/test/example"
+
+	"github.com/gogo/protobuf/io"
+)
+
+func BenchmarkUint32DelimWriterMarshaller(b *testing.B) {
+	w := io.NewUint32DelimitedWriter(ioutil.Discard, binary.BigEndian)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	msg := example.NewPopulatedA(r, true)
+
+	for i := 0; i < b.N; i++ {
+		if err := w.WriteMsg(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUint32DelimWriterFallback(b *testing.B) {
+	w := io.NewUint32DelimitedWriter(ioutil.Discard, binary.BigEndian)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	msg := test.NewPopulatedNinOptNative(r, true)
+
+	for i := 0; i < b.N; i++ {
+		if err := w.WriteMsg(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Don't use `binary.Write` which makes 2 allocs. Instead since we know we always want a uint32 encode this directly with `binary.PutUint32`, which is what `binary.Write` does.

Creates a fast path and a slow path. Fast path is for types that satisfy `marshaller` where we can work with just a single buffer.
Slow path is for everything else where it uses `proto.Marshal`.

```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkUint32DelimWriterMarshaller-8     159           77.8          -51.07%
BenchmarkUint32DelimWriterFallback-8       879           764           -13.08%

benchmark                                  old allocs     new allocs     delta
BenchmarkUint32DelimWriterMarshaller-8     3              0              -100.00%
BenchmarkUint32DelimWriterFallback-8       9              7              -22.22%

benchmark                                  old bytes     new bytes     delta
BenchmarkUint32DelimWriterMarshaller-8     80            0             -100.00%
BenchmarkUint32DelimWriterFallback-8       728           712           -2.20%
```
