### PR TITLE
fix:305 only serialize protofields

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ John Shahid <jvshahid@gmail.com>
 John Tuley <john@tuley.org>
 Laurent <laurent@adyoulike.com>
 Patrick Lee <patrick@dropbox.com>
+Roger Johansson <rogeralsing@gmail.com>
 Sergio Arbeo <serabe@gmail.com>
 Stephen J Day <stephen.day@docker.com>
 Tamir Duberstein <tamird@gmail.com>

--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -203,6 +203,12 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 		if strings.HasPrefix(valueField.Name, "XXX_") {
 			continue
 		}
+		
+		//this is not a protobuf field
+		tag := valueField.Tag.Get("protobuf")
+		if tag == "" {
+			continue
+		}
 
 		// IsNil will panic on most value kinds.
 		switch value.Kind() {

--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -203,10 +203,10 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 		if strings.HasPrefix(valueField.Name, "XXX_") {
 			continue
 		}
-		
+
 		//this is not a protobuf field
-		tag := valueField.Tag.Get("protobuf")
-		if tag == "" {
+		if !(valueField.Tag.Get("protobuf") != "" ||
+			valueField.Tag.Get("protobuf_oneof") != "") {
 			continue
 		}
 

--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -205,8 +205,7 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 		}
 
 		//this is not a protobuf field
-		if !(valueField.Tag.Get("protobuf") != "" ||
-			valueField.Tag.Get("protobuf_oneof") != "") {
+		if valueField.Tag.Get("protobuf") == "" && valueField.Tag.Get("protobuf_oneof") == "" {
 			continue
 		}
 

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -684,3 +684,33 @@ func (m *dynamicMessage) UnmarshalJSONPB(jum *Unmarshaler, json []byte) error {
 	m.rawJson = string(json)
 	return nil
 }
+
+// customFieldMessage implements protobuf.Message but is not a normal generated message type.
+type customFieldMessage struct {
+	someField string //this is not a proto field
+}
+
+func (m *customFieldMessage) Reset() {
+	m.someField = "hello"
+}
+
+func (m *customFieldMessage) String() string {
+	return m.someField
+}
+
+func (m *customFieldMessage) ProtoMessage() {
+}
+
+func TestMarshallCustomField(t *testing.T) {
+	rawJson := `{}`
+	m := &customFieldMessage{
+		someField: "hello world",
+	}
+	str, err := marshaler.MarshalToString(m)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
+	}
+	if str != rawJson {
+		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, rawJson)
+	}
+}

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -426,7 +426,6 @@ var marshalingTests = []struct {
 	{"BoolValue", marshaler, &pb.KnownTypes{Bool: &types.BoolValue{Value: true}}, `{"bool":true}`},
 	{"StringValue", marshaler, &pb.KnownTypes{Str: &types.StringValue{Value: "plush"}}, `{"str":"plush"}`},
 	{"BytesValue", marshaler, &pb.KnownTypes{Bytes: &types.BytesValue{Value: []byte("wow")}}, `{"bytes":"d293"}`},
-	{"ignore non proto field", marshaler, &customFieldMessage{someField: "Ignore me"}, `{}`},
 }
 
 func TestMarshaling(t *testing.T) {
@@ -684,20 +683,4 @@ func (m *dynamicMessage) MarshalJSONPB(jm *Marshaler) ([]byte, error) {
 func (m *dynamicMessage) UnmarshalJSONPB(jum *Unmarshaler, json []byte) error {
 	m.rawJson = string(json)
 	return nil
-}
-
-// customFieldMessage implements protobuf.Message but is not a normal generated message type.
-type customFieldMessage struct {
-	someField string //this is not a proto field
-}
-
-func (m *customFieldMessage) Reset() {
-	m.someField = "hello"
-}
-
-func (m *customFieldMessage) String() string {
-	return m.someField
-}
-
-func (m *customFieldMessage) ProtoMessage() {
 }

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -702,7 +702,7 @@ func (m *customFieldMessage) ProtoMessage() {
 }
 
 func TestMarshallCustomField(t *testing.T) {
-	rawJson := `{}`
+	expected := `{}`
 	m := &customFieldMessage{
 		someField: "hello world",
 	}
@@ -710,7 +710,23 @@ func TestMarshallCustomField(t *testing.T) {
 	if err != nil {
 		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
 	}
-	if str != rawJson {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, rawJson)
+	if str != expected {
+		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
+	}
+}
+
+func TestRegression(t *testing.T) {
+	expected := `{"title":"Grand Poobah"}`
+	m := &pb.MsgWithOneof{
+		Union: &pb.MsgWithOneof_Title{
+			Title: "Grand Poobah",
+		},
+	}
+	str, err := marshaler.MarshalToString(m)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
+	}
+	if str != expected {
+		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
 	}
 }

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -426,6 +426,7 @@ var marshalingTests = []struct {
 	{"BoolValue", marshaler, &pb.KnownTypes{Bool: &types.BoolValue{Value: true}}, `{"bool":true}`},
 	{"StringValue", marshaler, &pb.KnownTypes{Str: &types.StringValue{Value: "plush"}}, `{"str":"plush"}`},
 	{"BytesValue", marshaler, &pb.KnownTypes{Bytes: &types.BytesValue{Value: []byte("wow")}}, `{"bytes":"d293"}`},
+	{"ignore non proto field", marshaler, &customFieldMessage{someField: "Ignore me"}, `{}`},
 }
 
 func TestMarshaling(t *testing.T) {
@@ -699,34 +700,4 @@ func (m *customFieldMessage) String() string {
 }
 
 func (m *customFieldMessage) ProtoMessage() {
-}
-
-func TestMarshallCustomField(t *testing.T) {
-	expected := `{}`
-	m := &customFieldMessage{
-		someField: "hello world",
-	}
-	str, err := marshaler.MarshalToString(m)
-	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
-	}
-	if str != expected {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
-	}
-}
-
-func TestRegression(t *testing.T) {
-	expected := `{"title":"Grand Poobah"}`
-	m := &pb.MsgWithOneof{
-		Union: &pb.MsgWithOneof_Title{
-			Title: "Grand Poobah",
-		},
-	}
-	str, err := marshaler.MarshalToString(m)
-	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
-	}
-	if str != expected {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
-	}
 }

--- a/test/issue260/models.go
+++ b/test/issue260/models.go
@@ -3,8 +3,8 @@ package issue260
 import "time"
 
 type Dropped struct {
-	Name string
-	Age  int32
+	Name string `protobuf:"bytes,1,opt,name=name,json=name"`
+	Age  int32  `protobuf:"varint,2,opt,name=age,json=age"`
 }
 
 func (d *Dropped) Drop() bool {
@@ -12,8 +12,8 @@ func (d *Dropped) Drop() bool {
 }
 
 type DroppedWithoutGetters struct {
-	Width             int64
-	Height            int64
+	Width             int64      `protobuf:"varint,1,opt,name=width,json=width"`
+	Height            int64      `protobuf:"varint,2,opt,name=height,json=height"`
 	Timestamp         time.Time  `protobuf:"bytes,3,opt,name=timestamp,stdtime" json:"timestamp"`
 	NullableTimestamp *time.Time `protobuf:"bytes,4,opt,name=nullable_timestamp,json=nullableTimestamp,stdtime" json:"nullable_timestamp,omitempty"`
 }

--- a/test/jsonpb-gogo/jsonpb_gogo_test.go
+++ b/test/jsonpb-gogo/jsonpb_gogo_test.go
@@ -1,0 +1,36 @@
+package jsonpb_gogo
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/jsonpb"
+)
+
+// customFieldMessage implements protobuf.Message but is not a normal generated message type.
+type customFieldMessage struct {
+	someField string //this is not a proto field
+}
+
+func (m *customFieldMessage) Reset() {
+	m.someField = "hello"
+}
+
+func (m *customFieldMessage) String() string {
+	return m.someField
+}
+
+func (m *customFieldMessage) ProtoMessage() {
+}
+
+func TestUnmarshalWithJSONPBUnmarshaler(t *testing.T) {
+	rawJson := `{}`
+	marshaler := &jsonpb.Marshaler{}
+	msg := &customFieldMessage{someField: "Ignore me"}
+	str, err := marshaler.MarshalToString(msg)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshaling message: %v", err)
+	}
+	if str != rawJson {
+		t.Errorf("marshaled JSON was incorrect: got %s, wanted %s", str, rawJson)
+	}
+}

--- a/test/typedecl/models.go
+++ b/test/typedecl/models.go
@@ -1,8 +1,8 @@
 package typedecl
 
 type Dropped struct {
-	Name string
-	Age  int32
+	Name string `protobuf:"bytes,1,opt,name=name,json=name"`
+	Age  int32  `protobuf:"varint,2,opt,name=age,json=age"`
 }
 
 func (d *Dropped) Drop() bool {
@@ -10,8 +10,8 @@ func (d *Dropped) Drop() bool {
 }
 
 type DroppedWithoutGetters struct {
-	Width  int64
-	Height int64
+	Width  int64 `protobuf:"varint,1,opt,name=width,json=width"`
+	Height int64 `protobuf:"varint,2,opt,name=height,json=height"`
 }
 
 func (d *DroppedWithoutGetters) GetHeight() int64 {

--- a/test/typedecl_all/models.go
+++ b/test/typedecl_all/models.go
@@ -1,8 +1,8 @@
 package typedeclall
 
 type Dropped struct {
-	Name string
-	Age  int32
+	Name string `protobuf:"bytes,1,opt,name=name,json=name"`
+	Age  int32  `protobuf:"varint,2,opt,name=age,json=age"`
 }
 
 func (d *Dropped) Drop() bool {
@@ -10,8 +10,8 @@ func (d *Dropped) Drop() bool {
 }
 
 type DroppedWithoutGetters struct {
-	Width  int64
-	Height int64
+	Width  int64 `protobuf:"varint,1,opt,name=width,json=width"`
+	Height int64 `protobuf:"varint,2,opt,name=height,json=height"`
 }
 
 func (d *DroppedWithoutGetters) GetHeight() int64 {


### PR DESCRIPTION
This fixes #305
I am however not sure if this is the correct way to go about it, or if it even acceptable in terms of backwards compat to introduce this.

My understanding is however that when serializing using jsonpb, you only want to deal with fields defined in your proto contracts