### PR TITLE
 let generator to support all file options from pluging host

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -146,5 +146,56 @@ Here is an example using gofast:
 
 See [https://github.com/gogo/grpc-example](https://github.com/gogo/grpc-example) for an example of using gRPC with gogoprotobuf and the wider grpc-ecosystem.
 
+## Passing options to the generator
 
-  
+It is possible to enable or disable file global options by passing
+them with/or without a prefix `no_` to the `options=` part of the
+protoc plugin configuration.
+
+Format is as follows:
+
+    --plugin_out=[{[,]key=[[+]value]}]:output_path
+
+Example of disabling gogo proto imports for generated files with grpc plugin:
+
+    protoc ... --gogofaster_out=plugins=grpc,options=no_gogoproto_import:./grpc_api
+
+List of available plugin parameters:
+
+    - import_prefix
+    - import_path
+    - plugins
+    - options
+
+List of available options:
+
+    - goproto_getters_all
+    - goproto_enum_prefix_all
+    - goproto_stringer_all
+    - verbose_equal_all
+    - face_all
+    - gostring_all
+    - populate_all
+    - stringer_all
+    - onlyone_all
+    - equal_all
+    - description_all
+    - testgen_all
+    - benchgen_all
+    - marshaler_all
+    - unmarshaler_all
+    - stable_marshaler_all
+    - sizer_all
+    - goproto_enum_stringer_all
+    - enum_stringer_all
+    - unsafe_marshaler_all
+    - unsafe_unmarshaler_all
+    - goproto_extensions_map_all
+    - goproto_unrecognized_all
+    - gogoproto_import
+    - protosizer_all
+    - compare_all
+    - typedecl_all
+    - enumdecl_all
+    - goproto_registration
+

--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -52,6 +52,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -654,6 +655,7 @@ func (g *Generator) CommandLineParameters(parameter string) {
 
 	g.ImportMap = make(map[string]string)
 	pluginList := "none" // Default list of plugin names to enable (empty means all).
+	optionList := "none" // Default list of plugin names to enable (empty means all).
 	for k, v := range g.Param {
 		switch k {
 		case "import_prefix":
@@ -662,34 +664,69 @@ func (g *Generator) CommandLineParameters(parameter string) {
 			g.PackageImportPath = v
 		case "plugins":
 			pluginList = v
+		case "options":
+			optionList = v
 		default:
 			if len(k) > 0 && k[0] == 'M' {
 				g.ImportMap[k[1:]] = v
 			}
 		}
 	}
-	if pluginList == "" {
-		return
-	}
-	if pluginList == "none" {
-		pluginList = ""
-	}
-	gogoPluginNames := []string{"unmarshal", "unsafeunmarshaler", "union", "stringer", "size", "protosizer", "populate", "marshalto", "unsafemarshaler", "gostring", "face", "equal", "enumstringer", "embedcheck", "description", "defaultcheck", "oneofcheck", "compare"}
-	pluginList = strings.Join(append(gogoPluginNames, pluginList), "+")
-	if pluginList != "" {
-		// Amend the set of plugins.
-		enabled := make(map[string]bool)
-		for _, name := range strings.Split(pluginList, "+") {
-			enabled[name] = true
+
+	if pluginList != "" && pluginList != "none" {
+		pluginList = strings.Join(append(gogoPluginNames, pluginList), "+")
+		if pluginList != "" {
+			// Amend the set of plugins.
+			enabled := make(map[string]bool)
+			for _, name := range strings.Split(pluginList, "+") {
+				enabled[name] = true
+			}
+			var nplugins pluginSlice
+			for _, p := range plugins {
+				if enabled[p.Name()] {
+					nplugins = append(nplugins, p)
+				}
+			}
+			sort.Sort(nplugins)
+			plugins = nplugins
 		}
-		var nplugins pluginSlice
-		for _, p := range plugins {
-			if enabled[p.Name()] {
-				nplugins = append(nplugins, p)
+	}
+
+	if optionList != "" && optionList != "none" {
+		// Build proto files list for setting up all files options:
+		//     files := req.GetProtoFile()
+		//     files = vanity.FilterFiles(files, vanity.NotGoogleProtobufDescriptorProto)
+		// without introducing ancestor dependency from child package.
+		files := make([]*descriptor.FileDescriptorProto, 0, len(g.Request.GetProtoFile()))
+		for _, fd := range g.Request.GetProtoFile() {
+			if notGoogleProtobufDescriptorProto(fd) {
+				files = append(files, fd)
 			}
 		}
-		sort.Sort(nplugins)
-		plugins = nplugins
+
+		for _, key := range strings.Split(optionList, "+") {
+			name := strings.ToLower(key)
+			value := true
+			if strings.HasPrefix(name, "no_") {
+				name = name[3:]
+				value = false
+			}
+			ext, ok := gogoOptionsMap[name]
+			if !ok {
+				g.Fail("Option", name, "is not available")
+			}
+			for _, fd := range files {
+				if fileHasBoolExtension(fd, ext) {
+					return
+				}
+				if fd.Options == nil {
+					fd.Options = &descriptor.FileOptions{}
+				}
+				if err := proto.SetExtension(fd.Options, ext, &value); err != nil {
+					panic(err)
+				}
+			}
+		}
 	}
 }
 
@@ -3416,6 +3453,29 @@ func baseName(name string) string {
 	return name
 }
 
+func fileHasBoolExtension(file *descriptor.FileDescriptorProto, extension *proto.ExtensionDesc) bool {
+	if file.Options == nil {
+		return false
+	}
+	value, err := proto.GetExtension(file.Options, extension)
+	if err != nil {
+		return false
+	}
+	if value == nil {
+		return false
+	}
+	if value.(*bool) == nil {
+		return false
+	}
+	return true
+}
+
+func notGoogleProtobufDescriptorProto(file *descriptor.FileDescriptorProto) bool {
+	// can not just check if file.GetName() == "google/protobuf/descriptor.proto" because we do not want to assume compile path
+	_, fileName := filepath.Split(file.GetName())
+	return !(file.GetPackage() == "google.protobuf" && fileName == "descriptor.proto")
+}
+
 // The SourceCodeInfo message describes the location of elements of a parsed
 // .proto file by way of a "path", which is a sequence of integers that
 // describe the route from a FileDescriptorProto to the relevant submessage.
@@ -3436,4 +3496,59 @@ const (
 	messageOneofPath   = 8 // oneof_decl
 	// tag numbers in EnumDescriptorProto
 	enumValuePath = 2 // value
+)
+
+var (
+	gogoPluginNames = []string{
+		"unmarshal",
+		"unsafeunmarshaler",
+		"union",
+		"stringer",
+		"size",
+		"protosizer",
+		"populate",
+		"marshalto",
+		"unsafemarshaler",
+		"gostring",
+		"face",
+		"equal",
+		"enumstringer",
+		"embedcheck",
+		"description",
+		"defaultcheck",
+		"oneofcheck",
+		"compare",
+	}
+
+	gogoOptionsMap = map[string]*proto.ExtensionDesc{
+		"goproto_getters_all":        gogoproto.E_GoprotoGettersAll,
+		"goproto_enum_prefix_all":    gogoproto.E_GoprotoEnumPrefixAll,
+		"goproto_stringer_all":       gogoproto.E_GoprotoStringerAll,
+		"verbose_equal_all":          gogoproto.E_VerboseEqualAll,
+		"face_all":                   gogoproto.E_FaceAll,
+		"gostring_all":               gogoproto.E_GostringAll,
+		"populate_all":               gogoproto.E_PopulateAll,
+		"stringer_all":               gogoproto.E_StringerAll,
+		"onlyone_all":                gogoproto.E_OnlyoneAll,
+		"equal_all":                  gogoproto.E_EqualAll,
+		"description_all":            gogoproto.E_DescriptionAll,
+		"testgen_all":                gogoproto.E_TestgenAll,
+		"benchgen_all":               gogoproto.E_BenchgenAll,
+		"marshaler_all":              gogoproto.E_MarshalerAll,
+		"unmarshaler_all":            gogoproto.E_UnmarshalerAll,
+		"stable_marshaler_all":       gogoproto.E_StableMarshalerAll,
+		"sizer_all":                  gogoproto.E_SizerAll,
+		"goproto_enum_stringer_all":  gogoproto.E_GoprotoEnumStringerAll,
+		"enum_stringer_all":          gogoproto.E_EnumStringerAll,
+		"unsafe_marshaler_all":       gogoproto.E_UnsafeMarshalerAll,
+		"unsafe_unmarshaler_all":     gogoproto.E_UnsafeUnmarshalerAll,
+		"goproto_extensions_map_all": gogoproto.E_GoprotoExtensionsMapAll,
+		"goproto_unrecognized_all":   gogoproto.E_GoprotoUnrecognizedAll,
+		"gogoproto_import":           gogoproto.E_GogoprotoImport,
+		"protosizer_all":             gogoproto.E_ProtosizerAll,
+		"compare_all":                gogoproto.E_CompareAll,
+		"typedecl_all":               gogoproto.E_TypedeclAll,
+		"enumdecl_all":               gogoproto.E_EnumdeclAll,
+		"goproto_registration":       gogoproto.E_GoprotoRegistration,
+	}
 )


### PR DESCRIPTION
It is possible to enable or disable file global options by passing
them with/or without a prefix `no_` to the `options=` part of the
protoc plugin configuration.

Format is as follows:

    --plugin_out=[{[,]key=[[+]value]}]:output_path

Example of disabling gogo proto imports for generated files with grpc plugin:

    protoc ... --gogofaster_out=plugins=grpc,options=no_gogoproto_import:./grpc_api

List of available plugin parameters:

    - import_prefix
    - import_path
    - plugins
    - options

List of available options:

    - goproto_getters_all
    - goproto_enum_prefix_all
    - goproto_stringer_all
    - verbose_equal_all
    - face_all
    - gostring_all
    - populate_all
    - stringer_all
    - onlyone_all
    - equal_all
    - description_all
    - testgen_all
    - benchgen_all
    - marshaler_all
    - unmarshaler_all
    - stable_marshaler_all
    - sizer_all
    - goproto_enum_stringer_all
    - enum_stringer_all
    - unsafe_marshaler_all
    - unsafe_unmarshaler_all
    - goproto_extensions_map_all
    - goproto_unrecognized_all
    - gogoproto_import
    - protosizer_all
    - compare_all
    - typedecl_all
    - enumdecl_all
    - goproto_registration