### PR TITLE
Fix a race when using TextMarshal on a StdDuration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,5 +10,6 @@
 
 # Please keep the list sorted.
 
+Sendgrid, Inc
 Vastech SA (PTY) LTD
 Walter Schulze <awalterschulze@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,9 +12,11 @@ John Tuley <john@tuley.org>
 Laurent <laurent@adyoulike.com>
 Patrick Lee <patrick@dropbox.com>
 Roger Johansson <rogeralsing@gmail.com>
+Sam Nguyen <sam.nguyen@sendgrid.com>
 Sergio Arbeo <serabe@gmail.com>
 Stephen J Day <stephen.day@docker.com>
 Tamir Duberstein <tamird@gmail.com>
 Todd Eisenberger <teisenberger@dropbox.com>
 Tormod Erevik Lea <tormodlea@gmail.com>
+Vyacheslav Kim <kane@sendgrid.com>
 Walter Schulze <awalterschulze@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ regenerate:
 tests:
 	go build ./test/enumprefix
 	go test ./...
+	(cd test/stdtypes && make test)
 
 vet:
 	go vet ./...

--- a/Readme.md
+++ b/Readme.md
@@ -43,8 +43,9 @@ These projects use gogoprotobuf:
   - <a href="https://github.com/heroiclabs/nakama">nakama</a>
   - <a href="https://github.com/src-d/proteus">proteus</a>
   - <a href="https://github.com/go-graphite">carbonzipper stack</a>
+  - <a href="https://sendgrid.com/">SendGrid</a>
   
-Please lets us know if you are using gogoprotobuf by posting on our <a href="https://groups.google.com/forum/#!topic/gogoprotobuf/Brw76BxmFpQ">GoogleGroup</a>.
+Please let us know if you are using gogoprotobuf by posting on our <a href="https://groups.google.com/forum/#!topic/gogoprotobuf/Brw76BxmFpQ">GoogleGroup</a>.
 
 ### Mentioned
 

--- a/proto/text.go
+++ b/proto/text.go
@@ -531,9 +531,9 @@ func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Propert
 			if err != nil {
 				return err
 			}
-			props.StdTime = false
-			err = tm.writeAny(w, reflect.ValueOf(tproto), props)
-			props.StdTime = true
+			propsCopy := *props // Make a copy so that this is goroutine-safe
+			propsCopy.StdTime = false
+			err = tm.writeAny(w, reflect.ValueOf(tproto), &propsCopy)
 			return err
 		} else if props.StdDuration {
 			d, ok := v.Interface().(time.Duration)
@@ -541,9 +541,9 @@ func (tm *TextMarshaler) writeAny(w *textWriter, v reflect.Value, props *Propert
 				return fmt.Errorf("stdtime is not time.Duration, but %T", v.Interface())
 			}
 			dproto := durationProto(d)
-			props.StdDuration = false
-			err := tm.writeAny(w, reflect.ValueOf(dproto), props)
-			props.StdDuration = true
+			propsCopy := *props // Make a copy so that this is goroutine-safe
+			propsCopy.StdDuration = false
+			err := tm.writeAny(w, reflect.ValueOf(dproto), &propsCopy)
 			return err
 		}
 	}

--- a/test/stdtypes/Makefile
+++ b/test/stdtypes/Makefile
@@ -35,3 +35,5 @@ regenerate:
 	:. \
 	--proto_path=../../../../../:../../protobuf/:. stdtypes.proto
 
+test:
+	go test -race -run=TestConcurrentTextMarshal .

--- a/test/stdtypes/concurrency_test.go
+++ b/test/stdtypes/concurrency_test.go
@@ -1,0 +1,31 @@
+package stdtypes
+
+import (
+	"io/ioutil"
+	"sync"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+func TestConcurrentTextMarshal(t *testing.T) {
+	// Verify that there are no race conditions when calling
+	// TextMarshaler.Marshal on a protobuf message that contains a StdDuration
+
+	std := StdTypes{}
+	var wg sync.WaitGroup
+
+	tm := proto.TextMarshaler{}
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := tm.Marshal(ioutil.Discard, &std)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
- Benchmarks show performance to be roughly the same when performing the copy, no additional bytes allocated and no additional number of allocations
- ~~~Add in sync.Pool for bufio.Writer. Reduced allocations by 2 and run time by about 30% for TextMarshaler.Marshal~~~  (move this to upstream protobuf)

@awalterschulze I didn't see a guide for contributing. Please let me know if you accept pull requests and what needs to be done to get it approved.

Thanks,
/sam