### PR TITLE
Adding missing func to CustomType documentation

### DIFF
--- a/custom_types.md
+++ b/custom_types.md
@@ -41,6 +41,7 @@ signatures. Assuming the custom type is called `T`:
 func (t T) Marshal() ([]byte, error) {}
 func (t *T) MarshalTo(data []byte) (n int, err error) {}
 func (t *T) Unmarshal(data []byte) error {}
+func (t *T) Size() int {}
 
 func (t T) MarshalJSON() ([]byte, error) {}
 func (t *T) UnmarshalJSON(data []byte) error {}


### PR DESCRIPTION
The function `Size()` is mandatory for `CustomType` and should be documented