### PR TITLE
reorder some of the protoc paths in order to prefer our protobuf/goog…

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -29,8 +29,8 @@
 regenerate:
 	go install github.com/gogo/protobuf/protoc-gen-gogo
 	go install github.com/gogo/protobuf/protoc-gen-combo
-	protoc --gogo_out=. --proto_path=../:../../../../:../protobuf/:. thetest.proto
-	protoc-gen-combo --default=false --gogo_out=. --proto_path=../:../../../../:../protobuf/:. thetest.proto
+	protoc --gogo_out=. --proto_path=../protobuf/:../:../../../../:. thetest.proto
+	protoc-gen-combo --default=false --gogo_out=. --proto_path=../protobuf/:../:../../../../:. thetest.proto
 	cp uuid.go ./combos/both/
 	cp uuid.go ./combos/marshaler/
 	cp uuid.go ./combos/unmarshaler/

--- a/test/casttype/Makefile
+++ b/test/casttype/Makefile
@@ -29,4 +29,4 @@
 regenerate:
 	go install github.com/gogo/protobuf/protoc-gen-combo
 	go install github.com/gogo/protobuf/protoc-gen-gogo
-	protoc-gen-combo --gogo_out=. --version="3.0.0" --proto_path=../../../../../:../../protobuf/:. casttype.proto
+	protoc-gen-combo --gogo_out=. --version="3.0.0" --proto_path=../../protobuf/:../../../../../:. casttype.proto

--- a/test/castvalue/Makefile
+++ b/test/castvalue/Makefile
@@ -30,8 +30,8 @@ regenerate:
 	rm -rf combos
 	go install github.com/gogo/protobuf/protoc-gen-combo
 	go install github.com/gogo/protobuf/protoc-gen-gogo
-	protoc-min-version --version="3.0.0" --gogo_out=. --proto_path=../../../../../:../../protobuf/:. castvalue.proto
-	protoc-gen-combo --default=false --version="3.0.0" --gogo_out=. --proto_path=../../../../../:../../protobuf/:. castvalue.proto
+	protoc-min-version --version="3.0.0" --gogo_out=. --proto_path=../../protobuf/:../../../../../:. castvalue.proto
+	protoc-gen-combo --default=false --version="3.0.0" --gogo_out=. --proto_path=../../protobuf/:../../../../../:. castvalue.proto
 	cp mytypes.go ./combos/both/ || true
 	cp mytypes.go ./combos/marshaler/ || true
 	cp mytypes.go ./combos/unmarshaler/ || true

--- a/test/example/Makefile
+++ b/test/example/Makefile
@@ -27,4 +27,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 regenerate:
-	(protoc -I=. -I=$(GOPATH)/src -I=$(GOPATH)/src/github.com/gogo/protobuf/protobuf --gogo_out=. example.proto)
+	(protoc -I=. -I=$(GOPATH)/src/github.com/gogo/protobuf/protobuf -I=$(GOPATH)/src --gogo_out=. example.proto)

--- a/test/filedotname/Makefile
+++ b/test/filedotname/Makefile
@@ -28,4 +28,4 @@
 
 regenerate:
 	go install github.com/gogo/protobuf/protoc-gen-gogo
-	protoc --gogo_out=. --proto_path=../../../../../:../../protobuf/:. file.dot.proto
+	protoc --gogo_out=. --proto_path=../../protobuf/:../../../../../:. file.dot.proto

--- a/test/group/Makefile
+++ b/test/group/Makefile
@@ -27,4 +27,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 regenerate:
-	(protoc --proto_path=../../../../../:../../protobuf/:. --gogo_out=. group.proto)
+	(protoc --proto_path=../../protobuf/:../../../../../:. --gogo_out=. group.proto)

--- a/test/issue411/ids.go
+++ b/test/issue411/ids.go
@@ -104,7 +104,10 @@ func marshalBytes(dst []byte, src []byte) (n int, err error) {
 // Example: {high:2, low:1} => "AAAAAAAAAAIAAAAAAAAAAQ==".
 func (t TraceID) MarshalJSON() ([]byte, error) {
 	var b [16]byte
-	t.MarshalTo(b[:]) // can only error on incorrect buffer size
+	_, err := t.MarshalTo(b[:]) // can only error on incorrect buffer size
+	if err != nil {
+		return []byte{}, err
+	}
 	s := make([]byte, 24+2)
 	base64.StdEncoding.Encode(s[1:25], b[:])
 	s[0], s[25] = '"', '"'
@@ -191,7 +194,10 @@ func (s *SpanID) Unmarshal(data []byte) error {
 // Example: {1} => "AAAAAAAAAAE=".
 func (s SpanID) MarshalJSON() ([]byte, error) {
 	var b [8]byte
-	s.MarshalTo(b[:]) // can only error on incorrect buffer size
+	_, err := s.MarshalTo(b[:]) // can only error on incorrect buffer size
+	if err != nil {
+		return []byte{}, err
+	}
 	v := make([]byte, 12+2)
 	base64.StdEncoding.Encode(v[1:13], b[:])
 	v[0], v[13] = '"', '"'

--- a/test/mapdefaults/Makefile
+++ b/test/mapdefaults/Makefile
@@ -29,7 +29,7 @@
 regenerate:
 	go install github.com/gogo/protobuf/protoc-gen-combo
 	go install github.com/gogo/protobuf/protoc-gen-gogofast
-	protoc-gen-combo --version="3.0.0" --proto_path=../../../../../:../../protobuf/:. --gogo_out=. map.proto
+	protoc-gen-combo --version="3.0.0" --proto_path=../../protobuf/:../../../../../:. --gogo_out=. map.proto
 	find combos -type d -not -name combos -exec cp map_test.go.in {}/map_test.go \;
 	cp unknown_test.go.in ./combos/unmarshaler/unknown_test.go
 	cp unknown_test.go.in ./combos/both/unknown_test.go

--- a/test/mapsproto2/Makefile
+++ b/test/mapsproto2/Makefile
@@ -32,4 +32,4 @@ regenerate:
 	cp header.proto mapsproto2.proto
 	cat ../theproto3/maps.proto >> mapsproto2.proto
 	find combos -type d -not -name combos -exec cp mapsproto2_test.go.in {}/mapsproto2_test.go \;
-	protoc-gen-combo --version="3.0.0" --gogo_out=. --proto_path=../../../../../:../../protobuf/:. mapsproto2.proto
+	protoc-gen-combo --version="3.0.0" --gogo_out=. --proto_path=../../protobuf/:../../../../../:. mapsproto2.proto

--- a/test/oneof/Makefile
+++ b/test/oneof/Makefile
@@ -29,4 +29,4 @@
 regenerate:
 	go install github.com/gogo/protobuf/protoc-gen-combo
 	go install github.com/gogo/protobuf/protoc-gen-gogo
-	protoc-gen-combo --version="2.6.0" --gogo_out=. --proto_path=../../../../../:../../protobuf/:. one.proto
+	protoc-gen-combo --version="2.6.0" --gogo_out=. --proto_path=../../protobuf/:../../../../../:. one.proto

--- a/test/oneof3/Makefile
+++ b/test/oneof3/Makefile
@@ -29,4 +29,4 @@
 regenerate:
 	go install github.com/gogo/protobuf/protoc-gen-combo
 	go install github.com/gogo/protobuf/protoc-gen-gogo
-	protoc-gen-combo --version="3.0.0" --gogo_out=. --proto_path=../../../../../:../../protobuf/:. one.proto
+	protoc-gen-combo --version="3.0.0" --gogo_out=. --proto_path=../../protobuf/:../../../../../:. one.proto

--- a/test/theproto3/Makefile
+++ b/test/theproto3/Makefile
@@ -32,5 +32,5 @@ regenerate:
 	cp header.proto theproto3.proto
 	cat maps.proto >> theproto3.proto
 	cat footer.proto >> theproto3.proto
-	protoc-gen-combo --version="3.0.0" --gogo_out=. --proto_path=../../../../../:../../protobuf/:. theproto3.proto
+	protoc-gen-combo --version="3.0.0" --gogo_out=. --proto_path=../../protobuf/:../../../../../:. theproto3.proto
 	find combos -type d -not -name combos -exec cp proto3_test.go.in {}/proto3_test.go \;

--- a/test/unrecognized/Makefile
+++ b/test/unrecognized/Makefile
@@ -27,4 +27,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 regenerate:
-	(protoc --proto_path=../../../../../:../../protobuf/:. --gogo_out=. unrecognized.proto)
+	(protoc --proto_path=../../protobuf/:../../../../../:. --gogo_out=. unrecognized.proto)

--- a/test/unrecognizedgroup/Makefile
+++ b/test/unrecognizedgroup/Makefile
@@ -27,4 +27,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 regenerate:
-	(protoc --proto_path=../../../../../:../../protobuf/:. --gogo_out=. unrecognizedgroup.proto)
+	(protoc --proto_path=../../protobuf/:../../../../../:. --gogo_out=. unrecognizedgroup.proto)


### PR DESCRIPTION
…le/protobuf/*.proto files. This is just to avoid using the wrong protos if you have the same protos in you gopath/src dir.

Using other google/protobuf protos will generate different file descriptors. 