### PR TITLE
plugins: Fix code generation for a conflicting oneof

### DIFF
--- a/protoc-gen-gogo/generator/helper.go
+++ b/protoc-gen-gogo/generator/helper.go
@@ -209,6 +209,9 @@ func (g *Generator) GetOneOfFieldName(message *Descriptor, field *descriptor.Fie
 			return fieldname + "_"
 		}
 	}
+	if field.OneofIndex != nil && "Get"+CamelCase(message.OneofDecl[int(*field.OneofIndex)].GetName()) == fieldname {
+		return fieldname + "_"
+	}
 	return fieldname
 }
 


### PR DESCRIPTION
To reproduce the problem that this pull request fixes:

1. Create file `x.proto` with the following contents:
```proto
syntax = "proto3";
message M {
  oneof b {
    bool a = 1;
    bool get_b = 2;  // Conflicts with "oneof b".
  }
}
```
2. Run the following commands:
```shell
go get github.com/gogo/protobuf/protoc-gen-gofast
protoc --gofast_out=. --plugin=$HOME/go/bin/protoc-gen-gofast x.proto
grep M_GetB x.pb.go
```
3. Output will show that `MarshalTo`, `MarshalToSizedBuffer`, `Size`
   all have an incorrectly named receiver, `M_GetB`. It needs to be
   `M_GetB_` instead:
```
	//	*M_GetB_
type M_GetB_ struct {
func (*M_GetB_) isM_B() {}
	if x, ok := m.GetB().(*M_GetB_); ok {
		(*M_GetB_)(nil),
func (m *M_GetB) MarshalTo(dAtA []byte) (int, error) {
func (m *M_GetB) MarshalToSizedBuffer(dAtA []byte) (int, error) {
func (m *M_GetB) Size() (n int) {
			m.B = &M_GetB{b}
```