### PR TITLE
grouping similar imports in .pb.go file

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -718,23 +718,14 @@ func RegisterUniquePackageName(pkg string, f *FileDescriptor) string {
 	// Convert dots to underscores before finding a unique alias.
 	pkg = strings.Map(badToUnderscore, pkg)
 
-	var i = -1
 	var ptr *FileDescriptor = nil
-	for i, ptr = range pkgNamesInUse[pkg] {
+	for _, ptr = range pkgNamesInUse[pkg] {
 		if ptr == f {
-			if i == 0 {
-				return pkg
-			}
-			return pkg + strconv.Itoa(i)
+			return pkg
 		}
 	}
 
 	pkgNamesInUse[pkg] = append(pkgNamesInUse[pkg], f)
-	i += 1
-
-	if i > 0 {
-		pkg = pkg + strconv.Itoa(i)
-	}
 
 	if f != nil {
 		uniquePackageName[f.FileDescriptorProto] = pkg


### PR DESCRIPTION
I suggest to group similar imports in .pb.go file instead of making duplicates. 

Example. At the moment these imports in .proto file produce duplicated imports in resulting .pb.go file.
**.proto file**
`import "google/protobuf/wrappers.proto";`
`import "google/protobuf/timestamp.proto";`
**.pb.go file**
`import google_protobuf "google/protobuf"`
`import google_protobuf1 "google/protobuf"`

Nice feature, but this causes issues with parsing .pb.go file (we use code generation based on .pb.go file). 

This tiny PR removes duplication of imports and leaves only one import instead of a few similar.
**.pb.go file**
`import google_protobuf "google/protobuf"`