### PR TITLE
protoc-gen-gogo: int64 and uint64 types use string json option

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -2113,6 +2113,12 @@ func (g *Generator) generateMessage(message *Descriptor) {
 			if !gogoproto.IsNullable(field) && !repeatedNativeType {
 				jsonTag = jsonName
 			}
+			// for compat w/ jsonpb marshal/unmarshal
+			switch *field.Type {
+			case descriptor.FieldDescriptorProto_TYPE_INT64,
+				descriptor.FieldDescriptorProto_TYPE_UINT64:
+				jsonTag += ",string"
+			}
 			gogoJsonTag := gogoproto.GetJsonTag(field)
 			if gogoJsonTag != nil {
 				jsonTag = *gogoJsonTag


### PR DESCRIPTION
int64 and uint64 types are marshaled by jsonpb as string types and should be
tagged as `string` for interop with other golang json packages.