### PR TITLE
types: replace inline interface for reproducible builds

### DIFF
--- a/types/duration_gogo.go
+++ b/types/duration_gogo.go
@@ -33,9 +33,7 @@ import (
 	"time"
 )
 
-func NewPopulatedDuration(r interface {
-	Int63() int64
-}, easy bool) *Duration {
+func NewPopulatedDuration(r int63er, easy bool) *Duration {
 	this := &Duration{}
 	maxSecs := time.Hour.Nanoseconds() / 1e9
 	max := 2 * maxSecs
@@ -58,9 +56,7 @@ func (d *Duration) String() string {
 	return td.String()
 }
 
-func NewPopulatedStdDuration(r interface {
-	Int63() int64
-}, easy bool) *time.Duration {
+func NewPopulatedStdDuration(r int63er, easy bool) *time.Duration {
 	dur := NewPopulatedDuration(r, easy)
 	d, err := DurationFromProto(dur)
 	if err != nil {

--- a/types/int63er.go
+++ b/types/int63er.go
@@ -1,0 +1,5 @@
+package types
+
+type int63er interface {
+	Int63() int64
+}

--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -32,9 +32,7 @@ import (
 	"time"
 )
 
-func NewPopulatedTimestamp(r interface {
-	Int63() int64
-}, easy bool) *Timestamp {
+func NewPopulatedTimestamp(r int63er, easy bool) *Timestamp {
 	this := &Timestamp{}
 	ns := int64(r.Int63())
 	this.Seconds = ns / 1e9
@@ -46,9 +44,7 @@ func (ts *Timestamp) String() string {
 	return TimestampString(ts)
 }
 
-func NewPopulatedStdTime(r interface {
-	Int63() int64
-}, easy bool) *time.Time {
+func NewPopulatedStdTime(r int63er, easy bool) *time.Time {
 	timestamp := NewPopulatedTimestamp(r, easy)
 	t, err := TimestampFromProto(timestamp)
 	if err != nil {


### PR DESCRIPTION
Don't use inline interfaces. They cause non-reproducible builds until
https://golang.org/issue/30202 is fixed.