### PR TITLE
Avoids clashing with globalPackageNames within generatePlugin

### DIFF
--- a/protoc-gen-gogo/generator/helper.go
+++ b/protoc-gen-gogo/generator/helper.go
@@ -357,6 +357,9 @@ func (g *Generator) generatePlugin(file *FileDescriptor, p Plugin) {
 	g.usedPackageNames = make(map[GoPackageName]bool)
 	g.addedImports = make(map[GoImportPath]bool)
 	g.file = file
+	for name := range globalPackageNames {
+		g.usedPackageNames[name] = true
+	}
 
 	// Run the plugins before the imports so we know which imports are necessary.
 	p.Generate(file)


### PR DESCRIPTION
Scenario:
* Generating code via `GeneratePlugin`
* Input proto located at `a/proto/my_service.proto`, with dependency located at `b/proto/their_message.proto`

Issue:
* The `GoType` for `TheirMessage my_field = 1;` resolves to `*proto.TheirMessage`
* Generated Go imports will include global `proto` library, as well as a 2nd entry that clashes: `proto "github.com/them/b/proto"`

This patch fixes the issue.