### PR TITLE
Customtype  Warnings and issues  update

### DIFF
--- a/custom_types.md
+++ b/custom_types.md
@@ -66,4 +66,5 @@ Issues with customtype include:
   * <a href="https://github.com/gogo/protobuf/issues/125">Using a proto message as a customtype is not allowed.</a>
   * <a href="https://github.com/gogo/protobuf/issues/200">cusomtype of type map can not UnmarshalText</a>
   * <a href="https://github.com/gogo/protobuf/issues/201">customtype of type struct cannot jsonpb unmarshal</a>
-  * <a href="https://github.com/gogo/protobuf/issues/477">customtype field does not get a generated 'getter' method</a>
+  * <a href="https://github.com/gogo/protobuf/issues/477">Customtype field does not get a generated 'getter' method</a>
+  * <a href="https://github.com/gogo/protobuf/issues/478">Repeated customtype fields generate slices without pointer to the custom type </a>

--- a/custom_types.md
+++ b/custom_types.md
@@ -66,3 +66,4 @@ Issues with customtype include:
   * <a href="https://github.com/gogo/protobuf/issues/125">Using a proto message as a customtype is not allowed.</a>
   * <a href="https://github.com/gogo/protobuf/issues/200">cusomtype of type map can not UnmarshalText</a>
   * <a href="https://github.com/gogo/protobuf/issues/201">customtype of type struct cannot jsonpb unmarshal</a>
+  * <a href="https://github.com/gogo/protobuf/issues/477">customtype field does not get a generated 'getter' method</a>


### PR DESCRIPTION
Added two issues to the Warnings and issues list in the custom type documentation.
Issue #477 - Customtype field does not get a generated 'getter' method
and
Issue #478 - Repeated customtype fields generate slices without pointer to the custom type