### PR TITLE
Remove XXX_ fields from bson for timestamp type

### DIFF
--- a/types/timestamp.pb.go
+++ b/types/timestamp.pb.go
@@ -115,9 +115,9 @@ type Timestamp struct {
 	// that count forward in time. Must be from 0 to 999,999,999
 	// inclusive.
 	Nanos                int32    `protobuf:"varint,2,opt,name=nanos,proto3" json:"nanos,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-" bson:"-"`
+	XXX_unrecognized     []byte   `json:"-" bson:"-"`
+	XXX_sizecache        int32    `json:"-" bson:"-"`
 }
 
 func (m *Timestamp) Reset()      { *m = Timestamp{} }


### PR DESCRIPTION
Hi,

I create this PR just because we store directly the Timestamp struct to Mongdb.

And now, since the `XXX_` fields creations.
We have not just 2 entries but 5 entries.

And it's not cool to convert/marshal/unmarshal/compute/and/more just because `XXX_` private fields are now.

Do you have an opinion about that?