### PR TITLE
Generate correct values in maps with enumvalue_customname

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -1553,7 +1553,11 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 		if _, present := generated[*e.Number]; present {
 			duplicate = "// Duplicate value: "
 		}
-		g.P(duplicate, e.Number, ": ", strconv.Quote(*e.Name), ",")
+		name := *e.Name
+		if gogoproto.IsEnumValueCustomName(e) {
+			name = gogoproto.GetEnumValueCustomName(e)
+		}
+		g.P(duplicate, e.Number, ": ", strconv.Quote(name), ",")
 		generated[*e.Number] = true
 	}
 	g.Out()
@@ -1561,7 +1565,11 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 	g.P("var ", ccTypeName, "_value = map[string]int32{")
 	g.In()
 	for _, e := range enum.Value {
-		g.P(strconv.Quote(*e.Name), ": ", e.Number, ",")
+		name := *e.Name
+		if gogoproto.IsEnumValueCustomName(e) {
+			name = gogoproto.GetEnumValueCustomName(e)
+		}
+		g.P(strconv.Quote(name), ": ", e.Number, ",")
 	}
 	g.Out()
 	g.P("}")

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -193,11 +193,11 @@ const (
 
 var YetAnotherTestEnum_name = map[int32]string{
 	0: "AA",
-	1: "BB",
+	1: "BetterYetBB",
 }
 var YetAnotherTestEnum_value = map[string]int32{
-	"AA": 0,
-	"BB": 1,
+	"AA":          0,
+	"BetterYetBB": 1,
 }
 
 func (x YetAnotherTestEnum) Enum() *YetAnotherTestEnum {
@@ -229,11 +229,11 @@ const (
 
 var YetYetAnotherTestEnum_name = map[int32]string{
 	0: "CC",
-	1: "DD",
+	1: "BetterYetDD",
 }
 var YetYetAnotherTestEnum_value = map[string]int32{
-	"CC": 0,
-	"DD": 1,
+	"CC":          0,
+	"BetterYetDD": 1,
 }
 
 func (x YetYetAnotherTestEnum) Enum() *YetYetAnotherTestEnum {

--- a/test/combos/marshaler/thetest.pb.go
+++ b/test/combos/marshaler/thetest.pb.go
@@ -191,11 +191,11 @@ const (
 
 var YetAnotherTestEnum_name = map[int32]string{
 	0: "AA",
-	1: "BB",
+	1: "BetterYetBB",
 }
 var YetAnotherTestEnum_value = map[string]int32{
-	"AA": 0,
-	"BB": 1,
+	"AA":          0,
+	"BetterYetBB": 1,
 }
 
 func (x YetAnotherTestEnum) Enum() *YetAnotherTestEnum {
@@ -227,11 +227,11 @@ const (
 
 var YetYetAnotherTestEnum_name = map[int32]string{
 	0: "CC",
-	1: "DD",
+	1: "BetterYetDD",
 }
 var YetYetAnotherTestEnum_value = map[string]int32{
-	"CC": 0,
-	"DD": 1,
+	"CC":          0,
+	"BetterYetDD": 1,
 }
 
 func (x YetYetAnotherTestEnum) Enum() *YetYetAnotherTestEnum {

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -192,11 +192,11 @@ const (
 
 var YetAnotherTestEnum_name = map[int32]string{
 	0: "AA",
-	1: "BB",
+	1: "BetterYetBB",
 }
 var YetAnotherTestEnum_value = map[string]int32{
-	"AA": 0,
-	"BB": 1,
+	"AA":          0,
+	"BetterYetBB": 1,
 }
 
 func (x YetAnotherTestEnum) Enum() *YetAnotherTestEnum {
@@ -228,11 +228,11 @@ const (
 
 var YetYetAnotherTestEnum_name = map[int32]string{
 	0: "CC",
-	1: "DD",
+	1: "BetterYetDD",
 }
 var YetYetAnotherTestEnum_value = map[string]int32{
-	"CC": 0,
-	"DD": 1,
+	"CC":          0,
+	"BetterYetDD": 1,
 }
 
 func (x YetYetAnotherTestEnum) Enum() *YetYetAnotherTestEnum {

--- a/test/enumcustomname/enumcustomname.pb.go
+++ b/test/enumcustomname/enumcustomname.pb.go
@@ -44,12 +44,12 @@ const (
 )
 
 var MyCustomEnum_name = map[int32]string{
-	0: "A",
+	0: "MyBetterNameA",
 	1: "B",
 }
 var MyCustomEnum_value = map[string]int32{
-	"A": 0,
-	"B": 1,
+	"MyBetterNameA": 0,
+	"B":             1,
 }
 
 func (x MyCustomEnum) Enum() *MyCustomEnum {
@@ -78,12 +78,12 @@ const (
 )
 
 var MyCustomUnprefixedEnum_name = map[int32]string{
-	0: "UNPREFIXED_A",
+	0: "MyBetterNameUnprefixedA",
 	1: "UNPREFIXED_B",
 }
 var MyCustomUnprefixedEnum_value = map[string]int32{
-	"UNPREFIXED_A": 0,
-	"UNPREFIXED_B": 1,
+	"MyBetterNameUnprefixedA": 0,
+	"UNPREFIXED_B":            1,
 }
 
 func (x MyCustomUnprefixedEnum) Enum() *MyCustomUnprefixedEnum {
@@ -114,12 +114,12 @@ const (
 )
 
 var MyEnumWithEnumStringer_name = map[int32]string{
-	0: "STRINGER_A",
+	0: "EnumValueStringerA",
 	1: "STRINGER_B",
 }
 var MyEnumWithEnumStringer_value = map[string]int32{
-	"STRINGER_A": 0,
-	"STRINGER_B": 1,
+	"EnumValueStringerA": 0,
+	"STRINGER_B":         1,
 }
 
 func (x MyEnumWithEnumStringer) Enum() *MyEnumWithEnumStringer {

--- a/test/thetest.pb.go
+++ b/test/thetest.pb.go
@@ -189,11 +189,11 @@ const (
 
 var YetAnotherTestEnum_name = map[int32]string{
 	0: "AA",
-	1: "BB",
+	1: "BetterYetBB",
 }
 var YetAnotherTestEnum_value = map[string]int32{
-	"AA": 0,
-	"BB": 1,
+	"AA":          0,
+	"BetterYetBB": 1,
 }
 
 func (x YetAnotherTestEnum) Enum() *YetAnotherTestEnum {
@@ -225,11 +225,11 @@ const (
 
 var YetYetAnotherTestEnum_name = map[int32]string{
 	0: "CC",
-	1: "DD",
+	1: "BetterYetDD",
 }
 var YetYetAnotherTestEnum_value = map[string]int32{
-	"CC": 0,
-	"DD": 1,
+	"CC":          0,
+	"BetterYetDD": 1,
 }
 
 func (x YetYetAnotherTestEnum) Enum() *YetYetAnotherTestEnum {


### PR DESCRIPTION
Fixed `XXX_name` and `XXX_value` maps generation for enum with `enumvalue_customname` extension.

```protobuf
enum MyEnumWithEnumStringer {
	STRINGER_A = 0 [(gogoproto.enumvalue_customname) = "EnumValueStringerA"];
	STRINGER_B = 1;
}
```
was:
```go
var MyEnumWithEnumStringer_name = map[int32]string{
	0: "STRINGER_A",
	1: "STRINGER_B",
}
var MyEnumWithEnumStringer_value = map[string]int32{
	"STRINGER_A": 0,
	"STRINGER_B":         1,
}
```
corrected:
```go
var MyEnumWithEnumStringer_name = map[int32]string{
	0: "EnumValueStringerA",
	1: "STRINGER_B",
}
var MyEnumWithEnumStringer_value = map[string]int32{
	"EnumValueStringerA": 0,
	"STRINGER_B":         1,
}
```