### PR TITLE
generator: use consistent ModTime across go1.7 and go1.8

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -55,6 +55,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -3148,6 +3149,7 @@ func (g *Generator) generateFileDescriptor(file *FileDescriptor) {
 
 	var buf bytes.Buffer
 	w, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	w.Header.ModTime = time.Unix(0, 1) // consistent, non-zero val for time
 	w.Write(b)
 	w.Close()
 	b = buf.Bytes()


### PR DESCRIPTION
without this change, protos generated by golang 1.7 and golang 1.8 differ because gzip on golang 1.7 uses "nonsense" values for `ModTime` when it's a zeroval (see golang 1.8 changelog w/ respect to gzip changes)