### PR TITLE
Only rename size fields if sizer is enabled.

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -2049,8 +2049,11 @@ func (g *Generator) generateMessage(message *Descriptor) {
 	for _, n := range methodNames {
 		usedNames[n] = true
 	}
-	if !gogoproto.IsProtoSizer(message.file, message.DescriptorProto) {
+	if gogoproto.IsSizer(message.file, message.DescriptorProto) {
 		usedNames["Size"] = true
+	}
+	if gogoproto.IsProtoSizer(message.file, message.DescriptorProto) {
+		usedNames["ProtoSize"] = true
 	}
 	fieldNames := make(map[*descriptor.FieldDescriptorProto]string)
 	fieldGetterNames := make(map[*descriptor.FieldDescriptorProto]string)

--- a/protoc-gen-gogo/generator/helper.go
+++ b/protoc-gen-gogo/generator/helper.go
@@ -182,8 +182,13 @@ func (g *Generator) GetFieldName(message *Descriptor, field *descriptor.FieldDes
 			return fieldname + "_"
 		}
 	}
-	if !gogoproto.IsProtoSizer(message.file, message.DescriptorProto) {
+	if gogoproto.IsSizer(message.file, message.DescriptorProto) {
 		if fieldname == "Size" {
+			return fieldname + "_"
+		}
+	}
+	if gogoproto.IsProtoSizer(message.file, message.DescriptorProto) {
+		if fieldname == "ProtoSize" {
 			return fieldname + "_"
 		}
 	}


### PR DESCRIPTION
The Size method is only created if the sizer plugin is enabled, and other parts of the codebase seem to handle this case. The helpers here were assuming that either Size or ProtoSize exists, which is not true, especially if the base message was generated with the google golang plugin.