### PR TITLE
Support edge case where proto.Equal received a message with casttype for bytes.

### DIFF
--- a/proto/equal.go
+++ b/proto/equal.go
@@ -202,6 +202,17 @@ func equalAny(v1, v2 reflect.Value, prop *Properties) bool {
 			if v1.IsNil() != v2.IsNil() {
 				return false
 			}
+
+			// Edge case: if field is a cast type of []byte, special conversion
+			// to []byte is required for bytes.Equal.
+			if v1.Type() != reflect.TypeOf([]byte{}) {
+				w1 := reflect.New(reflect.TypeOf([]byte{})).Elem()
+				w2 := reflect.New(reflect.TypeOf([]byte{})).Elem()
+				w1.Set(v1)
+				w2.Set(v2)
+				return bytes.Equal(w1.Interface().([]byte), w2.Interface().([]byte))
+			}
+
 			return bytes.Equal(v1.Interface().([]byte), v2.Interface().([]byte))
 		}
 

--- a/proto/equal_test.go
+++ b/proto/equal_test.go
@@ -37,6 +37,7 @@ import (
 	. "github.com/gogo/protobuf/proto"
 	proto3pb "github.com/gogo/protobuf/proto/proto3_proto"
 	pb "github.com/gogo/protobuf/proto/test_proto"
+	casttypepb "github.com/gogo/protobuf/test/casttype/combos/both"
 )
 
 // Four identical base messages.
@@ -232,6 +233,12 @@ var EqualTests = []struct {
 		&pb.Communique{Union: &pb.Communique_Number{Number: 41}},
 		&pb.Communique{Union: &pb.Communique_Name{Name: "Bobby Tables"}},
 		false,
+	},
+	{
+		"casttype bytes",
+		&casttypepb.Castaway{MyBytes: []byte{0x01}},
+		&casttypepb.Castaway{MyBytes: []byte{0x01}},
+		true,
 	},
 }
 


### PR DESCRIPTION
See the following newly failing test which is now resolved with these changes. 

```
--- FAIL: TestEqual (0.00s)
panic: interface conversion: interface {} is casttype.Bytes, not []uint8 [recovered]
	panic: interface conversion: interface {} is casttype.Bytes, not []uint8

goroutine 34 [running]:
testing.tRunner.func1(0xc0000d0800)
	/usr/local/go/src/testing/testing.go:792 +0x387
panic(0x6d71a0, 0xc0002962d0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/gogo/protobuf/proto.equalAny(0x6d3e40, 0x98f9c0, 0x197, 0x6d3e40, 0x98faa0, 0x197, 0xc0002a4c00, 0x6d3e40)
	/tmp/protobuf/proto/equal.go:216 +0x1a06
github.com/gogo/protobuf/proto.equalStruct(0x719b20, 0x98f980, 0x199, 0x719b20, 0x98fa60, 0x199, 0x445400)
	/tmp/protobuf/proto/equal.go:114 +0x3cd
github.com/gogo/protobuf/proto.Equal(0x778be0, 0x98f980, 0x778be0, 0x98fa60, 0x0)
	/tmp/protobuf/proto/equal.go:92 +0x347
github.com/gogo/protobuf/proto_test.TestEqual(0xc0000d0800)
	/tmp/protobuf/proto/equal_test.go:247 +0x12c
testing.tRunner(0xc0000d0800, 0x73d8c8)
	/usr/local/go/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:878 +0x353
```