### PR TITLE
protoc-min-version: don't suppress protoc out

### DIFF
--- a/protoc-min-version/minversion.go
+++ b/protoc-min-version/minversion.go
@@ -30,10 +30,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/gogo/protobuf/version"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/gogo/protobuf/version"
 )
 
 func filter(ss []string, flag string) ([]string, string) {
@@ -57,9 +58,10 @@ func main() {
 		return
 	}
 	gen := exec.Command("protoc", args...)
-	out, err := gen.CombinedOutput()
+	gen.Stderr = os.Stderr
+	gen.Stdout = os.Stdout
+	err := gen.Run()
 	if err != nil {
-		fmt.Printf("%s\n", string(out))
 		panic(err)
 	}
 }


### PR DESCRIPTION
Have noticed, that protoc-min-version is suppressing warnings that protoc plugins write to stderr.
Seems to me, protoc-min-version should not change protoc behavior.
Also, it seems reasonable to `exit(1)` when the protoc version is not high enough.
