### PR TITLE
Fix wrong build tags

### DIFF
--- a/proto/pointer_unsafe_gogo.go
+++ b/proto/pointer_unsafe_gogo.go
@@ -26,7 +26,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !purego !appengine,!js
+// +build !purego,!appengine,!js
 
 // This file contains the implementation of the proto field accesses using package unsafe.
 


### PR DESCRIPTION
Fix wrong build tags.

Currently:
```
$ go test ./proto/
ok      github.com/gogo/protobuf/proto  0.025s
$ go test -tags=purego ./proto/
proto/pointer_unsafe_gogo.go:40:6: pointer.getRef redeclared in this block
        previous declaration at proto/pointer_reflect_gogo.go:43:6
proto/pointer_unsafe_gogo.go:41:18: unknown field 'p' in struct literal of type pointer
proto/pointer_unsafe_gogo.go:44:6: pointer.appendRef redeclared in this block
        previous declaration at proto/pointer_reflect_gogo.go:47:6
proto/pointer_unsafe_gogo.go:51:6: pointer.getSlice redeclared in this block
        previous declaration at proto/pointer_reflect_gogo.go:54:6
FAIL    github.com/gogo/protobuf/proto [build failed]
```

After fixes:
```
$ go test ./proto/
ok      github.com/gogo/protobuf/proto  0.024s
$ go test -tags=purego ./proto/
ok      github.com/gogo/protobuf/proto  0.048s
```