### PR TITLE
Update to protobuf 3.5.1 and minor cleanups for Golang 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 script:
   - PATH=/home/travis/bin:$PATH make buildserverall
   - echo $TRAVIS_GO_VERSION
-  - if [[ "$PROTOBUF_VERSION" == "3.5.0" ]] && [[ "$TRAVIS_GO_VERSION" =~ ^1\.9\.[0-9]+$ ]]; then ! git status --porcelain | read || (git status; git diff; exit 1); fi
+  - if [[ "$PROTOBUF_VERSION" == "3.5.1" ]] && [[ "$TRAVIS_GO_VERSION" =~ ^1\.9\.[0-9]+$ ]]; then ! git status --porcelain | read || (git status; git diff; exit 1); fi
 
 language: go
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ before_install:
 
 script:
   - PATH=/home/travis/bin:$PATH make buildserverall
-  - echo $TRAVIS_GO_VERSION
-  - if [ "$CHECK_DIFF" == 1 ]; then ! git status --porcelain | read || (git status; git diff; exit 1); fi
+  - if [[ "$CHECK_DIFF" == "1" ]] && [[ "$TRAVIS_GO_VERSION" =~ ^1\.9\.[0-9]+$ ]]; then ! git status --porcelain | read || (git status; git diff; exit 1); fi
 
 language: go
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   - PROTOBUF_VERSION=2.6.1
   - PROTOBUF_VERSION=3.0.2
-  - PROTOBUF_VERSION=3.4.0 CHECK_DIFF=1
+  - PROTOBUF_VERSION=3.5.0.1 CHECK_DIFF=1
 
 before_install:
   - ./install-protobuf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   - PROTOBUF_VERSION=2.6.1
   - PROTOBUF_VERSION=3.0.2
-  - PROTOBUF_VERSION=3.5.0 CHECK_DIFF=1
+  - PROTOBUF_VERSION=3.5.0
 
 before_install:
   - ./install-protobuf.sh
@@ -9,10 +9,12 @@ before_install:
 
 script:
   - PATH=/home/travis/bin:$PATH make buildserverall
-  - if [[ "$CHECK_DIFF" == "1" ]] && [[ "$TRAVIS_GO_VERSION" =~ ^1\.9\.[0-9]+$ ]]; then ! git status --porcelain | read || (git status; git diff; exit 1); fi
+  - echo $TRAVIS_GO_VERSION
+  - if [[ "$PROTOBUF_VERSION" == "3.5.0" ]] && [[ "$TRAVIS_GO_VERSION" =~ ^1\.9\.[0-9]+$ ]]; then ! git status --porcelain | read || (git status; git diff; exit 1); fi
 
 language: go
 
 go:
   - 1.8.x
   - 1.9.x
+  - 1.10beta1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   - PROTOBUF_VERSION=2.6.1
   - PROTOBUF_VERSION=3.0.2
-  - PROTOBUF_VERSION=3.5.0
+  - PROTOBUF_VERSION=3.5.1
 
 before_install:
   - ./install-protobuf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   - PROTOBUF_VERSION=2.6.1
   - PROTOBUF_VERSION=3.0.2
-  - PROTOBUF_VERSION=3.5.0.1 CHECK_DIFF=1
+  - PROTOBUF_VERSION=3.5.0 CHECK_DIFF=1
 
 before_install:
   - ./install-protobuf.sh

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ John Shahid <jvshahid@gmail.com>
 John Tuley <john@tuley.org>
 Laurent <laurent@adyoulike.com>
 Patrick Lee <patrick@dropbox.com>
+Peter Edge <peter.edge@gmail.com>
 Roger Johansson <rogeralsing@gmail.com>
 Sam Nguyen <sam.nguyen@sendgrid.com>
 Sergio Arbeo <serabe@gmail.com>

--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ After that you can choose:
 To install it, you must first have Go (at least version 1.6.3) installed (see [http://golang.org/doc/install](http://golang.org/doc/install)). Latest patch versions of Go 1.8, 1.9 and 1.10 are continuously tested.
 
 Next, install the standard protocol buffer implementation from [https://github.com/google/protobuf](https://github.com/google/protobuf).
-Most versions from 2.3.1 should not give any problems, but 2.6.1, 3.0.2 and 3.5.0 are continuously tested.
+Most versions from 2.3.1 should not give any problems, but 2.6.1, 3.0.2 and 3.5.1 are continuously tested.
 
 ### Speed
 

--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ After that you can choose:
 
 ### Installation
 
-To install it, you must first have Go (at least version 1.6.3) installed (see [http://golang.org/doc/install](http://golang.org/doc/install)). Latest patch versions of Go 1.8 and 1.9 are continuously tested.
+To install it, you must first have Go (at least version 1.6.3) installed (see [http://golang.org/doc/install](http://golang.org/doc/install)). Latest patch versions of Go 1.8, 1.9 and 1.10 are continuously tested.
 
 Next, install the standard protocol buffer implementation from [https://github.com/google/protobuf](https://github.com/google/protobuf).
 Most versions from 2.3.1 should not give any problems, but 2.6.1, 3.0.2 and 3.4.0 are continuously tested.

--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ After that you can choose:
 To install it, you must first have Go (at least version 1.6.3) installed (see [http://golang.org/doc/install](http://golang.org/doc/install)). Latest patch versions of Go 1.8, 1.9 and 1.10 are continuously tested.
 
 Next, install the standard protocol buffer implementation from [https://github.com/google/protobuf](https://github.com/google/protobuf).
-Most versions from 2.3.1 should not give any problems, but 2.6.1, 3.0.2 and 3.4.0 are continuously tested.
+Most versions from 2.3.1 should not give any problems, but 2.6.1, 3.0.2 and 3.5.0 are continuously tested.
 
 ### Speed
 

--- a/install-protobuf.sh
+++ b/install-protobuf.sh
@@ -26,7 +26,3 @@ case "$PROTOBUF_VERSION" in
     die "unknown protobuf version: $PROTOBUF_VERSION"
     ;;
 esac
-
-
-
-

--- a/protoc-gen-gogo/grpc/grpc.go
+++ b/protoc-gen-gogo/grpc/grpc.go
@@ -137,7 +137,7 @@ func (g *grpc) GenerateImports(file *generator.FileDescriptor) {
 
 // reservedClientName records whether a client name is reserved on the client side.
 var reservedClientName = map[string]bool{
-// TODO: do we need any in gRPC?
+	// TODO: do we need any in gRPC?
 }
 
 func unexport(s string) string { return strings.ToLower(s[:1]) + s[1:] }

--- a/protoc-gen-gogo/grpc/grpc.go
+++ b/protoc-gen-gogo/grpc/grpc.go
@@ -137,7 +137,7 @@ func (g *grpc) GenerateImports(file *generator.FileDescriptor) {
 
 // reservedClientName records whether a client name is reserved on the client side.
 var reservedClientName = map[string]bool{
-	// TODO: do we need any in gRPC?
+// TODO: do we need any in gRPC?
 }
 
 func unexport(s string) string { return strings.ToLower(s[:1]) + s[1:] }

--- a/test/jsonpb-gogo/jsonpb_gogo.go
+++ b/test/jsonpb-gogo/jsonpb_gogo.go
@@ -1,0 +1,1 @@
+package jsonpb_gogo


### PR DESCRIPTION
This does the following:

- Update the latest version of Protobuf from 3.4.0 to 3.5.0.1
- Remove some trailing newlines in install-protobuf.sh
- Add a dummy non-test file for `go vet` to work in Golang 1.10