### PR TITLE
plugin/populate: avoid loops on non top-level packages

### DIFF
--- a/plugin/populate/populate.go
+++ b/plugin/populate/populate.go
@@ -443,7 +443,7 @@ func (p *plugin) GenerateField(file *generator.FileDescriptor, message *generato
 	}
 }
 
-func (p *plugin) hasLoop(field *descriptor.FieldDescriptorProto, visited []*generator.Descriptor, excludes []*generator.Descriptor) *generator.Descriptor {
+func (p *plugin) hasLoop(pkg string, field *descriptor.FieldDescriptorProto, visited []*generator.Descriptor, excludes []*generator.Descriptor) *generator.Descriptor {
 	if field.IsMessage() || p.IsGroup(field) || p.IsMap(field) {
 		var fieldMessage *generator.Descriptor
 		if p.IsMap(field) {
@@ -467,11 +467,11 @@ func (p *plugin) hasLoop(field *descriptor.FieldDescriptorProto, visited []*gene
 				return fieldMessage
 			}
 		}
-		pkg := strings.Split(field.GetTypeName(), ".")[1]
+
 		for _, f := range fieldMessage.Field {
-			if strings.HasPrefix(f.GetTypeName(), "."+pkg+".") {
+			if strings.HasPrefix(f.GetTypeName(), "."+pkg) {
 				visited = append(visited, fieldMessage)
-				loopTo := p.hasLoop(f, visited, excludes)
+				loopTo := p.hasLoop(pkg, f, visited, excludes)
 				if loopTo != nil {
 					return loopTo
 				}
@@ -481,13 +481,13 @@ func (p *plugin) hasLoop(field *descriptor.FieldDescriptorProto, visited []*gene
 	return nil
 }
 
-func (p *plugin) loops(field *descriptor.FieldDescriptorProto, message *generator.Descriptor) int {
+func (p *plugin) loops(pkg string, field *descriptor.FieldDescriptorProto, message *generator.Descriptor) int {
 	//fmt.Fprintf(os.Stderr, "loops %v %v\n", field.GetTypeName(), generator.CamelCaseSlice(message.TypeName()))
 	excludes := []*generator.Descriptor{}
 	loops := 0
 	for {
 		visited := []*generator.Descriptor{}
-		loopTo := p.hasLoop(field, visited, excludes)
+		loopTo := p.hasLoop(pkg, field, visited, excludes)
 		if loopTo == nil {
 			break
 		}
@@ -522,7 +522,7 @@ func (p *plugin) Generate(file *generator.FileDescriptor) {
 		loopLevels := make([]int, len(message.Field))
 		maxLoopLevel := 0
 		for i, field := range message.Field {
-			loopLevels[i] = p.loops(field, message)
+			loopLevels[i] = p.loops(file.GetPackage(), field, message)
 			if loopLevels[i] > maxLoopLevel {
 				maxLoopLevel = loopLevels[i]
 			}

--- a/test/issue270/a/a1.proto
+++ b/test/issue270/a/a1.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package issue270.a;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/test/issue270/a/a2.proto";
+
+option (gogoproto.populate_all) = true;
+
+message A1 {
+    optional A2 a2 = 1;
+}

--- a/test/issue270/a/a2.proto
+++ b/test/issue270/a/a2.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package issue270.a;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/test/issue270/b/b.proto";
+
+option (gogoproto.populate_all) = true;
+
+message A2 {
+    optional issue270.b.B b = 1;
+}

--- a/test/issue270/b/b.proto
+++ b/test/issue270/b/b.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+package issue270.b;
+
+message B {
+}

--- a/test/issue270/doc.go
+++ b/test/issue270/doc.go
@@ -1,0 +1,1 @@
+package issue270

--- a/test/issue270/issue270_test.go
+++ b/test/issue270/issue270_test.go
@@ -1,0 +1,51 @@
+// Protocol Buffers for Go with Gadgets
+//
+// Copyright (c) 2013, The GoGo Authors. All rights reserved.
+// http://github.com/gogo/protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package issue270
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPopulateWarning(t *testing.T) {
+	cmd := exec.Command("protoc", "--gogo_out=.", "-I=../../../../../:../../protobuf/:.", "a/a1.proto")
+	data, err := cmd.CombinedOutput()
+	dataStr := string(data)
+	t.Logf("received error = %v and output = %v", err, dataStr)
+	if err != nil {
+		t.Error(err)
+	} else if strings.Contains(dataStr, "WARNING") {
+		t.Errorf("Unexpected WARNING: %s", dataStr)
+	}
+	if err = os.Remove("a/a1.pb.go"); err != nil && !os.IsNotExist(err) {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
The previous scheme for detecting when a type belonged to a different
package only considered the topmost component of the type name, when it
in fact needs to consider all but the last component of the type name.

Fix #207 (again).