### PR TITLE
Replace sov

### DIFF
--- a/plugin/size/size.go
+++ b/plugin/size/size.go
@@ -141,6 +141,7 @@ type size struct {
 	atleastOne bool
 	localName  string
 	typesPkg   generator.Single
+	bitsPkg    generator.Single
 }
 
 func NewSize() *size {
@@ -188,14 +189,7 @@ func keySize(fieldNumber int32, wireType int) int {
 func (p *size) sizeVarint() {
 	p.P(`
 	func sov`, p.localName, `(x uint64) (n int) {
-		for {
-			n++
-			x >>= 7
-			if x == 0 {
-				break
-			}
-		}
-		return n
+                return (`, p.bitsPkg.Use(), `.Len64(x | 1) + 6)/ 7
 	}`)
 }
 
@@ -589,6 +583,7 @@ func (p *size) Generate(file *generator.FileDescriptor) {
 	p.localName = generator.FileName(file)
 	p.typesPkg = p.NewImport("github.com/gogo/protobuf/types")
 	protoPkg := p.NewImport("github.com/gogo/protobuf/proto")
+	p.bitsPkg = p.NewImport("math/bits")
 	if !gogoproto.ImportsGoGoProto(file.FileDescriptorProto) {
 		protoPkg = p.NewImport("github.com/golang/protobuf/proto")
 	}

--- a/test/asymetric-issue125/asym.pb.go
+++ b/test/asymetric-issue125/asym.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -387,14 +388,7 @@ func (m *M) Size() (n int) {
 }
 
 func sovAsym(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAsym(x uint64) (n int) {
 	return sovAsym(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/cachedsize/cachedsize.pb.go
+++ b/test/cachedsize/cachedsize.pb.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -270,14 +271,7 @@ func (m *Bar) Size() (n int) {
 }
 
 func sovCachedsize(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCachedsize(x uint64) (n int) {
 	return sovCachedsize(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/both/casttype.pb.go
+++ b/test/casttype/combos/both/casttype.pb.go
@@ -17,6 +17,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1561,14 +1562,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/marshaler/casttype.pb.go
+++ b/test/casttype/combos/marshaler/casttype.pb.go
@@ -16,6 +16,7 @@ import (
 	github_com_gogo_protobuf_test_casttype "github.com/gogo/protobuf/test/casttype"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1560,14 +1561,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/neither/casttype.pb.go
+++ b/test/casttype/combos/neither/casttype.pb.go
@@ -15,6 +15,7 @@ import (
 	github_com_gogo_protobuf_test_casttype "github.com/gogo/protobuf/test/casttype"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1338,14 +1339,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/unmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unmarshaler/casttype.pb.go
@@ -17,6 +17,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1340,14 +1341,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/castvalue.pb.go
+++ b/test/castvalue/castvalue.pb.go
@@ -14,6 +14,7 @@ import (
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -842,14 +843,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/combos/both/castvalue.pb.go
+++ b/test/castvalue/combos/both/castvalue.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -970,14 +971,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/combos/marshaler/castvalue.pb.go
+++ b/test/castvalue/combos/marshaler/castvalue.pb.go
@@ -14,6 +14,7 @@ import (
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -969,14 +970,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/combos/unmarshaler/castvalue.pb.go
+++ b/test/castvalue/combos/unmarshaler/castvalue.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -844,14 +845,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -18,6 +18,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	sort "sort"
 	strconv "strconv"
@@ -30429,14 +30430,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/combos/marshaler/thetest.pb.go
+++ b/test/combos/marshaler/thetest.pb.go
@@ -17,6 +17,7 @@ import (
 	github_com_gogo_protobuf_test_custom_dash_type "github.com/gogo/protobuf/test/custom-dash-type"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	sort "sort"
 	strconv "strconv"
@@ -30428,14 +30429,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -18,6 +18,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	sort "sort"
 	strconv "strconv"
@@ -25832,14 +25833,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/data/data.pb.go
+++ b/test/data/data.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -304,14 +305,7 @@ func (m *MyMessage) Size() (n int) {
 }
 
 func sovData(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozData(x uint64) (n int) {
 	return sovData(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/deterministic/deterministic.pb.go
+++ b/test/deterministic/deterministic.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1318,14 +1319,7 @@ func (m *NestedMap2) Size() (n int) {
 }
 
 func sovDeterministic(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozDeterministic(x uint64) (n int) {
 	return sovDeterministic(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/enumdecl/enumdecl.pb.go
+++ b/test/enumdecl/enumdecl.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -304,14 +305,7 @@ func (m *Message) Size() (n int) {
 }
 
 func sovEnumdecl(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozEnumdecl(x uint64) (n int) {
 	return sovEnumdecl(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/enumdecl_all/enumdeclall.pb.go
+++ b/test/enumdecl_all/enumdeclall.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -357,14 +358,7 @@ func (m *Message) Size() (n int) {
 }
 
 func sovEnumdeclall(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozEnumdeclall(x uint64) (n int) {
 	return sovEnumdeclall(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/example/example.pb.go
+++ b/test/example/example.pb.go
@@ -16,6 +16,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1829,14 +1830,7 @@ func (m *CastType) Size() (n int) {
 }
 
 func sovExample(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozExample(x uint64) (n int) {
 	return sovExample(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/filedotname/file.dot.pb.go
+++ b/test/filedotname/file.dot.pb.go
@@ -13,6 +13,7 @@ import (
 	github_com_gogo_protobuf_protoc_gen_gogo_descriptor "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -567,14 +568,7 @@ func (m *M) Size() (n int) {
 }
 
 func sovFileDot(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozFileDot(x uint64) (n int) {
 	return sovFileDot(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/fuzztests/fuzz.pb.go
+++ b/test/fuzztests/fuzz.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1320,14 +1321,7 @@ func (m *NinOptStruct) Size() (n int) {
 }
 
 func sovFuzz(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozFuzz(x uint64) (n int) {
 	return sovFuzz(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/importcustom-issue389/imported/a.pb.go
+++ b/test/importcustom-issue389/imported/a.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -249,14 +250,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovA(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozA(x uint64) (n int) {
 	return sovA(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/importcustom-issue389/importing/c.pb.go
+++ b/test/importcustom-issue389/importing/c.pb.go
@@ -12,6 +12,7 @@ import (
 	github_com_gogo_protobuf_test_importcustom_issue389_imported "github.com/gogo/protobuf/test/importcustom-issue389/imported"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -258,14 +259,7 @@ func (m *C) Size() (n int) {
 }
 
 func sovC(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozC(x uint64) (n int) {
 	return sovC(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/indeximport-issue72/index/index.pb.go
+++ b/test/indeximport-issue72/index/index.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -290,14 +291,7 @@ func (m *IndexQuery) Size() (n int) {
 }
 
 func sovIndex(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIndex(x uint64) (n int) {
 	return sovIndex(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/indeximport-issue72/indeximport.pb.go
+++ b/test/indeximport-issue72/indeximport.pb.go
@@ -11,6 +11,7 @@ import (
 	index "github.com/gogo/protobuf/test/indeximport-issue72/index"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -272,14 +273,7 @@ func (m *IndexQueries) Size() (n int) {
 }
 
 func sovIndeximport(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIndeximport(x uint64) (n int) {
 	return sovIndeximport(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/int64support/object.pb.go
+++ b/test/int64support/object.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -308,14 +309,7 @@ func (m *Object) Size() (n int) {
 }
 
 func sovObject(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozObject(x uint64) (n int) {
 	return sovObject(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue260/issue260.pb.go
+++ b/test/issue260/issue260.pb.go
@@ -11,6 +11,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	time "time"
 )
 
@@ -644,14 +645,7 @@ func (m *Kept) Size() (n int) {
 }
 
 func sovIssue260(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue260(x uint64) (n int) {
 	return sovIssue260(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue261/issue261.pb.go
+++ b/test/issue261/issue261.pb.go
@@ -12,6 +12,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
@@ -237,14 +238,7 @@ func (m *MapStdTypes) Size() (n int) {
 }
 
 func sovIssue261(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue261(x uint64) (n int) {
 	return sovIssue261(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue262/timefail.pb.go
+++ b/test/issue262/timefail.pb.go
@@ -11,6 +11,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
@@ -192,14 +193,7 @@ func (m *TimeFail) Size() (n int) {
 }
 
 func sovTimefail(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTimefail(x uint64) (n int) {
 	return sovTimefail(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue322/issue322.pb.go
+++ b/test/issue322/issue322.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -418,14 +419,7 @@ func (m *OneofTest_I) Size() (n int) {
 }
 
 func sovIssue322(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue322(x uint64) (n int) {
 	return sovIssue322(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue330/issue330.pb.go
+++ b/test/issue330/issue330.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -249,14 +250,7 @@ func (m *Object) Size() (n int) {
 }
 
 func sovIssue330(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue330(x uint64) (n int) {
 	return sovIssue330(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue42order/issue42.pb.go
+++ b/test/issue42order/issue42.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -374,14 +375,7 @@ func (m *OrderedFields) Size() (n int) {
 }
 
 func sovIssue42(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue42(x uint64) (n int) {
 	return sovIssue42(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue438/issue438.pb.go
+++ b/test/issue438/issue438.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	types "github.com/gogo/protobuf/types"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -477,14 +478,7 @@ func (m *Types) ProtoSize() (n int) {
 }
 
 func sovIssue438(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue438(x uint64) (n int) {
 	return sovIssue438(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue444/issue444.pb.go
+++ b/test/issue444/issue444.pb.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -93,14 +94,7 @@ func (m *SizeMe) Size() (n int) {
 }
 
 func sovIssue444(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue444(x uint64) (n int) {
 	return sovIssue444(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue449/issue449.pb.go
+++ b/test/issue449/issue449.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -346,14 +347,7 @@ func (m *CodeGenMsg) Size() (n int) {
 }
 
 func sovIssue449(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue449(x uint64) (n int) {
 	return sovIssue449(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue498/issue498.pb.go
+++ b/test/issue498/issue498.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -348,14 +349,7 @@ func (m *Message) Size() (n int) {
 }
 
 func sovIssue498(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue498(x uint64) (n int) {
 	return sovIssue498(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue503/issue503.pb.go
+++ b/test/issue503/issue503.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -471,14 +472,7 @@ func (m *Foo) Size() (n int) {
 }
 
 func sovIssue503(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue503(x uint64) (n int) {
 	return sovIssue503(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue530/issue530.pb.go
+++ b/test/issue530/issue530.pb.go
@@ -10,6 +10,7 @@ import (
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1875,14 +1876,7 @@ func (m *Bar9) Size() (n int) {
 }
 
 func sovIssue530(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozIssue530(x uint64) (n int) {
 	return sovIssue530(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/both/map.pb.go
+++ b/test/mapdefaults/combos/both/map.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1031,14 +1032,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/marshaler/map.pb.go
+++ b/test/mapdefaults/combos/marshaler/map.pb.go
@@ -14,6 +14,7 @@ import (
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1030,14 +1031,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/neither/map.pb.go
+++ b/test/mapdefaults/combos/neither/map.pb.go
@@ -14,6 +14,7 @@ import (
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -884,14 +885,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/unmarshaler/map.pb.go
+++ b/test/mapdefaults/combos/unmarshaler/map.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -885,14 +886,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/both/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/both/mapsproto2.pb.go
@@ -18,6 +18,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -4175,14 +4176,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
@@ -17,6 +17,7 @@ import (
 	github_com_gogo_protobuf_test_custom "github.com/gogo/protobuf/test/custom"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -4174,14 +4175,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/neither/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/neither/mapsproto2.pb.go
@@ -16,6 +16,7 @@ import (
 	github_com_gogo_protobuf_test_custom "github.com/gogo/protobuf/test/custom"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -3243,14 +3244,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
@@ -18,6 +18,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -3247,14 +3248,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/nopackage/nopackage.pb.go
+++ b/test/nopackage/nopackage.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -157,14 +158,7 @@ func (m *M) Size() (n int) {
 }
 
 func sovNopackage(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozNopackage(x uint64) (n int) {
 	return sovNopackage(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/both/one.pb.go
+++ b/test/oneof/combos/both/one.pb.go
@@ -17,6 +17,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -4446,14 +4447,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/marshaler/one.pb.go
+++ b/test/oneof/combos/marshaler/one.pb.go
@@ -16,6 +16,7 @@ import (
 	github_com_gogo_protobuf_test_custom "github.com/gogo/protobuf/test/custom"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -4445,14 +4446,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/neither/one.pb.go
+++ b/test/oneof/combos/neither/one.pb.go
@@ -15,6 +15,7 @@ import (
 	github_com_gogo_protobuf_test_custom "github.com/gogo/protobuf/test/custom"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -4038,14 +4039,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/unmarshaler/one.pb.go
+++ b/test/oneof/combos/unmarshaler/one.pb.go
@@ -17,6 +17,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -4040,14 +4041,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/both/one.pb.go
+++ b/test/oneof3/combos/both/one.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -2686,14 +2687,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/marshaler/one.pb.go
+++ b/test/oneof3/combos/marshaler/one.pb.go
@@ -14,6 +14,7 @@ import (
 	github_com_gogo_protobuf_protoc_gen_gogo_descriptor "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -2685,14 +2686,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/neither/one.pb.go
+++ b/test/oneof3/combos/neither/one.pb.go
@@ -13,6 +13,7 @@ import (
 	github_com_gogo_protobuf_protoc_gen_gogo_descriptor "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -2465,14 +2466,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/unmarshaler/one.pb.go
+++ b/test/oneof3/combos/unmarshaler/one.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -2467,14 +2468,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/protosize/protosize.pb.go
+++ b/test/protosize/protosize.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -360,14 +361,7 @@ func (m *SizeMessage) ProtoSize() (n int) {
 }
 
 func sovProtosize(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozProtosize(x uint64) (n int) {
 	return sovProtosize(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/required/requiredexample.pb.go
+++ b/test/required/requiredexample.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1166,14 +1167,7 @@ func (m *NestedNinOptNative) Size() (n int) {
 }
 
 func sovRequiredexample(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRequiredexample(x uint64) (n int) {
 	return sovRequiredexample(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/sizeunderscore/sizeunderscore.pb.go
+++ b/test/sizeunderscore/sizeunderscore.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -327,14 +328,7 @@ func (m *SizeMessage) Size() (n int) {
 }
 
 func sovSizeunderscore(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozSizeunderscore(x uint64) (n int) {
 	return sovSizeunderscore(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/stdtypes/stdtypes.pb.go
+++ b/test/stdtypes/stdtypes.pb.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/gogo/protobuf/types"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
@@ -4948,14 +4949,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovStdtypes(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozStdtypes(x uint64) (n int) {
 	return sovStdtypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -18,6 +18,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -5985,14 +5986,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/marshaler/theproto3.pb.go
+++ b/test/theproto3/combos/marshaler/theproto3.pb.go
@@ -17,6 +17,7 @@ import (
 	github_com_gogo_protobuf_test_custom "github.com/gogo/protobuf/test/custom"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -5985,14 +5986,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/neither/theproto3.pb.go
+++ b/test/theproto3/combos/neither/theproto3.pb.go
@@ -16,6 +16,7 @@ import (
 	github_com_gogo_protobuf_test_custom "github.com/gogo/protobuf/test/custom"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -4726,14 +4727,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -18,6 +18,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -4728,14 +4729,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/thetest.pb.go
+++ b/test/thetest.pb.go
@@ -16,6 +16,7 @@ import (
 	github_com_gogo_protobuf_test_custom_dash_type "github.com/gogo/protobuf/test/custom-dash-type"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	sort "sort"
 	strconv "strconv"
@@ -25829,14 +25830,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/typedecl/typedecl.pb.go
+++ b/test/typedecl/typedecl.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -618,14 +619,7 @@ func (m *Kept) Size() (n int) {
 }
 
 func sovTypedecl(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTypedecl(x uint64) (n int) {
 	return sovTypedecl(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/typedecl_all/typedeclall.pb.go
+++ b/test/typedecl_all/typedeclall.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -618,14 +619,7 @@ func (m *Kept) Size() (n int) {
 }
 
 func sovTypedeclall(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTypedeclall(x uint64) (n int) {
 	return sovTypedeclall(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/both/types.pb.go
+++ b/test/types/combos/both/types.pb.go
@@ -12,6 +12,7 @@ import (
 	types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	time "time"
 )
 
@@ -12045,14 +12046,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/marshaler/types.pb.go
+++ b/test/types/combos/marshaler/types.pb.go
@@ -11,6 +11,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	types "github.com/gogo/protobuf/types"
 	math "math"
+	math_bits "math/bits"
 	time "time"
 )
 
@@ -12044,14 +12045,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/neither/types.pb.go
+++ b/test/types/combos/neither/types.pb.go
@@ -11,6 +11,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	types "github.com/gogo/protobuf/types"
 	math "math"
+	math_bits "math/bits"
 	time "time"
 )
 
@@ -9179,14 +9180,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/unmarshaler/types.pb.go
+++ b/test/types/combos/unmarshaler/types.pb.go
@@ -12,6 +12,7 @@ import (
 	types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	time "time"
 )
 
@@ -9180,14 +9181,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/unrecognized/unrecognized.pb.go
+++ b/test/unrecognized/unrecognized.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -2954,14 +2955,7 @@ func (m *OldU) Size() (n int) {
 }
 
 func sovUnrecognized(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozUnrecognized(x uint64) (n int) {
 	return sovUnrecognized(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/unrecognizedgroup/unrecognizedgroup.pb.go
+++ b/test/unrecognizedgroup/unrecognizedgroup.pb.go
@@ -15,6 +15,7 @@ import (
 	io "io"
 	io_ioutil "io/ioutil"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1413,14 +1414,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovUnrecognizedgroup(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozUnrecognizedgroup(x uint64) (n int) {
 	return sovUnrecognizedgroup(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/any.pb.go
+++ b/types/any.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -455,14 +456,7 @@ func (m *Any) Size() (n int) {
 }
 
 func sovAny(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAny(x uint64) (n int) {
 	return sovAny(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/api.pb.go
+++ b/types/api.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1304,14 +1305,7 @@ func (m *Mixin) Size() (n int) {
 }
 
 func sovApi(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozApi(x uint64) (n int) {
 	return sovApi(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/duration.pb.go
+++ b/types/duration.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -328,14 +329,7 @@ func (m *Duration) Size() (n int) {
 }
 
 func sovDuration(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozDuration(x uint64) (n int) {
 	return sovDuration(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/empty.pb.go
+++ b/types/empty.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -293,14 +294,7 @@ func (m *Empty) Size() (n int) {
 }
 
 func sovEmpty(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozEmpty(x uint64) (n int) {
 	return sovEmpty(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/field_mask.pb.go
+++ b/types/field_mask.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -542,14 +543,7 @@ func (m *FieldMask) Size() (n int) {
 }
 
 func sovFieldMask(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozFieldMask(x uint64) (n int) {
 	return sovFieldMask(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/source_context.pb.go
+++ b/types/source_context.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -321,14 +322,7 @@ func (m *SourceContext) Size() (n int) {
 }
 
 func sovSourceContext(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozSourceContext(x uint64) (n int) {
 	return sovSourceContext(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/struct.pb.go
+++ b/types/struct.pb.go
@@ -11,6 +11,7 @@ import (
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -1303,14 +1304,7 @@ func (m *ListValue) Size() (n int) {
 }
 
 func sovStruct(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozStruct(x uint64) (n int) {
 	return sovStruct(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/timestamp.pb.go
+++ b/types/timestamp.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -348,14 +349,7 @@ func (m *Timestamp) Size() (n int) {
 }
 
 func sovTimestamp(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTimestamp(x uint64) (n int) {
 	return sovTimestamp(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/type.pb.go
+++ b/types/type.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
@@ -2089,14 +2090,7 @@ func (m *Option) Size() (n int) {
 }
 
 func sovType(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozType(x uint64) (n int) {
 	return sovType(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/wrappers.pb.go
+++ b/types/wrappers.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -1803,14 +1804,7 @@ func (m *BytesValue) Size() (n int) {
 }
 
 func sovWrappers(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozWrappers(x uint64) (n int) {
 	return sovWrappers(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/fast/gogovanity.pb.go
+++ b/vanity/test/fast/gogovanity.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -176,14 +177,7 @@ func (m *B) Size() (n int) {
 }
 
 func sovGogovanity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozGogovanity(x uint64) (n int) {
 	return sovGogovanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/fast/proto3.pb.go
+++ b/vanity/test/fast/proto3.pb.go
@@ -8,6 +8,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -137,14 +138,7 @@ func (m *Aproto3) Size() (n int) {
 }
 
 func sovProto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozProto3(x uint64) (n int) {
 	return sovProto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/fast/vanity.pb.go
+++ b/vanity/test/fast/vanity.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -157,14 +158,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovVanity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozVanity(x uint64) (n int) {
 	return sovVanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/faster/gogovanity.pb.go
+++ b/vanity/test/faster/gogovanity.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -164,14 +165,7 @@ func (m *B) Size() (n int) {
 }
 
 func sovGogovanity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozGogovanity(x uint64) (n int) {
 	return sovGogovanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/faster/proto3.pb.go
+++ b/vanity/test/faster/proto3.pb.go
@@ -8,6 +8,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -128,14 +129,7 @@ func (m *Aproto3) Size() (n int) {
 }
 
 func sovProto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozProto3(x uint64) (n int) {
 	return sovProto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/faster/vanity.pb.go
+++ b/vanity/test/faster/vanity.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -139,14 +140,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovVanity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozVanity(x uint64) (n int) {
 	return sovVanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/slick/gogovanity.pb.go
+++ b/vanity/test/slick/gogovanity.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -233,14 +234,7 @@ func (m *B) Size() (n int) {
 }
 
 func sovGogovanity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozGogovanity(x uint64) (n int) {
 	return sovGogovanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/slick/proto3.pb.go
+++ b/vanity/test/slick/proto3.pb.go
@@ -8,6 +8,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -173,14 +174,7 @@ func (m *Aproto3) Size() (n int) {
 }
 
 func sovProto3(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozProto3(x uint64) (n int) {
 	return sovProto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/slick/vanity.pb.go
+++ b/vanity/test/slick/vanity.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 )
@@ -188,14 +189,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovVanity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozVanity(x uint64) (n int) {
 	return sovVanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))


### PR DESCRIPTION
Remove the loop in sovXXX by using bit twiddling.

```
benchmark                                                                  old ns/op     new ns/op     delta
BenchmarkNidOptNativeProtoMarshal-12                                       540           469           -13.15%
BenchmarkNinOptNativeProtoMarshal-12                                       535           481           -10.09%
BenchmarkNidRepNativeProtoMarshal-12                                       1492          1310          -12.20%
BenchmarkNinRepNativeProtoMarshal-12                                       1451          1308          -9.86%
BenchmarkNidRepPackedNativeProtoMarshal-12                                 1565          1426          -8.88%
BenchmarkNinRepPackedNativeProtoMarshal-12                                 1609          1456          -9.51%
BenchmarkNidOptStructProtoMarshal-12                                       1434          1279          -10.81%
BenchmarkNinOptStructProtoMarshal-12                                       1345          1158          -13.90%
BenchmarkNidRepStructProtoMarshal-12                                       2987          2541          -14.93%
BenchmarkNinRepStructProtoMarshal-12                                       2718          2336          -14.05%
BenchmarkNidEmbeddedStructProtoMarshal-12                                  1000          904           -9.60%
BenchmarkNinEmbeddedStructProtoMarshal-12                                  962           825           -14.24%
BenchmarkNidNestedStructProtoMarshal-12                                    7535          6258          -16.95%
BenchmarkNinNestedStructProtoMarshal-12                                    6650          5347          -19.59%
BenchmarkNidOptCustomProtoMarshal-12                                       217           225           +3.69%
BenchmarkCustomDashProtoMarshal-12                                         217           203           -6.45%
BenchmarkNinOptCustomProtoMarshal-12                                       219           226           +3.20%
BenchmarkNidRepCustomProtoMarshal-12                                       492           470           -4.47%
BenchmarkNinRepCustomProtoMarshal-12                                       496           464           -6.45%
BenchmarkNinOptNativeUnionProtoMarshal-12                                  133           135           +1.50%
BenchmarkNinOptStructUnionProtoMarshal-12                                  278           271           -2.52%
BenchmarkNinEmbeddedStructUnionProtoMarshal-12                             472           438           -7.20%
BenchmarkNinNestedStructUnionProtoMarshal-12                               361           329           -8.86%
BenchmarkTreeProtoMarshal-12                                               331           325           -1.81%
BenchmarkOrBranchProtoMarshal-12                                           607           595           -1.98%
BenchmarkAndBranchProtoMarshal-12                                          646           550           -14.86%
BenchmarkLeafProtoMarshal-12                                               261           263           +0.77%
BenchmarkDeepTreeProtoMarshal-12                                           455           452           -0.66%
BenchmarkADeepBranchProtoMarshal-12                                        541           549           +1.48%
BenchmarkAndDeepBranchProtoMarshal-12                                      899           863           -4.00%
BenchmarkDeepLeafProtoMarshal-12                                           427           401           -6.09%
BenchmarkNilProtoMarshal-12                                                124           120           -3.23%
BenchmarkNidOptEnumProtoMarshal-12                                         151           151           +0.00%
BenchmarkNinOptEnumProtoMarshal-12                                         189           187           -1.06%
BenchmarkNidRepEnumProtoMarshal-12                                         344           326           -5.23%
BenchmarkNinRepEnumProtoMarshal-12                                         348           309           -11.21%
BenchmarkNinOptEnumDefaultProtoMarshal-12                                  187           189           +1.07%
BenchmarkAnotherNinOptEnumProtoMarshal-12                                  182           191           +4.95%
BenchmarkAnotherNinOptEnumDefaultProtoMarshal-12                           191           190           -0.52%
BenchmarkTimerProtoMarshal-12                                              234           226           -3.42%
BenchmarkMyExtendableProtoMarshal-12                                       428           422           -1.40%
BenchmarkOtherExtenableProtoMarshal-12                                     831           841           +1.20%
BenchmarkNestedDefinitionProtoMarshal-12                                   524           498           -4.96%
BenchmarkNestedDefinition_NestedMessageProtoMarshal-12                     288           294           +2.08%
BenchmarkNestedDefinition_NestedMessage_NestedNestedMsgProtoMarshal-12     212           211           -0.47%
BenchmarkNestedScopeProtoMarshal-12                                        470           437           -7.02%
BenchmarkNinOptNativeDefaultProtoMarshal-12                                513           448           -12.67%
BenchmarkCustomContainerProtoMarshal-12                                    312           290           -7.05%
BenchmarkCustomNameNidOptNativeProtoMarshal-12                             540           442           -18.15%
BenchmarkCustomNameNinOptNativeProtoMarshal-12                             526           473           -10.08%
BenchmarkCustomNameNinRepNativeProtoMarshal-12                             1502          1341          -10.72%
BenchmarkCustomNameNinStructProtoMarshal-12                                1689          1464          -13.32%
BenchmarkCustomNameCustomTypeProtoMarshal-12                               533           551           +3.38%
BenchmarkCustomNameNinEmbeddedStructUnionProtoMarshal-12                   473           435           -8.03%
BenchmarkCustomNameEnumProtoMarshal-12                                     246           239           -2.85%
BenchmarkNoExtensionsMapProtoMarshal-12                                    261           240           -8.05%
BenchmarkUnrecognizedProtoMarshal-12                                       154           152           -1.30%
BenchmarkUnrecognizedWithInnerProtoMarshal-12                              337           317           -5.93%
BenchmarkUnrecognizedWithInner_InnerProtoMarshal-12                        65.6          63.6          -3.05%
BenchmarkUnrecognizedWithEmbedProtoMarshal-12                              274           264           -3.65%
BenchmarkUnrecognizedWithEmbed_EmbeddedProtoMarshal-12                     65.5          61.4          -6.26%
BenchmarkNodeProtoMarshal-12                                               248           269           +8.47%
BenchmarkNonByteCustomTypeProtoMarshal-12                                  251           264           +5.18%
BenchmarkNidOptNonByteCustomTypeProtoMarshal-12                            289           275           -4.84%
BenchmarkNinOptNonByteCustomTypeProtoMarshal-12                            265           263           -0.75%
BenchmarkNidRepNonByteCustomTypeProtoMarshal-12                            631           597           -5.39%
BenchmarkNinRepNonByteCustomTypeProtoMarshal-12                            594           575           -3.20%
BenchmarkProtoTypeProtoMarshal-12                                          205           216           +5.37%

```