### PR TITLE
Reenable types test for Struct and Any

### DIFF
--- a/test/types/types.proto
+++ b/test/types/types.proto
@@ -32,9 +32,9 @@ package types;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
-//import "google/protobuf/any.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-//import "google/protobuf/struct.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 


### PR DESCRIPTION
See #197.

Seems to fail on my machine building with (as travis) `make buildserverall`

```
protoc-gen-combo --version="3.0.0" --gogo_out=\
	Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,\
	Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,\
	Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,\
	Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,\
	Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types:. \
	--proto_path=../../../../../:../../protobuf/:. types.proto
protoc-gen-combo:  combos/neither/types.proto:66:3: "google.protobuf.Struct" is not defined.
protoc-gen-combo:  combos/neither/types.proto:67:3: "google.protobuf.Any" is not defined.
protoc-gen-combo: error: exit status 1make[1]: *** [regenerate] Error 1
make: *** [regenerate] Error 2
```