### PR TITLE
only use current field to determine packed varints size

### DIFF
--- a/plugin/unmarshal/unmarshal.go
+++ b/plugin/unmarshal/unmarshal.go
@@ -1378,7 +1378,7 @@ func (p *unmarshal) Generate(file *generator.FileDescriptor) {
 					p.P(`elementCount = packedLen/`, 4)
 				case descriptor.FieldDescriptorProto_TYPE_INT64, descriptor.FieldDescriptorProto_TYPE_UINT64, descriptor.FieldDescriptorProto_TYPE_INT32, descriptor.FieldDescriptorProto_TYPE_UINT32, descriptor.FieldDescriptorProto_TYPE_SINT32, descriptor.FieldDescriptorProto_TYPE_SINT64:
 					p.P(`var count int`)
-					p.P(`for _, integer := range dAtA {`)
+					p.P(`for _, integer := range dAtA[iNdEx:postIndex] {`)
 					p.In()
 					p.P(`if integer < 128 {`)
 					p.In()

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -7010,10 +7010,10 @@ func (this *MyExtendable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -7092,10 +7092,10 @@ func (this *OtherExtenable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -14555,7 +14555,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -14604,7 +14604,7 @@ func (this *MyExtendable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}
@@ -14671,7 +14671,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -14732,7 +14732,7 @@ func (this *OtherExtenable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}
@@ -32512,7 +32512,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32585,7 +32585,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32658,7 +32658,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32731,7 +32731,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32805,7 +32805,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32880,7 +32880,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -33428,7 +33428,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -33501,7 +33501,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -33574,7 +33574,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -33647,7 +33647,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -33721,7 +33721,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -33796,7 +33796,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -34344,7 +34344,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -34417,7 +34417,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -34490,7 +34490,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -34563,7 +34563,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -34637,7 +34637,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -34712,7 +34712,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -35202,7 +35202,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -35275,7 +35275,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -35348,7 +35348,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -35421,7 +35421,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -35495,7 +35495,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -35570,7 +35570,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -36702,7 +36702,7 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -36776,7 +36776,7 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -37221,7 +37221,7 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -37295,7 +37295,7 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -43317,7 +43317,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -43390,7 +43390,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -43463,7 +43463,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -43536,7 +43536,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -43610,7 +43610,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -43685,7 +43685,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}

--- a/test/combos/marshaler/thetest.pb.go
+++ b/test/combos/marshaler/thetest.pb.go
@@ -7009,10 +7009,10 @@ func (this *MyExtendable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -7091,10 +7091,10 @@ func (this *OtherExtenable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -14554,7 +14554,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -14603,7 +14603,7 @@ func (this *MyExtendable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}
@@ -14670,7 +14670,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -14731,7 +14731,7 @@ func (this *OtherExtenable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -6398,10 +6398,10 @@ func (this *MyExtendable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -6480,10 +6480,10 @@ func (this *OtherExtenable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -13943,7 +13943,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -13992,7 +13992,7 @@ func (this *MyExtendable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}
@@ -14059,7 +14059,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -14120,7 +14120,7 @@ func (this *OtherExtenable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}
@@ -27915,7 +27915,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -27988,7 +27988,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28061,7 +28061,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28134,7 +28134,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28208,7 +28208,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28283,7 +28283,7 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28831,7 +28831,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28904,7 +28904,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -28977,7 +28977,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29050,7 +29050,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29124,7 +29124,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29199,7 +29199,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29747,7 +29747,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29820,7 +29820,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29893,7 +29893,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -29966,7 +29966,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30040,7 +30040,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30115,7 +30115,7 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30605,7 +30605,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30678,7 +30678,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30751,7 +30751,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30824,7 +30824,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30898,7 +30898,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -30973,7 +30973,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32105,7 +32105,7 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32179,7 +32179,7 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32624,7 +32624,7 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -32698,7 +32698,7 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -38720,7 +38720,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -38793,7 +38793,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -38866,7 +38866,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -38939,7 +38939,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -39013,7 +39013,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -39088,7 +39088,7 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}

--- a/test/packed/packed.pb.go
+++ b/test/packed/packed.pb.go
@@ -1335,7 +1335,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -1408,7 +1408,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -1481,7 +1481,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -1554,7 +1554,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -1628,7 +1628,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -1703,7 +1703,7 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -2193,7 +2193,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -2266,7 +2266,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -2339,7 +2339,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -2412,7 +2412,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -2486,7 +2486,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -2561,7 +2561,7 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3051,7 +3051,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3124,7 +3124,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3197,7 +3197,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3270,7 +3270,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3344,7 +3344,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3419,7 +3419,7 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3909,7 +3909,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -3982,7 +3982,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -4055,7 +4055,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -4128,7 +4128,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -4202,7 +4202,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -4277,7 +4277,7 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}

--- a/test/thetest.pb.go
+++ b/test/thetest.pb.go
@@ -6395,10 +6395,10 @@ func (this *MyExtendable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -6477,10 +6477,10 @@ func (this *OtherExtenable) Compare(that interface{}) int {
 	thismap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(this)
 	thatmap := github_com_gogo_protobuf_proto.GetUnsafeExtensionsMap(that1)
 	extkeys := make([]int32, 0, len(thismap)+len(thatmap))
-	for k := range thismap {
+	for k, _ := range thismap {
 		extkeys = append(extkeys, k)
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			extkeys = append(extkeys, k)
 		}
@@ -13940,7 +13940,7 @@ func (this *MyExtendable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -13989,7 +13989,7 @@ func (this *MyExtendable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}
@@ -14056,7 +14056,7 @@ func (this *OtherExtenable) VerboseEqual(that interface{}) error {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In that", k)
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return fmt.Errorf("XXX_InternalExtensions[%v] Not In this", k)
 		}
@@ -14117,7 +14117,7 @@ func (this *OtherExtenable) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	for k := range thatmap {
+	for k, _ := range thatmap {
 		if _, ok := thismap[k]; !ok {
 			return false
 		}


### PR DESCRIPTION
Fixes #503 which was introduced in https://github.com/gogo/protobuf/commit/7c690aec3cc11748961ec9b98b294bb01bbd32cb

The intention was to precompute the slice size for varint types. However, the estimate used all the data not just the data for the current field.

I also reran make the in the test directory.