### PR TITLE
proto: use sync.Pool for temporary Buffer types

### DIFF
--- a/proto/lib.go
+++ b/proto/lib.go
@@ -343,6 +343,13 @@ func (p *Buffer) SetBuf(s []byte) {
 // Bytes returns the contents of the Buffer.
 func (p *Buffer) Bytes() []byte { return p.buf }
 
+// bufPool is a pool of temporary Buffers.
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		return NewBuffer(nil)
+	},
+}
+
 /*
  * Helper routines for simplifying the creation of optional fields of basic type.
  */


### PR DESCRIPTION
Lower GC pressure for whenever temporary `Buffer` types are allocated, evidently it's an issue [grpc-go](https://github.com/grpc/grpc-go) ran into in the past. Additionally remove TODOs left regarding exactly this.

+cc https://github.com/grpc/grpc-go/pull/1478#issuecomment-325058960, https://github.com/golang/protobuf/pull/418
