### PR TITLE
fix error: bad Go source code was generated, illegal hexadecimal number

### DIFF
--- a/plugin/unmarshal/unmarshal.go
+++ b/plugin/unmarshal/unmarshal.go
@@ -1152,7 +1152,7 @@ func (p *unmarshal) Generate(file *generator.FileDescriptor) {
 				if !ok {
 					panic("field is required, but no bit registered")
 				}
-				p.P(`hasFields[`, strconv.Itoa(int(fieldBit/64)), `] |= uint64(`, fmt.Sprintf("0x%08x", 1<<(fieldBit%64)), `)`)
+				p.P(`hasFields[`, strconv.Itoa(int(fieldBit/64)), `] |= uint64(`, fmt.Sprintf("0x%08x", uint64(1)<<(fieldBit%64)), `)`)
 			}
 		}
 		p.Out()
@@ -1241,7 +1241,7 @@ func (p *unmarshal) Generate(file *generator.FileDescriptor) {
 				panic("field is required, but no bit registered")
 			}
 
-			p.P(`if hasFields[`, strconv.Itoa(int(fieldBit/64)), `] & uint64(`, fmt.Sprintf("0x%08x", 1<<(fieldBit%64)), `) == 0 {`)
+			p.P(`if hasFields[`, strconv.Itoa(int(fieldBit/64)), `] & uint64(`, fmt.Sprintf("0x%08x", uint64(1)<<(fieldBit%64)), `) == 0 {`)
 			p.In()
 			if !gogoproto.ImportsGoGoProto(file.FileDescriptorProto) {
 				p.P(`return new(`, protoPkg.Use(), `.RequiredNotSetError)`)


### PR DESCRIPTION
**gen**:
protoc-gen-gogofaster.exe

**error**:
`protoc-gen-gogo: error:bad Go source code was generated: 2311:91: illegal hexadecimal number (and 1 more errors) `

**error code**:
`hasFields[0] |= uint64(0x-8000000000000000)`

**test.proto**
```
syntax = "proto2";

package test;

message TestMsg {
    required uint32 a1 = 1;
    required uint32 a2 = 2;
    required uint32 a3 = 3;
    required uint32 a4 = 4;
    required uint32 a5 = 5;
    required uint32 a6 = 6;
    required uint32 a7 = 7;
    required uint32 a8 = 8;
    required uint32 a9 = 9;
    required uint32 a10 = 10;
    required uint32 a11 = 11;
    required uint32 a12 = 12;
    required uint32 a13 = 13;
    required uint32 a14 = 14;
    required uint32 a15 = 15;
    required uint32 a16 = 16;
    required uint32 a17 = 17;
    required uint32 a18 = 18;
    required uint32 a19 = 19;
    required uint32 a20 = 20;
    required uint32 a21 = 21;
    required uint32 a22 = 22;
    required uint32 a23 = 23;
    required uint32 a24 = 24;
    required uint32 a25 = 25;
    required uint32 a26 = 26;
    required uint32 a27 = 27;
    required uint32 a28 = 28;
    required uint32 a29 = 29;
    required uint32 a30 = 30;
    required uint32 a31 = 31;
    required uint32 a32 = 32;
    required uint32 a33 = 33;
    required uint32 a34 = 34;
    required uint32 a35 = 35;
    required uint32 a36 = 36;
    required uint32 a37 = 37;
    required uint32 a38 = 38;
    required uint32 a39 = 39;
    required uint32 a40 = 40;
    required uint32 a41 = 41;
    required uint32 a42 = 42;
    required uint32 a43 = 43;
    required uint32 a44 = 44;
    required uint32 a45 = 45;
    required uint32 a46 = 46;
    required uint32 a47 = 47;
    required uint32 a48 = 48;
    required uint32 a49 = 49;
    required uint32 a50 = 50;
    required uint32 a51 = 51;
    required uint32 a52 = 52;
    required uint32 a53 = 53;
    required uint32 a54 = 54;
    required uint32 a55 = 55;
    required uint32 a56 = 56;
    required uint32 a57 = 57;
    required uint32 a58 = 58;
    required uint32 a59 = 59;
    required uint32 a60 = 60;
    required uint32 a61 = 61;
    required uint32 a62 = 62;
    required uint32 a63 = 63;
    required uint32 a64 = 64;
    required uint32 a65 = 65;
}

```