### PR TITLE
Mentioning the bit about proto_path up front

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,14 +95,16 @@ Other binaries are also included:
 Installing any of these binaries is easy.  Simply run:
 
     go get github.com/gogo/protobuf/proto
-    go get github.com/gogo/protobuf/protoc-gen-gogo{fast|faster|slick}
+    go get github.com/gogo/protobuf/{binary}
     go get github.com/gogo/protobuf/gogoproto
 
-These binaries allow you to use gogoprotobuf [extensions](https://github.com/gogo/protobuf/blob/master/extensions.md).
+These binaries allow you to use gogoprotobuf [extensions](https://github.com/gogo/protobuf/blob/master/extensions.md). You can also use your own binary.
 
 To generate the code, you also need to set the include path properly.
 
-    protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --gogo{fast|faster|slick}_out=. myproto.proto
+    protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --{binary}_out=. myproto.proto
+
+Note that in the protoc command, {binary} does not contain the initial prefix of "protoc-gen". 
 
 ### Most Speed and most customization
 

--- a/Readme.md
+++ b/Readme.md
@@ -95,10 +95,14 @@ Other binaries are also included:
 Installing any of these binaries is easy.  Simply run:
 
     go get github.com/gogo/protobuf/proto
-    go get github.com/gogo/protobuf/{binary}
+    go get github.com/gogo/protobuf/protoc-gen-gogo{fast|faster|slick}
     go get github.com/gogo/protobuf/gogoproto
 
 These binaries allow you to use gogoprotobuf [extensions](https://github.com/gogo/protobuf/blob/master/extensions.md).
+
+To generate the code, you also need to set the include path properly.
+
+    protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --gogo{fast|faster|slick}_out=. myproto.proto
 
 ### Most Speed and most customization
 


### PR DESCRIPTION
I had to spend quite some time trying to debug and understand how to setup the proto_path. The example in the Makefile just shows some relative paths which are not very helpful.

I think mentioning them directly in the README will save every one a lot of time. (It sure would have done for mine !)