### PR TITLE
plugin/populate generates variables that are highly likely to clash with package names

### DIFF
--- a/plugin/populate/populate.go
+++ b/plugin/populate/populate.go
@@ -111,11 +111,11 @@ func NewVarGen() VarGen {
 
 func (this *varGen) Next() string {
 	this.index++
-	return fmt.Sprintf("v%d", this.index)
+	return fmt.Sprintf("vAlue%d", this.index)
 }
 
 func (this *varGen) Current() string {
-	return fmt.Sprintf("v%d", this.index)
+	return fmt.Sprintf("vAlue%d", this.index)
 }
 
 type plugin struct {

--- a/test/asymetric-issue125/asym.pb.go
+++ b/test/asymetric-issue125/asym.pb.go
@@ -294,11 +294,11 @@ func encodeVarintAsym(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedM(r randyAsym, easy bool) *M {
 	this := &M{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
-		this.Arr = make([]MyType, v1)
-		for i := 0; i < v1; i++ {
-			v2 := NewPopulatedMyType(r)
-			this.Arr[i] = *v2
+		vAlue1 := r.Intn(10)
+		this.Arr = make([]MyType, vAlue1)
+		for i := 0; i < vAlue1; i++ {
+			vAlue2 := NewPopulatedMyType(r)
+			this.Arr[i] = *vAlue2
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -326,9 +326,9 @@ func randUTF8RuneAsym(r randyAsym) rune {
 	return rune(ru + 61)
 }
 func randStringAsym(r randyAsym) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneAsym(r)
 	}
 	return string(tmps)
@@ -350,11 +350,11 @@ func randFieldAsym(dAtA []byte, r randyAsym, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateAsym(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateAsym(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateAsym(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateAsym(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/casttype/combos/both/casttype.pb.go
+++ b/test/casttype/combos/both/casttype.pb.go
@@ -1291,97 +1291,97 @@ func encodeVarintCasttype(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := int32(r.Int63())
+		vAlue1 := int32(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Int32Ptr = &v1
+		this.Int32Ptr = &vAlue1
 	}
 	this.Int32 = int32(r.Int63())
 	if r.Intn(2) == 0 {
 		this.Int32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
-		this.MyUint64Ptr = &v2
+		vAlue2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		this.MyUint64Ptr = &vAlue2
 	}
 	this.MyUint64 = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 	if r.Intn(5) != 0 {
-		v3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
+		vAlue3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.MyFloat32Ptr = &v3
+		this.MyFloat32Ptr = &vAlue3
 	}
 	this.MyFloat32 = github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 	if r.Intn(2) == 0 {
 		this.MyFloat32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
+		vAlue4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.MyFloat64Ptr = &v4
+		this.MyFloat64Ptr = &vAlue4
 	}
 	this.MyFloat64 = github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 	if r.Intn(2) == 0 {
 		this.MyFloat64 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(100)
-		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(100)
+		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.MyBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(100)
-		this.NormalBytes = make([]byte, v6)
-		for i := 0; i < v6; i++ {
+		vAlue6 := r.Intn(100)
+		this.NormalBytes = make([]byte, vAlue6)
+		for i := 0; i < vAlue6; i++ {
 			this.NormalBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
-		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(10)
+		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.MyUint64S[i] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
-		for i := 0; i < v8; i++ {
-			v9 := randStringCasttype(r)
-			this.MyMap[v9] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringCasttype(r)
+			this.MyMap[vAlue9] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
-		for i := 0; i < v10; i++ {
-			v11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-			this.MyCustomMap[v11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+			this.MyCustomMap[vAlue11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.MyNullableMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]*Wilson)
-		for i := 0; i < v12; i++ {
+		for i := 0; i < vAlue12; i++ {
 			this.MyNullableMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.MyEmbeddedMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]Wilson)
-		for i := 0; i < v13; i++ {
+		for i := 0; i < vAlue13; i++ {
 			this.MyEmbeddedMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = *NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-		this.String_ = &v14
+		vAlue14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+		this.String_ = &vAlue14
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 17)
@@ -1392,11 +1392,11 @@ func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCasttype, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v15 := int64(r.Int63())
+		vAlue15 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v15 *= -1
+			vAlue15 *= -1
 		}
-		this.Int64 = &v15
+		this.Int64 = &vAlue15
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 2)
@@ -1423,9 +1423,9 @@ func randUTF8RuneCasttype(r randyCasttype) rune {
 	return rune(ru + 61)
 }
 func randStringCasttype(r randyCasttype) string {
-	v16 := r.Intn(100)
-	tmps := make([]rune, v16)
-	for i := 0; i < v16; i++ {
+	vAlue16 := r.Intn(100)
+	tmps := make([]rune, vAlue16)
+	for i := 0; i < vAlue16; i++ {
 		tmps[i] = randUTF8RuneCasttype(r)
 	}
 	return string(tmps)
@@ -1447,11 +1447,11 @@ func randFieldCasttype(dAtA []byte, r randyCasttype, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
-		v17 := r.Int63()
+		vAlue17 := r.Int63()
 		if r.Intn(2) == 0 {
-			v17 *= -1
+			vAlue17 *= -1
 		}
-		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(v17))
+		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(vAlue17))
 	case 1:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/casttype/combos/marshaler/casttype.pb.go
+++ b/test/casttype/combos/marshaler/casttype.pb.go
@@ -1290,97 +1290,97 @@ func encodeVarintCasttype(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := int32(r.Int63())
+		vAlue1 := int32(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Int32Ptr = &v1
+		this.Int32Ptr = &vAlue1
 	}
 	this.Int32 = int32(r.Int63())
 	if r.Intn(2) == 0 {
 		this.Int32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
-		this.MyUint64Ptr = &v2
+		vAlue2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		this.MyUint64Ptr = &vAlue2
 	}
 	this.MyUint64 = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 	if r.Intn(5) != 0 {
-		v3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
+		vAlue3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.MyFloat32Ptr = &v3
+		this.MyFloat32Ptr = &vAlue3
 	}
 	this.MyFloat32 = github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 	if r.Intn(2) == 0 {
 		this.MyFloat32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
+		vAlue4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.MyFloat64Ptr = &v4
+		this.MyFloat64Ptr = &vAlue4
 	}
 	this.MyFloat64 = github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 	if r.Intn(2) == 0 {
 		this.MyFloat64 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(100)
-		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(100)
+		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.MyBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(100)
-		this.NormalBytes = make([]byte, v6)
-		for i := 0; i < v6; i++ {
+		vAlue6 := r.Intn(100)
+		this.NormalBytes = make([]byte, vAlue6)
+		for i := 0; i < vAlue6; i++ {
 			this.NormalBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
-		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(10)
+		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.MyUint64S[i] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
-		for i := 0; i < v8; i++ {
-			v9 := randStringCasttype(r)
-			this.MyMap[v9] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringCasttype(r)
+			this.MyMap[vAlue9] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
-		for i := 0; i < v10; i++ {
-			v11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-			this.MyCustomMap[v11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+			this.MyCustomMap[vAlue11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.MyNullableMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]*Wilson)
-		for i := 0; i < v12; i++ {
+		for i := 0; i < vAlue12; i++ {
 			this.MyNullableMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.MyEmbeddedMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]Wilson)
-		for i := 0; i < v13; i++ {
+		for i := 0; i < vAlue13; i++ {
 			this.MyEmbeddedMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = *NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-		this.String_ = &v14
+		vAlue14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+		this.String_ = &vAlue14
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 17)
@@ -1391,11 +1391,11 @@ func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCasttype, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v15 := int64(r.Int63())
+		vAlue15 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v15 *= -1
+			vAlue15 *= -1
 		}
-		this.Int64 = &v15
+		this.Int64 = &vAlue15
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 2)
@@ -1422,9 +1422,9 @@ func randUTF8RuneCasttype(r randyCasttype) rune {
 	return rune(ru + 61)
 }
 func randStringCasttype(r randyCasttype) string {
-	v16 := r.Intn(100)
-	tmps := make([]rune, v16)
-	for i := 0; i < v16; i++ {
+	vAlue16 := r.Intn(100)
+	tmps := make([]rune, vAlue16)
+	for i := 0; i < vAlue16; i++ {
 		tmps[i] = randUTF8RuneCasttype(r)
 	}
 	return string(tmps)
@@ -1446,11 +1446,11 @@ func randFieldCasttype(dAtA []byte, r randyCasttype, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
-		v17 := r.Int63()
+		vAlue17 := r.Int63()
 		if r.Intn(2) == 0 {
-			v17 *= -1
+			vAlue17 *= -1
 		}
-		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(v17))
+		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(vAlue17))
 	case 1:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/casttype/combos/neither/casttype.pb.go
+++ b/test/casttype/combos/neither/casttype.pb.go
@@ -1055,97 +1055,97 @@ func valueToGoStringCasttype(v interface{}, typ string) string {
 func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := int32(r.Int63())
+		vAlue1 := int32(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Int32Ptr = &v1
+		this.Int32Ptr = &vAlue1
 	}
 	this.Int32 = int32(r.Int63())
 	if r.Intn(2) == 0 {
 		this.Int32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
-		this.MyUint64Ptr = &v2
+		vAlue2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		this.MyUint64Ptr = &vAlue2
 	}
 	this.MyUint64 = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 	if r.Intn(5) != 0 {
-		v3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
+		vAlue3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.MyFloat32Ptr = &v3
+		this.MyFloat32Ptr = &vAlue3
 	}
 	this.MyFloat32 = github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 	if r.Intn(2) == 0 {
 		this.MyFloat32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
+		vAlue4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.MyFloat64Ptr = &v4
+		this.MyFloat64Ptr = &vAlue4
 	}
 	this.MyFloat64 = github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 	if r.Intn(2) == 0 {
 		this.MyFloat64 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(100)
-		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(100)
+		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.MyBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(100)
-		this.NormalBytes = make([]byte, v6)
-		for i := 0; i < v6; i++ {
+		vAlue6 := r.Intn(100)
+		this.NormalBytes = make([]byte, vAlue6)
+		for i := 0; i < vAlue6; i++ {
 			this.NormalBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
-		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(10)
+		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.MyUint64S[i] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
-		for i := 0; i < v8; i++ {
-			v9 := randStringCasttype(r)
-			this.MyMap[v9] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringCasttype(r)
+			this.MyMap[vAlue9] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
-		for i := 0; i < v10; i++ {
-			v11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-			this.MyCustomMap[v11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+			this.MyCustomMap[vAlue11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.MyNullableMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]*Wilson)
-		for i := 0; i < v12; i++ {
+		for i := 0; i < vAlue12; i++ {
 			this.MyNullableMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.MyEmbeddedMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]Wilson)
-		for i := 0; i < v13; i++ {
+		for i := 0; i < vAlue13; i++ {
 			this.MyEmbeddedMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = *NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-		this.String_ = &v14
+		vAlue14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+		this.String_ = &vAlue14
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 17)
@@ -1156,11 +1156,11 @@ func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCasttype, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v15 := int64(r.Int63())
+		vAlue15 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v15 *= -1
+			vAlue15 *= -1
 		}
-		this.Int64 = &v15
+		this.Int64 = &vAlue15
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 2)
@@ -1187,9 +1187,9 @@ func randUTF8RuneCasttype(r randyCasttype) rune {
 	return rune(ru + 61)
 }
 func randStringCasttype(r randyCasttype) string {
-	v16 := r.Intn(100)
-	tmps := make([]rune, v16)
-	for i := 0; i < v16; i++ {
+	vAlue16 := r.Intn(100)
+	tmps := make([]rune, vAlue16)
+	for i := 0; i < vAlue16; i++ {
 		tmps[i] = randUTF8RuneCasttype(r)
 	}
 	return string(tmps)
@@ -1211,11 +1211,11 @@ func randFieldCasttype(dAtA []byte, r randyCasttype, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
-		v17 := r.Int63()
+		vAlue17 := r.Int63()
 		if r.Intn(2) == 0 {
-			v17 *= -1
+			vAlue17 *= -1
 		}
-		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(v17))
+		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(vAlue17))
 	case 1:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/casttype/combos/unmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unmarshaler/casttype.pb.go
@@ -1057,97 +1057,97 @@ func valueToGoStringCasttype(v interface{}, typ string) string {
 func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := int32(r.Int63())
+		vAlue1 := int32(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Int32Ptr = &v1
+		this.Int32Ptr = &vAlue1
 	}
 	this.Int32 = int32(r.Int63())
 	if r.Intn(2) == 0 {
 		this.Int32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
-		this.MyUint64Ptr = &v2
+		vAlue2 := github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		this.MyUint64Ptr = &vAlue2
 	}
 	this.MyUint64 = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 	if r.Intn(5) != 0 {
-		v3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
+		vAlue3 := github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.MyFloat32Ptr = &v3
+		this.MyFloat32Ptr = &vAlue3
 	}
 	this.MyFloat32 = github_com_gogo_protobuf_test_casttype.MyFloat32Type(r.Float32())
 	if r.Intn(2) == 0 {
 		this.MyFloat32 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
+		vAlue4 := github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.MyFloat64Ptr = &v4
+		this.MyFloat64Ptr = &vAlue4
 	}
 	this.MyFloat64 = github_com_gogo_protobuf_test_casttype.MyFloat64Type(r.Float64())
 	if r.Intn(2) == 0 {
 		this.MyFloat64 *= -1
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(100)
-		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(100)
+		this.MyBytes = make(github_com_gogo_protobuf_test_casttype.Bytes, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.MyBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(100)
-		this.NormalBytes = make([]byte, v6)
-		for i := 0; i < v6; i++ {
+		vAlue6 := r.Intn(100)
+		this.NormalBytes = make([]byte, vAlue6)
+		for i := 0; i < vAlue6; i++ {
 			this.NormalBytes[i] = byte(r.Intn(256))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
-		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(10)
+		this.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.MyUint64S[i] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.MyMap = make(github_com_gogo_protobuf_test_casttype.MyMapType)
-		for i := 0; i < v8; i++ {
-			v9 := randStringCasttype(r)
-			this.MyMap[v9] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringCasttype(r)
+			this.MyMap[vAlue9] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.MyCustomMap = make(map[github_com_gogo_protobuf_test_casttype.MyStringType]github_com_gogo_protobuf_test_casttype.MyUint64Type)
-		for i := 0; i < v10; i++ {
-			v11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-			this.MyCustomMap[v11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+			this.MyCustomMap[vAlue11] = github_com_gogo_protobuf_test_casttype.MyUint64Type(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.MyNullableMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]*Wilson)
-		for i := 0; i < v12; i++ {
+		for i := 0; i < vAlue12; i++ {
 			this.MyNullableMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.MyEmbeddedMap = make(map[github_com_gogo_protobuf_test_casttype.MyInt32Type]Wilson)
-		for i := 0; i < v13; i++ {
+		for i := 0; i < vAlue13; i++ {
 			this.MyEmbeddedMap[github_com_gogo_protobuf_test_casttype.MyInt32Type(int32(r.Int31()))] = *NewPopulatedWilson(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
-		this.String_ = &v14
+		vAlue14 := github_com_gogo_protobuf_test_casttype.MyStringType(randStringCasttype(r))
+		this.String_ = &vAlue14
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 17)
@@ -1158,11 +1158,11 @@ func NewPopulatedCastaway(r randyCasttype, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCasttype, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v15 := int64(r.Int63())
+		vAlue15 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v15 *= -1
+			vAlue15 *= -1
 		}
-		this.Int64 = &v15
+		this.Int64 = &vAlue15
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCasttype(r, 2)
@@ -1189,9 +1189,9 @@ func randUTF8RuneCasttype(r randyCasttype) rune {
 	return rune(ru + 61)
 }
 func randStringCasttype(r randyCasttype) string {
-	v16 := r.Intn(100)
-	tmps := make([]rune, v16)
-	for i := 0; i < v16; i++ {
+	vAlue16 := r.Intn(100)
+	tmps := make([]rune, vAlue16)
+	for i := 0; i < vAlue16; i++ {
 		tmps[i] = randUTF8RuneCasttype(r)
 	}
 	return string(tmps)
@@ -1213,11 +1213,11 @@ func randFieldCasttype(dAtA []byte, r randyCasttype, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
-		v17 := r.Int63()
+		vAlue17 := r.Int63()
 		if r.Intn(2) == 0 {
-			v17 *= -1
+			vAlue17 *= -1
 		}
-		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(v17))
+		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(vAlue17))
 	case 1:
 		dAtA = encodeVarintPopulateCasttype(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/castvalue/castvalue.pb.go
+++ b/test/castvalue/castvalue.pb.go
@@ -687,16 +687,16 @@ func valueToGoStringCastvalue(v interface{}, typ string) string {
 func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.CastMapValueMessage = make(map[int32]MyWilson)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.CastMapValueMessage[int32(r.Int31())] = (MyWilson)(*NewPopulatedWilson(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.CastMapValueMessageNullable = make(map[int32]*MyWilson)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.CastMapValueMessageNullable[int32(r.Int31())] = (*MyWilson)(NewPopulatedWilson(r, easy))
 		}
 	}
@@ -709,11 +709,11 @@ func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCastvalue, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Int64 = &v3
+		this.Int64 = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCastvalue(r, 2)
@@ -740,9 +740,9 @@ func randUTF8RuneCastvalue(r randyCastvalue) rune {
 	return rune(ru + 61)
 }
 func randStringCastvalue(r randyCastvalue) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneCastvalue(r)
 	}
 	return string(tmps)
@@ -764,11 +764,11 @@ func randFieldCastvalue(dAtA []byte, r randyCastvalue, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/castvalue/combos/both/castvalue.pb.go
+++ b/test/castvalue/combos/both/castvalue.pb.go
@@ -823,16 +823,16 @@ func encodeVarintCastvalue(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.CastMapValueMessage = make(map[int32]MyWilson)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.CastMapValueMessage[int32(r.Int31())] = (MyWilson)(*NewPopulatedWilson(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.CastMapValueMessageNullable = make(map[int32]*MyWilson)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.CastMapValueMessageNullable[int32(r.Int31())] = (*MyWilson)(NewPopulatedWilson(r, easy))
 		}
 	}
@@ -845,11 +845,11 @@ func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCastvalue, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Int64 = &v3
+		this.Int64 = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCastvalue(r, 2)
@@ -876,9 +876,9 @@ func randUTF8RuneCastvalue(r randyCastvalue) rune {
 	return rune(ru + 61)
 }
 func randStringCastvalue(r randyCastvalue) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneCastvalue(r)
 	}
 	return string(tmps)
@@ -900,11 +900,11 @@ func randFieldCastvalue(dAtA []byte, r randyCastvalue, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/castvalue/combos/marshaler/castvalue.pb.go
+++ b/test/castvalue/combos/marshaler/castvalue.pb.go
@@ -822,16 +822,16 @@ func encodeVarintCastvalue(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.CastMapValueMessage = make(map[int32]MyWilson)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.CastMapValueMessage[int32(r.Int31())] = (MyWilson)(*NewPopulatedWilson(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.CastMapValueMessageNullable = make(map[int32]*MyWilson)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.CastMapValueMessageNullable[int32(r.Int31())] = (*MyWilson)(NewPopulatedWilson(r, easy))
 		}
 	}
@@ -844,11 +844,11 @@ func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCastvalue, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Int64 = &v3
+		this.Int64 = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCastvalue(r, 2)
@@ -875,9 +875,9 @@ func randUTF8RuneCastvalue(r randyCastvalue) rune {
 	return rune(ru + 61)
 }
 func randStringCastvalue(r randyCastvalue) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneCastvalue(r)
 	}
 	return string(tmps)
@@ -899,11 +899,11 @@ func randFieldCastvalue(dAtA []byte, r randyCastvalue, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/castvalue/combos/unmarshaler/castvalue.pb.go
+++ b/test/castvalue/combos/unmarshaler/castvalue.pb.go
@@ -689,16 +689,16 @@ func valueToGoStringCastvalue(v interface{}, typ string) string {
 func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 	this := &Castaway{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.CastMapValueMessage = make(map[int32]MyWilson)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.CastMapValueMessage[int32(r.Int31())] = (MyWilson)(*NewPopulatedWilson(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.CastMapValueMessageNullable = make(map[int32]*MyWilson)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.CastMapValueMessageNullable[int32(r.Int31())] = (*MyWilson)(NewPopulatedWilson(r, easy))
 		}
 	}
@@ -711,11 +711,11 @@ func NewPopulatedCastaway(r randyCastvalue, easy bool) *Castaway {
 func NewPopulatedWilson(r randyCastvalue, easy bool) *Wilson {
 	this := &Wilson{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Int64 = &v3
+		this.Int64 = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedCastvalue(r, 2)
@@ -742,9 +742,9 @@ func randUTF8RuneCastvalue(r randyCastvalue) rune {
 	return rune(ru + 61)
 }
 func randStringCastvalue(r randyCastvalue) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneCastvalue(r)
 	}
 	return string(tmps)
@@ -766,11 +766,11 @@ func randFieldCastvalue(dAtA []byte, r randyCastvalue, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateCastvalue(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -26651,9 +26651,9 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 	}
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -26665,89 +26665,89 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 	this := &NinOptNative{}
 	if r.Intn(5) != 0 {
-		v2 := float64(r.Float64())
+		vAlue2 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := float32(r.Float32())
+		vAlue3 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field2 = &v3
+		this.Field2 = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := int32(r.Int31())
+		vAlue4 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field3 = &v4
+		this.Field3 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
-		v5 := int64(r.Int63())
+		vAlue5 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		this.Field4 = &v5
+		this.Field4 = &vAlue5
 	}
 	if r.Intn(5) != 0 {
-		v6 := uint32(r.Uint32())
-		this.Field5 = &v6
+		vAlue6 := uint32(r.Uint32())
+		this.Field5 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v7
+		vAlue7 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue7
 	}
 	if r.Intn(5) != 0 {
-		v8 := int32(r.Int31())
+		vAlue8 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v8 *= -1
+			vAlue8 *= -1
 		}
-		this.Field7 = &v8
+		this.Field7 = &vAlue8
 	}
 	if r.Intn(5) != 0 {
-		v9 := int64(r.Int63())
+		vAlue9 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		this.Field8 = &v9
+		this.Field8 = &vAlue9
 	}
 	if r.Intn(5) != 0 {
-		v10 := uint32(r.Uint32())
-		this.Field9 = &v10
+		vAlue10 := uint32(r.Uint32())
+		this.Field9 = &vAlue10
 	}
 	if r.Intn(5) != 0 {
-		v11 := int32(r.Int31())
+		vAlue11 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v11 *= -1
+			vAlue11 *= -1
 		}
-		this.Field10 = &v11
+		this.Field10 = &vAlue11
 	}
 	if r.Intn(5) != 0 {
-		v12 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v12
+		vAlue12 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue12
 	}
 	if r.Intn(5) != 0 {
-		v13 := int64(r.Int63())
+		vAlue13 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v13 *= -1
+			vAlue13 *= -1
 		}
-		this.Field12 = &v13
+		this.Field12 = &vAlue13
 	}
 	if r.Intn(5) != 0 {
-		v14 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v14
+		vAlue14 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue14
 	}
 	if r.Intn(5) != 0 {
-		v15 := string(randStringThetest(r))
-		this.Field14 = &v15
+		vAlue15 := string(randStringThetest(r))
+		this.Field14 = &vAlue15
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(100)
-		this.Field15 = make([]byte, v16)
-		for i := 0; i < v16; i++ {
+		vAlue16 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue16)
+		for i := 0; i < vAlue16; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -26760,9 +26760,9 @@ func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 	this := &NidRepNative{}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
-		this.Field1 = make([]float64, v17)
-		for i := 0; i < v17; i++ {
+		vAlue17 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue17)
+		for i := 0; i < vAlue17; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -26770,9 +26770,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
-		this.Field2 = make([]float32, v18)
-		for i := 0; i < v18; i++ {
+		vAlue18 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue18)
+		for i := 0; i < vAlue18; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -26780,9 +26780,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
-		this.Field3 = make([]int32, v19)
-		for i := 0; i < v19; i++ {
+		vAlue19 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue19)
+		for i := 0; i < vAlue19; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -26790,9 +26790,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
-		this.Field4 = make([]int64, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -26800,23 +26800,23 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
-		this.Field5 = make([]uint32, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
-		this.Field6 = make([]uint64, v22)
-		for i := 0; i < v22; i++ {
+		vAlue22 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue22)
+		for i := 0; i < vAlue22; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
-		this.Field7 = make([]int32, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -26824,9 +26824,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
-		this.Field8 = make([]int64, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -26834,16 +26834,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
-		this.Field9 = make([]uint32, v25)
-		for i := 0; i < v25; i++ {
+		vAlue25 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue25)
+		for i := 0; i < vAlue25; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
-		this.Field10 = make([]int32, v26)
-		for i := 0; i < v26; i++ {
+		vAlue26 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue26)
+		for i := 0; i < vAlue26; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -26851,16 +26851,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
-		this.Field11 = make([]uint64, v27)
-		for i := 0; i < v27; i++ {
+		vAlue27 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue27)
+		for i := 0; i < vAlue27; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
-		this.Field12 = make([]int64, v28)
-		for i := 0; i < v28; i++ {
+		vAlue28 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue28)
+		for i := 0; i < vAlue28; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -26868,26 +26868,26 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
-		this.Field13 = make([]bool, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
-		this.Field14 = make([]string, v30)
-		for i := 0; i < v30; i++ {
+		vAlue30 := r.Intn(10)
+		this.Field14 = make([]string, vAlue30)
+		for i := 0; i < vAlue30; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
-		this.Field15 = make([][]byte, v31)
-		for i := 0; i < v31; i++ {
-			v32 := r.Intn(100)
-			this.Field15[i] = make([]byte, v32)
-			for j := 0; j < v32; j++ {
+		vAlue31 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue31)
+		for i := 0; i < vAlue31; i++ {
+			vAlue32 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue32)
+			for j := 0; j < vAlue32; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -26901,9 +26901,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 	this := &NinRepNative{}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
-		this.Field1 = make([]float64, v33)
-		for i := 0; i < v33; i++ {
+		vAlue33 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue33)
+		for i := 0; i < vAlue33; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -26911,9 +26911,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v34 := r.Intn(10)
-		this.Field2 = make([]float32, v34)
-		for i := 0; i < v34; i++ {
+		vAlue34 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue34)
+		for i := 0; i < vAlue34; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -26921,9 +26921,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
-		this.Field3 = make([]int32, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -26931,9 +26931,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
-		this.Field4 = make([]int64, v36)
-		for i := 0; i < v36; i++ {
+		vAlue36 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue36)
+		for i := 0; i < vAlue36; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -26941,23 +26941,23 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
-		this.Field5 = make([]uint32, v37)
-		for i := 0; i < v37; i++ {
+		vAlue37 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue37)
+		for i := 0; i < vAlue37; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
-		this.Field6 = make([]uint64, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
-		this.Field7 = make([]int32, v39)
-		for i := 0; i < v39; i++ {
+		vAlue39 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue39)
+		for i := 0; i < vAlue39; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -26965,9 +26965,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
-		this.Field8 = make([]int64, v40)
-		for i := 0; i < v40; i++ {
+		vAlue40 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue40)
+		for i := 0; i < vAlue40; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -26975,16 +26975,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
-		this.Field9 = make([]uint32, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
-		this.Field10 = make([]int32, v42)
-		for i := 0; i < v42; i++ {
+		vAlue42 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue42)
+		for i := 0; i < vAlue42; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -26992,16 +26992,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
-		this.Field11 = make([]uint64, v43)
-		for i := 0; i < v43; i++ {
+		vAlue43 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue43)
+		for i := 0; i < vAlue43; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
-		this.Field12 = make([]int64, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -27009,26 +27009,26 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
-		this.Field13 = make([]bool, v45)
-		for i := 0; i < v45; i++ {
+		vAlue45 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue45)
+		for i := 0; i < vAlue45; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
-		this.Field14 = make([]string, v46)
-		for i := 0; i < v46; i++ {
+		vAlue46 := r.Intn(10)
+		this.Field14 = make([]string, vAlue46)
+		for i := 0; i < vAlue46; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
-		this.Field15 = make([][]byte, v47)
-		for i := 0; i < v47; i++ {
-			v48 := r.Intn(100)
-			this.Field15[i] = make([]byte, v48)
-			for j := 0; j < v48; j++ {
+		vAlue47 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue47)
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue48)
+			for j := 0; j < vAlue48; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -27042,9 +27042,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNative {
 	this := &NidRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
-		this.Field1 = make([]float64, v49)
-		for i := 0; i < v49; i++ {
+		vAlue49 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue49)
+		for i := 0; i < vAlue49; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27052,9 +27052,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
-		this.Field2 = make([]float32, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27062,9 +27062,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
-		this.Field3 = make([]int32, v51)
-		for i := 0; i < v51; i++ {
+		vAlue51 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue51)
+		for i := 0; i < vAlue51; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -27072,9 +27072,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
-		this.Field4 = make([]int64, v52)
-		for i := 0; i < v52; i++ {
+		vAlue52 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue52)
+		for i := 0; i < vAlue52; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -27082,23 +27082,23 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
-		this.Field5 = make([]uint32, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
-		this.Field6 = make([]uint64, v54)
-		for i := 0; i < v54; i++ {
+		vAlue54 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue54)
+		for i := 0; i < vAlue54; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
-		this.Field7 = make([]int32, v55)
-		for i := 0; i < v55; i++ {
+		vAlue55 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue55)
+		for i := 0; i < vAlue55; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27106,9 +27106,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
-		this.Field8 = make([]int64, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -27116,16 +27116,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
-		this.Field9 = make([]uint32, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
-		this.Field10 = make([]int32, v58)
-		for i := 0; i < v58; i++ {
+		vAlue58 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue58)
+		for i := 0; i < vAlue58; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -27133,16 +27133,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
-		this.Field11 = make([]uint64, v59)
-		for i := 0; i < v59; i++ {
+		vAlue59 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue59)
+		for i := 0; i < vAlue59; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
-		this.Field12 = make([]int64, v60)
-		for i := 0; i < v60; i++ {
+		vAlue60 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue60)
+		for i := 0; i < vAlue60; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -27150,9 +27150,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
-		this.Field13 = make([]bool, v61)
-		for i := 0; i < v61; i++ {
+		vAlue61 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue61)
+		for i := 0; i < vAlue61; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -27165,9 +27165,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNative {
 	this := &NinRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
-		this.Field1 = make([]float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27175,9 +27175,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
-		this.Field2 = make([]float32, v63)
-		for i := 0; i < v63; i++ {
+		vAlue63 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue63)
+		for i := 0; i < vAlue63; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27185,9 +27185,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
-		this.Field3 = make([]int32, v64)
-		for i := 0; i < v64; i++ {
+		vAlue64 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue64)
+		for i := 0; i < vAlue64; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -27195,9 +27195,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
-		this.Field4 = make([]int64, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -27205,23 +27205,23 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(10)
-		this.Field5 = make([]uint32, v66)
-		for i := 0; i < v66; i++ {
+		vAlue66 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
-		this.Field6 = make([]uint64, v67)
-		for i := 0; i < v67; i++ {
+		vAlue67 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue67)
+		for i := 0; i < vAlue67; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
-		this.Field7 = make([]int32, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27229,9 +27229,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
-		this.Field8 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
+		vAlue69 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -27239,16 +27239,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
-		this.Field9 = make([]uint32, v70)
-		for i := 0; i < v70; i++ {
+		vAlue70 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue70)
+		for i := 0; i < vAlue70; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
-		this.Field10 = make([]int32, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -27256,16 +27256,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(10)
-		this.Field11 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
+		vAlue72 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v73 := r.Intn(10)
-		this.Field12 = make([]int64, v73)
-		for i := 0; i < v73; i++ {
+		vAlue73 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue73)
+		for i := 0; i < vAlue73; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -27273,9 +27273,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(10)
-		this.Field13 = make([]bool, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -27295,22 +27295,22 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 	if r.Intn(2) == 0 {
 		this.Field2 *= -1
 	}
-	v75 := NewPopulatedNidOptNative(r, easy)
-	this.Field3 = *v75
-	v76 := NewPopulatedNinOptNative(r, easy)
-	this.Field4 = *v76
+	vAlue75 := NewPopulatedNidOptNative(r, easy)
+	this.Field3 = *vAlue75
+	vAlue76 := NewPopulatedNinOptNative(r, easy)
+	this.Field4 = *vAlue76
 	this.Field6 = uint64(uint64(r.Uint32()))
 	this.Field7 = int32(r.Int31())
 	if r.Intn(2) == 0 {
 		this.Field7 *= -1
 	}
-	v77 := NewPopulatedNidOptNative(r, easy)
-	this.Field8 = *v77
+	vAlue77 := NewPopulatedNidOptNative(r, easy)
+	this.Field8 = *vAlue77
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v78 := r.Intn(100)
-	this.Field15 = make([]byte, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27322,18 +27322,18 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 	this := &NinOptStruct{}
 	if r.Intn(5) != 0 {
-		v79 := float64(r.Float64())
+		vAlue79 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		this.Field1 = &v79
+		this.Field1 = &vAlue79
 	}
 	if r.Intn(5) != 0 {
-		v80 := float32(r.Float32())
+		vAlue80 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v80 *= -1
+			vAlue80 *= -1
 		}
-		this.Field2 = &v80
+		this.Field2 = &vAlue80
 	}
 	if r.Intn(5) != 0 {
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
@@ -27342,31 +27342,31 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v81 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v81
+		vAlue81 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue81
 	}
 	if r.Intn(5) != 0 {
-		v82 := int32(r.Int31())
+		vAlue82 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v82 *= -1
+			vAlue82 *= -1
 		}
-		this.Field7 = &v82
+		this.Field7 = &vAlue82
 	}
 	if r.Intn(5) != 0 {
 		this.Field8 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v83 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v83
+		vAlue83 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue83
 	}
 	if r.Intn(5) != 0 {
-		v84 := string(randStringThetest(r))
-		this.Field14 = &v84
+		vAlue84 := string(randStringThetest(r))
+		this.Field14 = &vAlue84
 	}
 	if r.Intn(5) != 0 {
-		v85 := r.Intn(100)
-		this.Field15 = make([]byte, v85)
-		for i := 0; i < v85; i++ {
+		vAlue85 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue85)
+		for i := 0; i < vAlue85; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -27379,9 +27379,9 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 	this := &NidRepStruct{}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(10)
-		this.Field1 = make([]float64, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27389,9 +27389,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(10)
-		this.Field2 = make([]float32, v87)
-		for i := 0; i < v87; i++ {
+		vAlue87 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue87)
+		for i := 0; i < vAlue87; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27399,32 +27399,32 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v88 := r.Intn(5)
-		this.Field3 = make([]NidOptNative, v88)
-		for i := 0; i < v88; i++ {
-			v89 := NewPopulatedNidOptNative(r, easy)
-			this.Field3[i] = *v89
+		vAlue88 := r.Intn(5)
+		this.Field3 = make([]NidOptNative, vAlue88)
+		for i := 0; i < vAlue88; i++ {
+			vAlue89 := NewPopulatedNidOptNative(r, easy)
+			this.Field3[i] = *vAlue89
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(5)
-		this.Field4 = make([]NinOptNative, v90)
-		for i := 0; i < v90; i++ {
-			v91 := NewPopulatedNinOptNative(r, easy)
-			this.Field4[i] = *v91
+		vAlue90 := r.Intn(5)
+		this.Field4 = make([]NinOptNative, vAlue90)
+		for i := 0; i < vAlue90; i++ {
+			vAlue91 := NewPopulatedNinOptNative(r, easy)
+			this.Field4[i] = *vAlue91
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
-		this.Field6 = make([]uint64, v92)
-		for i := 0; i < v92; i++ {
+		vAlue92 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue92)
+		for i := 0; i < vAlue92; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
-		this.Field7 = make([]int32, v93)
-		for i := 0; i < v93; i++ {
+		vAlue93 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue93)
+		for i := 0; i < vAlue93; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27432,34 +27432,34 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(5)
-		this.Field8 = make([]NidOptNative, v94)
-		for i := 0; i < v94; i++ {
-			v95 := NewPopulatedNidOptNative(r, easy)
-			this.Field8[i] = *v95
+		vAlue94 := r.Intn(5)
+		this.Field8 = make([]NidOptNative, vAlue94)
+		for i := 0; i < vAlue94; i++ {
+			vAlue95 := NewPopulatedNidOptNative(r, easy)
+			this.Field8[i] = *vAlue95
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
-		this.Field13 = make([]bool, v96)
-		for i := 0; i < v96; i++ {
+		vAlue96 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue96)
+		for i := 0; i < vAlue96; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
-		this.Field14 = make([]string, v97)
-		for i := 0; i < v97; i++ {
+		vAlue97 := r.Intn(10)
+		this.Field14 = make([]string, vAlue97)
+		for i := 0; i < vAlue97; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
-		this.Field15 = make([][]byte, v98)
-		for i := 0; i < v98; i++ {
-			v99 := r.Intn(100)
-			this.Field15[i] = make([]byte, v99)
-			for j := 0; j < v99; j++ {
+		vAlue98 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue98)
+		for i := 0; i < vAlue98; i++ {
+			vAlue99 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue99)
+			for j := 0; j < vAlue99; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -27473,9 +27473,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 	this := &NinRepStruct{}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
-		this.Field1 = make([]float64, v100)
-		for i := 0; i < v100; i++ {
+		vAlue100 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue100)
+		for i := 0; i < vAlue100; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27483,9 +27483,9 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
-		this.Field2 = make([]float32, v101)
-		for i := 0; i < v101; i++ {
+		vAlue101 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue101)
+		for i := 0; i < vAlue101; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27493,30 +27493,30 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(5)
-		this.Field3 = make([]*NidOptNative, v102)
-		for i := 0; i < v102; i++ {
+		vAlue102 := r.Intn(5)
+		this.Field3 = make([]*NidOptNative, vAlue102)
+		for i := 0; i < vAlue102; i++ {
 			this.Field3[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(5)
-		this.Field4 = make([]*NinOptNative, v103)
-		for i := 0; i < v103; i++ {
+		vAlue103 := r.Intn(5)
+		this.Field4 = make([]*NinOptNative, vAlue103)
+		for i := 0; i < vAlue103; i++ {
 			this.Field4[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
-		this.Field6 = make([]uint64, v104)
-		for i := 0; i < v104; i++ {
+		vAlue104 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue104)
+		for i := 0; i < vAlue104; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
-		this.Field7 = make([]int32, v105)
-		for i := 0; i < v105; i++ {
+		vAlue105 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue105)
+		for i := 0; i < vAlue105; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27524,33 +27524,33 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(5)
-		this.Field8 = make([]*NidOptNative, v106)
-		for i := 0; i < v106; i++ {
+		vAlue106 := r.Intn(5)
+		this.Field8 = make([]*NidOptNative, vAlue106)
+		for i := 0; i < vAlue106; i++ {
 			this.Field8[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
-		this.Field13 = make([]bool, v107)
-		for i := 0; i < v107; i++ {
+		vAlue107 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue107)
+		for i := 0; i < vAlue107; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
-		this.Field14 = make([]string, v108)
-		for i := 0; i < v108; i++ {
+		vAlue108 := r.Intn(10)
+		this.Field14 = make([]string, vAlue108)
+		for i := 0; i < vAlue108; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
-		this.Field15 = make([][]byte, v109)
-		for i := 0; i < v109; i++ {
-			v110 := r.Intn(100)
-			this.Field15[i] = make([]byte, v110)
-			for j := 0; j < v110; j++ {
+		vAlue109 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue109)
+		for i := 0; i < vAlue109; i++ {
+			vAlue110 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue110)
+			for j := 0; j < vAlue110; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -27566,8 +27566,8 @@ func NewPopulatedNidEmbeddedStruct(r randyThetest, easy bool) *NidEmbeddedStruct
 	if r.Intn(5) != 0 {
 		this.NidOptNative = NewPopulatedNidOptNative(r, easy)
 	}
-	v111 := NewPopulatedNidOptNative(r, easy)
-	this.Field200 = *v111
+	vAlue111 := NewPopulatedNidOptNative(r, easy)
+	this.Field200 = *vAlue111
 	this.Field210 = bool(bool(r.Intn(2) == 0))
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -27584,8 +27584,8 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 		this.Field200 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v112 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v112
+		vAlue112 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue112
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -27595,14 +27595,14 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 
 func NewPopulatedNidNestedStruct(r randyThetest, easy bool) *NidNestedStruct {
 	this := &NidNestedStruct{}
-	v113 := NewPopulatedNidOptStruct(r, easy)
-	this.Field1 = *v113
+	vAlue113 := NewPopulatedNidOptStruct(r, easy)
+	this.Field1 = *vAlue113
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(5)
-		this.Field2 = make([]NidRepStruct, v114)
-		for i := 0; i < v114; i++ {
-			v115 := NewPopulatedNidRepStruct(r, easy)
-			this.Field2[i] = *v115
+		vAlue114 := r.Intn(5)
+		this.Field2 = make([]NidRepStruct, vAlue114)
+		for i := 0; i < vAlue114; i++ {
+			vAlue115 := NewPopulatedNidRepStruct(r, easy)
+			this.Field2[i] = *vAlue115
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27617,9 +27617,9 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 		this.Field1 = NewPopulatedNinOptStruct(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(5)
-		this.Field2 = make([]*NinRepStruct, v116)
-		for i := 0; i < v116; i++ {
+		vAlue116 := r.Intn(5)
+		this.Field2 = make([]*NinRepStruct, vAlue116)
+		for i := 0; i < vAlue116; i++ {
 			this.Field2[i] = NewPopulatedNinRepStruct(r, easy)
 		}
 	}
@@ -27631,10 +27631,10 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 
 func NewPopulatedNidOptCustom(r randyThetest, easy bool) *NidOptCustom {
 	this := &NidOptCustom{}
-	v117 := NewPopulatedUuid(r)
-	this.Id = *v117
-	v118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Value = *v118
+	vAlue117 := NewPopulatedUuid(r)
+	this.Id = *vAlue117
+	vAlue118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Value = *vAlue118
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27669,19 +27669,19 @@ func NewPopulatedNinOptCustom(r randyThetest, easy bool) *NinOptCustom {
 func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 	this := &NidRepCustom{}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
-		this.Id = make([]Uuid, v119)
-		for i := 0; i < v119; i++ {
-			v120 := NewPopulatedUuid(r)
-			this.Id[i] = *v120
+		vAlue119 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue119)
+		for i := 0; i < vAlue119; i++ {
+			vAlue120 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue120
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v121)
-		for i := 0; i < v121; i++ {
-			v122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v122
+		vAlue121 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue121)
+		for i := 0; i < vAlue121; i++ {
+			vAlue122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue122
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27693,19 +27693,19 @@ func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 func NewPopulatedNinRepCustom(r randyThetest, easy bool) *NinRepCustom {
 	this := &NinRepCustom{}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
-		this.Id = make([]Uuid, v123)
-		for i := 0; i < v123; i++ {
-			v124 := NewPopulatedUuid(r)
-			this.Id[i] = *v124
+		vAlue123 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue123)
+		for i := 0; i < vAlue123; i++ {
+			vAlue124 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue124
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v125)
-		for i := 0; i < v125; i++ {
-			v126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v126
+		vAlue125 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue125)
+		for i := 0; i < vAlue125; i++ {
+			vAlue126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue126
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27719,45 +27719,45 @@ func NewPopulatedNinOptNativeUnion(r randyThetest, easy bool) *NinOptNativeUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v127 := float64(r.Float64())
+		vAlue127 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v127 *= -1
+			vAlue127 *= -1
 		}
-		this.Field1 = &v127
+		this.Field1 = &vAlue127
 	case 1:
-		v128 := float32(r.Float32())
+		vAlue128 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v128 *= -1
+			vAlue128 *= -1
 		}
-		this.Field2 = &v128
+		this.Field2 = &vAlue128
 	case 2:
-		v129 := int32(r.Int31())
+		vAlue129 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v129 *= -1
+			vAlue129 *= -1
 		}
-		this.Field3 = &v129
+		this.Field3 = &vAlue129
 	case 3:
-		v130 := int64(r.Int63())
+		vAlue130 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v130 *= -1
+			vAlue130 *= -1
 		}
-		this.Field4 = &v130
+		this.Field4 = &vAlue130
 	case 4:
-		v131 := uint32(r.Uint32())
-		this.Field5 = &v131
+		vAlue131 := uint32(r.Uint32())
+		this.Field5 = &vAlue131
 	case 5:
-		v132 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v132
+		vAlue132 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue132
 	case 6:
-		v133 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v133
+		vAlue133 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue133
 	case 7:
-		v134 := string(randStringThetest(r))
-		this.Field14 = &v134
+		vAlue134 := string(randStringThetest(r))
+		this.Field14 = &vAlue134
 	case 8:
-		v135 := r.Intn(100)
-		this.Field15 = make([]byte, v135)
-		for i := 0; i < v135; i++ {
+		vAlue135 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue135)
+		for i := 0; i < vAlue135; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -27769,40 +27769,40 @@ func NewPopulatedNinOptStructUnion(r randyThetest, easy bool) *NinOptStructUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v136 := float64(r.Float64())
+		vAlue136 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v136 *= -1
+			vAlue136 *= -1
 		}
-		this.Field1 = &v136
+		this.Field1 = &vAlue136
 	case 1:
-		v137 := float32(r.Float32())
+		vAlue137 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v137 *= -1
+			vAlue137 *= -1
 		}
-		this.Field2 = &v137
+		this.Field2 = &vAlue137
 	case 2:
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
 	case 3:
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	case 4:
-		v138 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v138
+		vAlue138 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue138
 	case 5:
-		v139 := int32(r.Int31())
+		vAlue139 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v139 *= -1
+			vAlue139 *= -1
 		}
-		this.Field7 = &v139
+		this.Field7 = &vAlue139
 	case 6:
-		v140 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v140
+		vAlue140 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue140
 	case 7:
-		v141 := string(randStringThetest(r))
-		this.Field14 = &v141
+		vAlue141 := string(randStringThetest(r))
+		this.Field14 = &vAlue141
 	case 8:
-		v142 := r.Intn(100)
-		this.Field15 = make([]byte, v142)
-		for i := 0; i < v142; i++ {
+		vAlue142 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue142)
+		for i := 0; i < vAlue142; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -27818,8 +27818,8 @@ func NewPopulatedNinEmbeddedStructUnion(r randyThetest, easy bool) *NinEmbeddedS
 	case 1:
 		this.Field200 = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v143 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v143
+		vAlue143 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue143
 	}
 	return this
 }
@@ -27854,10 +27854,10 @@ func NewPopulatedTree(r randyThetest, easy bool) *Tree {
 
 func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 	this := &OrBranch{}
-	v144 := NewPopulatedTree(r, easy)
-	this.Left = *v144
-	v145 := NewPopulatedTree(r, easy)
-	this.Right = *v145
+	vAlue144 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue144
+	vAlue145 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue145
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27866,10 +27866,10 @@ func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 
 func NewPopulatedAndBranch(r randyThetest, easy bool) *AndBranch {
 	this := &AndBranch{}
-	v146 := NewPopulatedTree(r, easy)
-	this.Left = *v146
-	v147 := NewPopulatedTree(r, easy)
-	this.Right = *v147
+	vAlue146 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue146
+	vAlue147 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue147
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27905,8 +27905,8 @@ func NewPopulatedDeepTree(r randyThetest, easy bool) *DeepTree {
 
 func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 	this := &ADeepBranch{}
-	v148 := NewPopulatedDeepTree(r, easy)
-	this.Down = *v148
+	vAlue148 := NewPopulatedDeepTree(r, easy)
+	this.Down = *vAlue148
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27915,10 +27915,10 @@ func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 
 func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 	this := &AndDeepBranch{}
-	v149 := NewPopulatedDeepTree(r, easy)
-	this.Left = *v149
-	v150 := NewPopulatedDeepTree(r, easy)
-	this.Right = *v150
+	vAlue149 := NewPopulatedDeepTree(r, easy)
+	this.Left = *vAlue149
+	vAlue150 := NewPopulatedDeepTree(r, easy)
+	this.Right = *vAlue150
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27927,8 +27927,8 @@ func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 
 func NewPopulatedDeepLeaf(r randyThetest, easy bool) *DeepLeaf {
 	this := &DeepLeaf{}
-	v151 := NewPopulatedTree(r, easy)
-	this.Tree = *v151
+	vAlue151 := NewPopulatedTree(r, easy)
+	this.Tree = *vAlue151
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -27955,16 +27955,16 @@ func NewPopulatedNidOptEnum(r randyThetest, easy bool) *NidOptEnum {
 func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 	this := &NinOptEnum{}
 	if r.Intn(5) != 0 {
-		v152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v152
+		vAlue152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue152
 	}
 	if r.Intn(5) != 0 {
-		v153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v153
+		vAlue153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue153
 	}
 	if r.Intn(5) != 0 {
-		v154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v154
+		vAlue154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue154
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -27975,23 +27975,23 @@ func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 	this := &NidRepEnum{}
 	if r.Intn(5) != 0 {
-		v155 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v155)
-		for i := 0; i < v155; i++ {
+		vAlue155 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue155)
+		for i := 0; i < vAlue155; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v156 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v156)
-		for i := 0; i < v156; i++ {
+		vAlue156 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue156)
+		for i := 0; i < vAlue156; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v157 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v157)
-		for i := 0; i < v157; i++ {
+		vAlue157 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue157)
+		for i := 0; i < vAlue157; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -28004,23 +28004,23 @@ func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 	this := &NinRepEnum{}
 	if r.Intn(5) != 0 {
-		v158 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v158)
-		for i := 0; i < v158; i++ {
+		vAlue158 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue158)
+		for i := 0; i < vAlue158; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v159 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v159)
-		for i := 0; i < v159; i++ {
+		vAlue159 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue159)
+		for i := 0; i < vAlue159; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v160 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v160)
-		for i := 0; i < v160; i++ {
+		vAlue160 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue160)
+		for i := 0; i < vAlue160; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -28033,16 +28033,16 @@ func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault {
 	this := &NinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v161
+		vAlue161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue161
 	}
 	if r.Intn(5) != 0 {
-		v162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v162
+		vAlue162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue162
 	}
 	if r.Intn(5) != 0 {
-		v163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v163
+		vAlue163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue163
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -28053,16 +28053,16 @@ func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault
 func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum {
 	this := &AnotherNinOptEnum{}
 	if r.Intn(5) != 0 {
-		v164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v164
+		vAlue164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue164
 	}
 	if r.Intn(5) != 0 {
-		v165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v165
+		vAlue165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue165
 	}
 	if r.Intn(5) != 0 {
-		v166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v166
+		vAlue166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue166
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -28073,16 +28073,16 @@ func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum
 func NewPopulatedAnotherNinOptEnumDefault(r randyThetest, easy bool) *AnotherNinOptEnumDefault {
 	this := &AnotherNinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v167
+		vAlue167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue167
 	}
 	if r.Intn(5) != 0 {
-		v168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v168
+		vAlue168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue168
 	}
 	if r.Intn(5) != 0 {
-		v169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v169
+		vAlue169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue169
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -28100,9 +28100,9 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 	if r.Intn(2) == 0 {
 		this.Time2 *= -1
 	}
-	v170 := r.Intn(100)
-	this.Data = make([]byte, v170)
-	for i := 0; i < v170; i++ {
+	vAlue170 := r.Intn(100)
+	this.Data = make([]byte, vAlue170)
+	for i := 0; i < vAlue170; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28114,11 +28114,11 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 func NewPopulatedMyExtendable(r randyThetest, easy bool) *MyExtendable {
 	this := &MyExtendable{}
 	if r.Intn(5) != 0 {
-		v171 := int64(r.Int63())
+		vAlue171 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v171 *= -1
+			vAlue171 *= -1
 		}
-		this.Field1 = &v171
+		this.Field1 = &vAlue171
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -28144,18 +28144,18 @@ func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 		this.M = NewPopulatedMyExtendable(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v172 := int64(r.Int63())
+		vAlue172 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v172 *= -1
+			vAlue172 *= -1
 		}
-		this.Field2 = &v172
+		this.Field2 = &vAlue172
 	}
 	if r.Intn(5) != 0 {
-		v173 := int64(r.Int63())
+		vAlue173 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v173 *= -1
+			vAlue173 *= -1
 		}
-		this.Field13 = &v173
+		this.Field13 = &vAlue173
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -28185,15 +28185,15 @@ func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 	this := &NestedDefinition{}
 	if r.Intn(5) != 0 {
-		v174 := int64(r.Int63())
+		vAlue174 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v174 *= -1
+			vAlue174 *= -1
 		}
-		this.Field1 = &v174
+		this.Field1 = &vAlue174
 	}
 	if r.Intn(5) != 0 {
-		v175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.EnumField = &v175
+		vAlue175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.EnumField = &vAlue175
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -28210,8 +28210,8 @@ func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *NestedDefinition_NestedMessage {
 	this := &NestedDefinition_NestedMessage{}
 	if r.Intn(5) != 0 {
-		v176 := uint64(uint64(r.Uint32()))
-		this.NestedField1 = &v176
+		vAlue176 := uint64(uint64(r.Uint32()))
+		this.NestedField1 = &vAlue176
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -28225,8 +28225,8 @@ func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *Nest
 func NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r randyThetest, easy bool) *NestedDefinition_NestedMessage_NestedNestedMsg {
 	this := &NestedDefinition_NestedMessage_NestedNestedMsg{}
 	if r.Intn(5) != 0 {
-		v177 := string(randStringThetest(r))
-		this.NestedNestedField1 = &v177
+		vAlue177 := string(randStringThetest(r))
+		this.NestedNestedField1 = &vAlue177
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 11)
@@ -28240,8 +28240,8 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 		this.A = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.B = &v178
+		vAlue178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.B = &vAlue178
 	}
 	if r.Intn(5) != 0 {
 		this.C = NewPopulatedNestedDefinition_NestedMessage(r, easy)
@@ -28255,89 +28255,89 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDefault {
 	this := &NinOptNativeDefault{}
 	if r.Intn(5) != 0 {
-		v179 := float64(r.Float64())
+		vAlue179 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v179 *= -1
+			vAlue179 *= -1
 		}
-		this.Field1 = &v179
+		this.Field1 = &vAlue179
 	}
 	if r.Intn(5) != 0 {
-		v180 := float32(r.Float32())
+		vAlue180 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v180 *= -1
+			vAlue180 *= -1
 		}
-		this.Field2 = &v180
+		this.Field2 = &vAlue180
 	}
 	if r.Intn(5) != 0 {
-		v181 := int32(r.Int31())
+		vAlue181 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v181 *= -1
+			vAlue181 *= -1
 		}
-		this.Field3 = &v181
+		this.Field3 = &vAlue181
 	}
 	if r.Intn(5) != 0 {
-		v182 := int64(r.Int63())
+		vAlue182 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v182 *= -1
+			vAlue182 *= -1
 		}
-		this.Field4 = &v182
+		this.Field4 = &vAlue182
 	}
 	if r.Intn(5) != 0 {
-		v183 := uint32(r.Uint32())
-		this.Field5 = &v183
+		vAlue183 := uint32(r.Uint32())
+		this.Field5 = &vAlue183
 	}
 	if r.Intn(5) != 0 {
-		v184 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v184
+		vAlue184 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue184
 	}
 	if r.Intn(5) != 0 {
-		v185 := int32(r.Int31())
+		vAlue185 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v185 *= -1
+			vAlue185 *= -1
 		}
-		this.Field7 = &v185
+		this.Field7 = &vAlue185
 	}
 	if r.Intn(5) != 0 {
-		v186 := int64(r.Int63())
+		vAlue186 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v186 *= -1
+			vAlue186 *= -1
 		}
-		this.Field8 = &v186
+		this.Field8 = &vAlue186
 	}
 	if r.Intn(5) != 0 {
-		v187 := uint32(r.Uint32())
-		this.Field9 = &v187
+		vAlue187 := uint32(r.Uint32())
+		this.Field9 = &vAlue187
 	}
 	if r.Intn(5) != 0 {
-		v188 := int32(r.Int31())
+		vAlue188 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v188 *= -1
+			vAlue188 *= -1
 		}
-		this.Field10 = &v188
+		this.Field10 = &vAlue188
 	}
 	if r.Intn(5) != 0 {
-		v189 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v189
+		vAlue189 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue189
 	}
 	if r.Intn(5) != 0 {
-		v190 := int64(r.Int63())
+		vAlue190 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v190 *= -1
+			vAlue190 *= -1
 		}
-		this.Field12 = &v190
+		this.Field12 = &vAlue190
 	}
 	if r.Intn(5) != 0 {
-		v191 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v191
+		vAlue191 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue191
 	}
 	if r.Intn(5) != 0 {
-		v192 := string(randStringThetest(r))
-		this.Field14 = &v192
+		vAlue192 := string(randStringThetest(r))
+		this.Field14 = &vAlue192
 	}
 	if r.Intn(5) != 0 {
-		v193 := r.Intn(100)
-		this.Field15 = make([]byte, v193)
-		for i := 0; i < v193; i++ {
+		vAlue193 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue193)
+		for i := 0; i < vAlue193; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -28349,8 +28349,8 @@ func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDef
 
 func NewPopulatedCustomContainer(r randyThetest, easy bool) *CustomContainer {
 	this := &CustomContainer{}
-	v194 := NewPopulatedNidOptCustom(r, easy)
-	this.CustomStruct = *v194
+	vAlue194 := NewPopulatedNidOptCustom(r, easy)
+	this.CustomStruct = *vAlue194
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -28397,9 +28397,9 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 	}
 	this.FieldM = bool(bool(r.Intn(2) == 0))
 	this.FieldN = string(randStringThetest(r))
-	v195 := r.Intn(100)
-	this.FieldO = make([]byte, v195)
-	for i := 0; i < v195; i++ {
+	vAlue195 := r.Intn(100)
+	this.FieldO = make([]byte, vAlue195)
+	for i := 0; i < vAlue195; i++ {
 		this.FieldO[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28411,89 +28411,89 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNinOptNative {
 	this := &CustomNameNinOptNative{}
 	if r.Intn(5) != 0 {
-		v196 := float64(r.Float64())
+		vAlue196 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v196 *= -1
+			vAlue196 *= -1
 		}
-		this.FieldA = &v196
+		this.FieldA = &vAlue196
 	}
 	if r.Intn(5) != 0 {
-		v197 := float32(r.Float32())
+		vAlue197 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v197 *= -1
+			vAlue197 *= -1
 		}
-		this.FieldB = &v197
+		this.FieldB = &vAlue197
 	}
 	if r.Intn(5) != 0 {
-		v198 := int32(r.Int31())
+		vAlue198 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v198 *= -1
+			vAlue198 *= -1
 		}
-		this.FieldC = &v198
+		this.FieldC = &vAlue198
 	}
 	if r.Intn(5) != 0 {
-		v199 := int64(r.Int63())
+		vAlue199 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v199 *= -1
+			vAlue199 *= -1
 		}
-		this.FieldD = &v199
+		this.FieldD = &vAlue199
 	}
 	if r.Intn(5) != 0 {
-		v200 := uint32(r.Uint32())
-		this.FieldE = &v200
+		vAlue200 := uint32(r.Uint32())
+		this.FieldE = &vAlue200
 	}
 	if r.Intn(5) != 0 {
-		v201 := uint64(uint64(r.Uint32()))
-		this.FieldF = &v201
+		vAlue201 := uint64(uint64(r.Uint32()))
+		this.FieldF = &vAlue201
 	}
 	if r.Intn(5) != 0 {
-		v202 := int32(r.Int31())
+		vAlue202 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v202 *= -1
+			vAlue202 *= -1
 		}
-		this.FieldG = &v202
+		this.FieldG = &vAlue202
 	}
 	if r.Intn(5) != 0 {
-		v203 := int64(r.Int63())
+		vAlue203 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v203 *= -1
+			vAlue203 *= -1
 		}
-		this.FieldH = &v203
+		this.FieldH = &vAlue203
 	}
 	if r.Intn(5) != 0 {
-		v204 := uint32(r.Uint32())
-		this.FieldI = &v204
+		vAlue204 := uint32(r.Uint32())
+		this.FieldI = &vAlue204
 	}
 	if r.Intn(5) != 0 {
-		v205 := int32(r.Int31())
+		vAlue205 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v205 *= -1
+			vAlue205 *= -1
 		}
-		this.FieldJ = &v205
+		this.FieldJ = &vAlue205
 	}
 	if r.Intn(5) != 0 {
-		v206 := uint64(uint64(r.Uint32()))
-		this.FieldK = &v206
+		vAlue206 := uint64(uint64(r.Uint32()))
+		this.FieldK = &vAlue206
 	}
 	if r.Intn(5) != 0 {
-		v207 := int64(r.Int63())
+		vAlue207 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v207 *= -1
+			vAlue207 *= -1
 		}
-		this.FielL = &v207
+		this.FielL = &vAlue207
 	}
 	if r.Intn(5) != 0 {
-		v208 := bool(bool(r.Intn(2) == 0))
-		this.FieldM = &v208
+		vAlue208 := bool(bool(r.Intn(2) == 0))
+		this.FieldM = &vAlue208
 	}
 	if r.Intn(5) != 0 {
-		v209 := string(randStringThetest(r))
-		this.FieldN = &v209
+		vAlue209 := string(randStringThetest(r))
+		this.FieldN = &vAlue209
 	}
 	if r.Intn(5) != 0 {
-		v210 := r.Intn(100)
-		this.FieldO = make([]byte, v210)
-		for i := 0; i < v210; i++ {
+		vAlue210 := r.Intn(100)
+		this.FieldO = make([]byte, vAlue210)
+		for i := 0; i < vAlue210; i++ {
 			this.FieldO[i] = byte(r.Intn(256))
 		}
 	}
@@ -28506,9 +28506,9 @@ func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNinRepNative {
 	this := &CustomNameNinRepNative{}
 	if r.Intn(5) != 0 {
-		v211 := r.Intn(10)
-		this.FieldA = make([]float64, v211)
-		for i := 0; i < v211; i++ {
+		vAlue211 := r.Intn(10)
+		this.FieldA = make([]float64, vAlue211)
+		for i := 0; i < vAlue211; i++ {
 			this.FieldA[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.FieldA[i] *= -1
@@ -28516,9 +28516,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v212 := r.Intn(10)
-		this.FieldB = make([]float32, v212)
-		for i := 0; i < v212; i++ {
+		vAlue212 := r.Intn(10)
+		this.FieldB = make([]float32, vAlue212)
+		for i := 0; i < vAlue212; i++ {
 			this.FieldB[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.FieldB[i] *= -1
@@ -28526,9 +28526,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v213 := r.Intn(10)
-		this.FieldC = make([]int32, v213)
-		for i := 0; i < v213; i++ {
+		vAlue213 := r.Intn(10)
+		this.FieldC = make([]int32, vAlue213)
+		for i := 0; i < vAlue213; i++ {
 			this.FieldC[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldC[i] *= -1
@@ -28536,9 +28536,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v214 := r.Intn(10)
-		this.FieldD = make([]int64, v214)
-		for i := 0; i < v214; i++ {
+		vAlue214 := r.Intn(10)
+		this.FieldD = make([]int64, vAlue214)
+		for i := 0; i < vAlue214; i++ {
 			this.FieldD[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldD[i] *= -1
@@ -28546,23 +28546,23 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v215 := r.Intn(10)
-		this.FieldE = make([]uint32, v215)
-		for i := 0; i < v215; i++ {
+		vAlue215 := r.Intn(10)
+		this.FieldE = make([]uint32, vAlue215)
+		for i := 0; i < vAlue215; i++ {
 			this.FieldE[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v216 := r.Intn(10)
-		this.FieldF = make([]uint64, v216)
-		for i := 0; i < v216; i++ {
+		vAlue216 := r.Intn(10)
+		this.FieldF = make([]uint64, vAlue216)
+		for i := 0; i < vAlue216; i++ {
 			this.FieldF[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v217 := r.Intn(10)
-		this.FieldG = make([]int32, v217)
-		for i := 0; i < v217; i++ {
+		vAlue217 := r.Intn(10)
+		this.FieldG = make([]int32, vAlue217)
+		for i := 0; i < vAlue217; i++ {
 			this.FieldG[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldG[i] *= -1
@@ -28570,9 +28570,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v218 := r.Intn(10)
-		this.FieldH = make([]int64, v218)
-		for i := 0; i < v218; i++ {
+		vAlue218 := r.Intn(10)
+		this.FieldH = make([]int64, vAlue218)
+		for i := 0; i < vAlue218; i++ {
 			this.FieldH[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldH[i] *= -1
@@ -28580,16 +28580,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v219 := r.Intn(10)
-		this.FieldI = make([]uint32, v219)
-		for i := 0; i < v219; i++ {
+		vAlue219 := r.Intn(10)
+		this.FieldI = make([]uint32, vAlue219)
+		for i := 0; i < vAlue219; i++ {
 			this.FieldI[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v220 := r.Intn(10)
-		this.FieldJ = make([]int32, v220)
-		for i := 0; i < v220; i++ {
+		vAlue220 := r.Intn(10)
+		this.FieldJ = make([]int32, vAlue220)
+		for i := 0; i < vAlue220; i++ {
 			this.FieldJ[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldJ[i] *= -1
@@ -28597,16 +28597,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v221 := r.Intn(10)
-		this.FieldK = make([]uint64, v221)
-		for i := 0; i < v221; i++ {
+		vAlue221 := r.Intn(10)
+		this.FieldK = make([]uint64, vAlue221)
+		for i := 0; i < vAlue221; i++ {
 			this.FieldK[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v222 := r.Intn(10)
-		this.FieldL = make([]int64, v222)
-		for i := 0; i < v222; i++ {
+		vAlue222 := r.Intn(10)
+		this.FieldL = make([]int64, vAlue222)
+		for i := 0; i < vAlue222; i++ {
 			this.FieldL[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldL[i] *= -1
@@ -28614,26 +28614,26 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v223 := r.Intn(10)
-		this.FieldM = make([]bool, v223)
-		for i := 0; i < v223; i++ {
+		vAlue223 := r.Intn(10)
+		this.FieldM = make([]bool, vAlue223)
+		for i := 0; i < vAlue223; i++ {
 			this.FieldM[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v224 := r.Intn(10)
-		this.FieldN = make([]string, v224)
-		for i := 0; i < v224; i++ {
+		vAlue224 := r.Intn(10)
+		this.FieldN = make([]string, vAlue224)
+		for i := 0; i < vAlue224; i++ {
 			this.FieldN[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v225 := r.Intn(10)
-		this.FieldO = make([][]byte, v225)
-		for i := 0; i < v225; i++ {
-			v226 := r.Intn(100)
-			this.FieldO[i] = make([]byte, v226)
-			for j := 0; j < v226; j++ {
+		vAlue225 := r.Intn(10)
+		this.FieldO = make([][]byte, vAlue225)
+		for i := 0; i < vAlue225; i++ {
+			vAlue226 := r.Intn(100)
+			this.FieldO[i] = make([]byte, vAlue226)
+			for j := 0; j < vAlue226; j++ {
 				this.FieldO[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -28647,55 +28647,55 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinStruct(r randyThetest, easy bool) *CustomNameNinStruct {
 	this := &CustomNameNinStruct{}
 	if r.Intn(5) != 0 {
-		v227 := float64(r.Float64())
+		vAlue227 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v227 *= -1
+			vAlue227 *= -1
 		}
-		this.FieldA = &v227
+		this.FieldA = &vAlue227
 	}
 	if r.Intn(5) != 0 {
-		v228 := float32(r.Float32())
+		vAlue228 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v228 *= -1
+			vAlue228 *= -1
 		}
-		this.FieldB = &v228
+		this.FieldB = &vAlue228
 	}
 	if r.Intn(5) != 0 {
 		this.FieldC = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v229 := r.Intn(5)
-		this.FieldD = make([]*NinOptNative, v229)
-		for i := 0; i < v229; i++ {
+		vAlue229 := r.Intn(5)
+		this.FieldD = make([]*NinOptNative, vAlue229)
+		for i := 0; i < vAlue229; i++ {
 			this.FieldD[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v230 := uint64(uint64(r.Uint32()))
-		this.FieldE = &v230
+		vAlue230 := uint64(uint64(r.Uint32()))
+		this.FieldE = &vAlue230
 	}
 	if r.Intn(5) != 0 {
-		v231 := int32(r.Int31())
+		vAlue231 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v231 *= -1
+			vAlue231 *= -1
 		}
-		this.FieldF = &v231
+		this.FieldF = &vAlue231
 	}
 	if r.Intn(5) != 0 {
 		this.FieldG = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v232 := bool(bool(r.Intn(2) == 0))
-		this.FieldH = &v232
+		vAlue232 := bool(bool(r.Intn(2) == 0))
+		this.FieldH = &vAlue232
 	}
 	if r.Intn(5) != 0 {
-		v233 := string(randStringThetest(r))
-		this.FieldI = &v233
+		vAlue233 := string(randStringThetest(r))
+		this.FieldI = &vAlue233
 	}
 	if r.Intn(5) != 0 {
-		v234 := r.Intn(100)
-		this.FieldJ = make([]byte, v234)
-		for i := 0; i < v234; i++ {
+		vAlue234 := r.Intn(100)
+		this.FieldJ = make([]byte, vAlue234)
+		for i := 0; i < vAlue234; i++ {
 			this.FieldJ[i] = byte(r.Intn(256))
 		}
 	}
@@ -28714,19 +28714,19 @@ func NewPopulatedCustomNameCustomType(r randyThetest, easy bool) *CustomNameCust
 		this.FieldB = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	}
 	if r.Intn(5) != 0 {
-		v235 := r.Intn(10)
-		this.FieldC = make([]Uuid, v235)
-		for i := 0; i < v235; i++ {
-			v236 := NewPopulatedUuid(r)
-			this.FieldC[i] = *v236
+		vAlue235 := r.Intn(10)
+		this.FieldC = make([]Uuid, vAlue235)
+		for i := 0; i < vAlue235; i++ {
+			vAlue236 := NewPopulatedUuid(r)
+			this.FieldC[i] = *vAlue236
 		}
 	}
 	if r.Intn(5) != 0 {
-		v237 := r.Intn(10)
-		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, v237)
-		for i := 0; i < v237; i++ {
-			v238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.FieldD[i] = *v238
+		vAlue237 := r.Intn(10)
+		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue237)
+		for i := 0; i < vAlue237; i++ {
+			vAlue238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.FieldD[i] = *vAlue238
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28744,8 +28744,8 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 	case 1:
 		this.FieldA = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v239 := bool(bool(r.Intn(2) == 0))
-		this.FieldB = &v239
+		vAlue239 := bool(bool(r.Intn(2) == 0))
+		this.FieldB = &vAlue239
 	}
 	return this
 }
@@ -28753,13 +28753,13 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 	this := &CustomNameEnum{}
 	if r.Intn(5) != 0 {
-		v240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.FieldA = &v240
+		vAlue240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.FieldA = &vAlue240
 	}
 	if r.Intn(5) != 0 {
-		v241 := r.Intn(10)
-		this.FieldB = make([]TheTestEnum, v241)
-		for i := 0; i < v241; i++ {
+		vAlue241 := r.Intn(10)
+		this.FieldB = make([]TheTestEnum, vAlue241)
+		for i := 0; i < vAlue241; i++ {
 			this.FieldB[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
@@ -28772,11 +28772,11 @@ func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 	this := &NoExtensionsMap{}
 	if r.Intn(5) != 0 {
-		v242 := int64(r.Int63())
+		vAlue242 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v242 *= -1
+			vAlue242 *= -1
 		}
-		this.Field1 = &v242
+		this.Field1 = &vAlue242
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -28799,8 +28799,8 @@ func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 	this := &Unrecognized{}
 	if r.Intn(5) != 0 {
-		v243 := string(randStringThetest(r))
-		this.Field1 = &v243
+		vAlue243 := string(randStringThetest(r))
+		this.Field1 = &vAlue243
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -28810,15 +28810,15 @@ func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedWithInner {
 	this := &UnrecognizedWithInner{}
 	if r.Intn(5) != 0 {
-		v244 := r.Intn(5)
-		this.Embedded = make([]*UnrecognizedWithInner_Inner, v244)
-		for i := 0; i < v244; i++ {
+		vAlue244 := r.Intn(5)
+		this.Embedded = make([]*UnrecognizedWithInner_Inner, vAlue244)
+		for i := 0; i < vAlue244; i++ {
 			this.Embedded[i] = NewPopulatedUnrecognizedWithInner_Inner(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v245 := string(randStringThetest(r))
-		this.Field2 = &v245
+		vAlue245 := string(randStringThetest(r))
+		this.Field2 = &vAlue245
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -28829,8 +28829,8 @@ func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *UnrecognizedWithInner_Inner {
 	this := &UnrecognizedWithInner_Inner{}
 	if r.Intn(5) != 0 {
-		v246 := uint32(r.Uint32())
-		this.Field1 = &v246
+		vAlue246 := uint32(r.Uint32())
+		this.Field1 = &vAlue246
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -28839,11 +28839,11 @@ func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *Unrecog
 
 func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedWithEmbed {
 	this := &UnrecognizedWithEmbed{}
-	v247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
-	this.UnrecognizedWithEmbed_Embedded = *v247
+	vAlue247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
+	this.UnrecognizedWithEmbed_Embedded = *vAlue247
 	if r.Intn(5) != 0 {
-		v248 := string(randStringThetest(r))
-		this.Field2 = &v248
+		vAlue248 := string(randStringThetest(r))
+		this.Field2 = &vAlue248
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -28854,8 +28854,8 @@ func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *UnrecognizedWithEmbed_Embedded {
 	this := &UnrecognizedWithEmbed_Embedded{}
 	if r.Intn(5) != 0 {
-		v249 := uint32(r.Uint32())
-		this.Field1 = &v249
+		vAlue249 := uint32(r.Uint32())
+		this.Field1 = &vAlue249
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -28865,13 +28865,13 @@ func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *Unre
 func NewPopulatedNode(r randyThetest, easy bool) *Node {
 	this := &Node{}
 	if r.Intn(5) != 0 {
-		v250 := string(randStringThetest(r))
-		this.Label = &v250
+		vAlue250 := string(randStringThetest(r))
+		this.Label = &vAlue250
 	}
 	if r.Intn(5) == 0 {
-		v251 := r.Intn(5)
-		this.Children = make([]*Node, v251)
-		for i := 0; i < v251; i++ {
+		vAlue251 := r.Intn(5)
+		this.Children = make([]*Node, vAlue251)
+		for i := 0; i < vAlue251; i++ {
 			this.Children[i] = NewPopulatedNode(r, easy)
 		}
 	}
@@ -28894,8 +28894,8 @@ func NewPopulatedNonByteCustomType(r randyThetest, easy bool) *NonByteCustomType
 
 func NewPopulatedNidOptNonByteCustomType(r randyThetest, easy bool) *NidOptNonByteCustomType {
 	this := &NidOptNonByteCustomType{}
-	v252 := NewPopulatedT(r)
-	this.Field1 = *v252
+	vAlue252 := NewPopulatedT(r)
+	this.Field1 = *vAlue252
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -28916,11 +28916,11 @@ func NewPopulatedNinOptNonByteCustomType(r randyThetest, easy bool) *NinOptNonBy
 func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonByteCustomType {
 	this := &NidRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v253 := r.Intn(10)
-		this.Field1 = make([]T, v253)
-		for i := 0; i < v253; i++ {
-			v254 := NewPopulatedT(r)
-			this.Field1[i] = *v254
+		vAlue253 := r.Intn(10)
+		this.Field1 = make([]T, vAlue253)
+		for i := 0; i < vAlue253; i++ {
+			vAlue254 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue254
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28932,11 +28932,11 @@ func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonBy
 func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonByteCustomType {
 	this := &NinRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v255 := r.Intn(10)
-		this.Field1 = make([]T, v255)
-		for i := 0; i < v255; i++ {
-			v256 := NewPopulatedT(r)
-			this.Field1[i] = *v256
+		vAlue255 := r.Intn(10)
+		this.Field1 = make([]T, vAlue255)
+		for i := 0; i < vAlue255; i++ {
+			vAlue256 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue256
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28948,8 +28948,8 @@ func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonBy
 func NewPopulatedProtoType(r randyThetest, easy bool) *ProtoType {
 	this := &ProtoType{}
 	if r.Intn(5) != 0 {
-		v257 := string(randStringThetest(r))
-		this.Field2 = &v257
+		vAlue257 := string(randStringThetest(r))
+		this.Field2 = &vAlue257
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
@@ -28976,9 +28976,9 @@ func randUTF8RuneThetest(r randyThetest) rune {
 	return rune(ru + 61)
 }
 func randStringThetest(r randyThetest) string {
-	v258 := r.Intn(100)
-	tmps := make([]rune, v258)
-	for i := 0; i < v258; i++ {
+	vAlue258 := r.Intn(100)
+	tmps := make([]rune, vAlue258)
+	for i := 0; i < vAlue258; i++ {
 		tmps[i] = randUTF8RuneThetest(r)
 	}
 	return string(tmps)
@@ -29000,11 +29000,11 @@ func randFieldThetest(dAtA []byte, r randyThetest, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
-		v259 := r.Int63()
+		vAlue259 := r.Int63()
 		if r.Intn(2) == 0 {
-			v259 *= -1
+			vAlue259 *= -1
 		}
-		dAtA = encodeVarintPopulateThetest(dAtA, uint64(v259))
+		dAtA = encodeVarintPopulateThetest(dAtA, uint64(vAlue259))
 	case 1:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/combos/marshaler/thetest.pb.go
+++ b/test/combos/marshaler/thetest.pb.go
@@ -26650,9 +26650,9 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 	}
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -26664,89 +26664,89 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 	this := &NinOptNative{}
 	if r.Intn(5) != 0 {
-		v2 := float64(r.Float64())
+		vAlue2 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := float32(r.Float32())
+		vAlue3 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field2 = &v3
+		this.Field2 = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := int32(r.Int31())
+		vAlue4 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field3 = &v4
+		this.Field3 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
-		v5 := int64(r.Int63())
+		vAlue5 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		this.Field4 = &v5
+		this.Field4 = &vAlue5
 	}
 	if r.Intn(5) != 0 {
-		v6 := uint32(r.Uint32())
-		this.Field5 = &v6
+		vAlue6 := uint32(r.Uint32())
+		this.Field5 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v7
+		vAlue7 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue7
 	}
 	if r.Intn(5) != 0 {
-		v8 := int32(r.Int31())
+		vAlue8 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v8 *= -1
+			vAlue8 *= -1
 		}
-		this.Field7 = &v8
+		this.Field7 = &vAlue8
 	}
 	if r.Intn(5) != 0 {
-		v9 := int64(r.Int63())
+		vAlue9 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		this.Field8 = &v9
+		this.Field8 = &vAlue9
 	}
 	if r.Intn(5) != 0 {
-		v10 := uint32(r.Uint32())
-		this.Field9 = &v10
+		vAlue10 := uint32(r.Uint32())
+		this.Field9 = &vAlue10
 	}
 	if r.Intn(5) != 0 {
-		v11 := int32(r.Int31())
+		vAlue11 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v11 *= -1
+			vAlue11 *= -1
 		}
-		this.Field10 = &v11
+		this.Field10 = &vAlue11
 	}
 	if r.Intn(5) != 0 {
-		v12 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v12
+		vAlue12 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue12
 	}
 	if r.Intn(5) != 0 {
-		v13 := int64(r.Int63())
+		vAlue13 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v13 *= -1
+			vAlue13 *= -1
 		}
-		this.Field12 = &v13
+		this.Field12 = &vAlue13
 	}
 	if r.Intn(5) != 0 {
-		v14 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v14
+		vAlue14 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue14
 	}
 	if r.Intn(5) != 0 {
-		v15 := string(randStringThetest(r))
-		this.Field14 = &v15
+		vAlue15 := string(randStringThetest(r))
+		this.Field14 = &vAlue15
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(100)
-		this.Field15 = make([]byte, v16)
-		for i := 0; i < v16; i++ {
+		vAlue16 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue16)
+		for i := 0; i < vAlue16; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -26759,9 +26759,9 @@ func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 	this := &NidRepNative{}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
-		this.Field1 = make([]float64, v17)
-		for i := 0; i < v17; i++ {
+		vAlue17 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue17)
+		for i := 0; i < vAlue17; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -26769,9 +26769,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
-		this.Field2 = make([]float32, v18)
-		for i := 0; i < v18; i++ {
+		vAlue18 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue18)
+		for i := 0; i < vAlue18; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -26779,9 +26779,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
-		this.Field3 = make([]int32, v19)
-		for i := 0; i < v19; i++ {
+		vAlue19 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue19)
+		for i := 0; i < vAlue19; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -26789,9 +26789,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
-		this.Field4 = make([]int64, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -26799,23 +26799,23 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
-		this.Field5 = make([]uint32, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
-		this.Field6 = make([]uint64, v22)
-		for i := 0; i < v22; i++ {
+		vAlue22 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue22)
+		for i := 0; i < vAlue22; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
-		this.Field7 = make([]int32, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -26823,9 +26823,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
-		this.Field8 = make([]int64, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -26833,16 +26833,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
-		this.Field9 = make([]uint32, v25)
-		for i := 0; i < v25; i++ {
+		vAlue25 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue25)
+		for i := 0; i < vAlue25; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
-		this.Field10 = make([]int32, v26)
-		for i := 0; i < v26; i++ {
+		vAlue26 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue26)
+		for i := 0; i < vAlue26; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -26850,16 +26850,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
-		this.Field11 = make([]uint64, v27)
-		for i := 0; i < v27; i++ {
+		vAlue27 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue27)
+		for i := 0; i < vAlue27; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
-		this.Field12 = make([]int64, v28)
-		for i := 0; i < v28; i++ {
+		vAlue28 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue28)
+		for i := 0; i < vAlue28; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -26867,26 +26867,26 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
-		this.Field13 = make([]bool, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
-		this.Field14 = make([]string, v30)
-		for i := 0; i < v30; i++ {
+		vAlue30 := r.Intn(10)
+		this.Field14 = make([]string, vAlue30)
+		for i := 0; i < vAlue30; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
-		this.Field15 = make([][]byte, v31)
-		for i := 0; i < v31; i++ {
-			v32 := r.Intn(100)
-			this.Field15[i] = make([]byte, v32)
-			for j := 0; j < v32; j++ {
+		vAlue31 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue31)
+		for i := 0; i < vAlue31; i++ {
+			vAlue32 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue32)
+			for j := 0; j < vAlue32; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -26900,9 +26900,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 	this := &NinRepNative{}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
-		this.Field1 = make([]float64, v33)
-		for i := 0; i < v33; i++ {
+		vAlue33 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue33)
+		for i := 0; i < vAlue33; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -26910,9 +26910,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v34 := r.Intn(10)
-		this.Field2 = make([]float32, v34)
-		for i := 0; i < v34; i++ {
+		vAlue34 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue34)
+		for i := 0; i < vAlue34; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -26920,9 +26920,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
-		this.Field3 = make([]int32, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -26930,9 +26930,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
-		this.Field4 = make([]int64, v36)
-		for i := 0; i < v36; i++ {
+		vAlue36 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue36)
+		for i := 0; i < vAlue36; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -26940,23 +26940,23 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
-		this.Field5 = make([]uint32, v37)
-		for i := 0; i < v37; i++ {
+		vAlue37 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue37)
+		for i := 0; i < vAlue37; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
-		this.Field6 = make([]uint64, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
-		this.Field7 = make([]int32, v39)
-		for i := 0; i < v39; i++ {
+		vAlue39 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue39)
+		for i := 0; i < vAlue39; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -26964,9 +26964,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
-		this.Field8 = make([]int64, v40)
-		for i := 0; i < v40; i++ {
+		vAlue40 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue40)
+		for i := 0; i < vAlue40; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -26974,16 +26974,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
-		this.Field9 = make([]uint32, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
-		this.Field10 = make([]int32, v42)
-		for i := 0; i < v42; i++ {
+		vAlue42 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue42)
+		for i := 0; i < vAlue42; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -26991,16 +26991,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
-		this.Field11 = make([]uint64, v43)
-		for i := 0; i < v43; i++ {
+		vAlue43 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue43)
+		for i := 0; i < vAlue43; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
-		this.Field12 = make([]int64, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -27008,26 +27008,26 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
-		this.Field13 = make([]bool, v45)
-		for i := 0; i < v45; i++ {
+		vAlue45 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue45)
+		for i := 0; i < vAlue45; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
-		this.Field14 = make([]string, v46)
-		for i := 0; i < v46; i++ {
+		vAlue46 := r.Intn(10)
+		this.Field14 = make([]string, vAlue46)
+		for i := 0; i < vAlue46; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
-		this.Field15 = make([][]byte, v47)
-		for i := 0; i < v47; i++ {
-			v48 := r.Intn(100)
-			this.Field15[i] = make([]byte, v48)
-			for j := 0; j < v48; j++ {
+		vAlue47 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue47)
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue48)
+			for j := 0; j < vAlue48; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -27041,9 +27041,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNative {
 	this := &NidRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
-		this.Field1 = make([]float64, v49)
-		for i := 0; i < v49; i++ {
+		vAlue49 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue49)
+		for i := 0; i < vAlue49; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27051,9 +27051,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
-		this.Field2 = make([]float32, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27061,9 +27061,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
-		this.Field3 = make([]int32, v51)
-		for i := 0; i < v51; i++ {
+		vAlue51 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue51)
+		for i := 0; i < vAlue51; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -27071,9 +27071,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
-		this.Field4 = make([]int64, v52)
-		for i := 0; i < v52; i++ {
+		vAlue52 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue52)
+		for i := 0; i < vAlue52; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -27081,23 +27081,23 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
-		this.Field5 = make([]uint32, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
-		this.Field6 = make([]uint64, v54)
-		for i := 0; i < v54; i++ {
+		vAlue54 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue54)
+		for i := 0; i < vAlue54; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
-		this.Field7 = make([]int32, v55)
-		for i := 0; i < v55; i++ {
+		vAlue55 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue55)
+		for i := 0; i < vAlue55; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27105,9 +27105,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
-		this.Field8 = make([]int64, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -27115,16 +27115,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
-		this.Field9 = make([]uint32, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
-		this.Field10 = make([]int32, v58)
-		for i := 0; i < v58; i++ {
+		vAlue58 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue58)
+		for i := 0; i < vAlue58; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -27132,16 +27132,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
-		this.Field11 = make([]uint64, v59)
-		for i := 0; i < v59; i++ {
+		vAlue59 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue59)
+		for i := 0; i < vAlue59; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
-		this.Field12 = make([]int64, v60)
-		for i := 0; i < v60; i++ {
+		vAlue60 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue60)
+		for i := 0; i < vAlue60; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -27149,9 +27149,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
-		this.Field13 = make([]bool, v61)
-		for i := 0; i < v61; i++ {
+		vAlue61 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue61)
+		for i := 0; i < vAlue61; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -27164,9 +27164,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNative {
 	this := &NinRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
-		this.Field1 = make([]float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27174,9 +27174,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
-		this.Field2 = make([]float32, v63)
-		for i := 0; i < v63; i++ {
+		vAlue63 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue63)
+		for i := 0; i < vAlue63; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27184,9 +27184,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
-		this.Field3 = make([]int32, v64)
-		for i := 0; i < v64; i++ {
+		vAlue64 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue64)
+		for i := 0; i < vAlue64; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -27194,9 +27194,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
-		this.Field4 = make([]int64, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -27204,23 +27204,23 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(10)
-		this.Field5 = make([]uint32, v66)
-		for i := 0; i < v66; i++ {
+		vAlue66 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
-		this.Field6 = make([]uint64, v67)
-		for i := 0; i < v67; i++ {
+		vAlue67 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue67)
+		for i := 0; i < vAlue67; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
-		this.Field7 = make([]int32, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27228,9 +27228,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
-		this.Field8 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
+		vAlue69 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -27238,16 +27238,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
-		this.Field9 = make([]uint32, v70)
-		for i := 0; i < v70; i++ {
+		vAlue70 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue70)
+		for i := 0; i < vAlue70; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
-		this.Field10 = make([]int32, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -27255,16 +27255,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(10)
-		this.Field11 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
+		vAlue72 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v73 := r.Intn(10)
-		this.Field12 = make([]int64, v73)
-		for i := 0; i < v73; i++ {
+		vAlue73 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue73)
+		for i := 0; i < vAlue73; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -27272,9 +27272,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(10)
-		this.Field13 = make([]bool, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -27294,22 +27294,22 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 	if r.Intn(2) == 0 {
 		this.Field2 *= -1
 	}
-	v75 := NewPopulatedNidOptNative(r, easy)
-	this.Field3 = *v75
-	v76 := NewPopulatedNinOptNative(r, easy)
-	this.Field4 = *v76
+	vAlue75 := NewPopulatedNidOptNative(r, easy)
+	this.Field3 = *vAlue75
+	vAlue76 := NewPopulatedNinOptNative(r, easy)
+	this.Field4 = *vAlue76
 	this.Field6 = uint64(uint64(r.Uint32()))
 	this.Field7 = int32(r.Int31())
 	if r.Intn(2) == 0 {
 		this.Field7 *= -1
 	}
-	v77 := NewPopulatedNidOptNative(r, easy)
-	this.Field8 = *v77
+	vAlue77 := NewPopulatedNidOptNative(r, easy)
+	this.Field8 = *vAlue77
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v78 := r.Intn(100)
-	this.Field15 = make([]byte, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27321,18 +27321,18 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 	this := &NinOptStruct{}
 	if r.Intn(5) != 0 {
-		v79 := float64(r.Float64())
+		vAlue79 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		this.Field1 = &v79
+		this.Field1 = &vAlue79
 	}
 	if r.Intn(5) != 0 {
-		v80 := float32(r.Float32())
+		vAlue80 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v80 *= -1
+			vAlue80 *= -1
 		}
-		this.Field2 = &v80
+		this.Field2 = &vAlue80
 	}
 	if r.Intn(5) != 0 {
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
@@ -27341,31 +27341,31 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v81 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v81
+		vAlue81 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue81
 	}
 	if r.Intn(5) != 0 {
-		v82 := int32(r.Int31())
+		vAlue82 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v82 *= -1
+			vAlue82 *= -1
 		}
-		this.Field7 = &v82
+		this.Field7 = &vAlue82
 	}
 	if r.Intn(5) != 0 {
 		this.Field8 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v83 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v83
+		vAlue83 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue83
 	}
 	if r.Intn(5) != 0 {
-		v84 := string(randStringThetest(r))
-		this.Field14 = &v84
+		vAlue84 := string(randStringThetest(r))
+		this.Field14 = &vAlue84
 	}
 	if r.Intn(5) != 0 {
-		v85 := r.Intn(100)
-		this.Field15 = make([]byte, v85)
-		for i := 0; i < v85; i++ {
+		vAlue85 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue85)
+		for i := 0; i < vAlue85; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -27378,9 +27378,9 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 	this := &NidRepStruct{}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(10)
-		this.Field1 = make([]float64, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27388,9 +27388,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(10)
-		this.Field2 = make([]float32, v87)
-		for i := 0; i < v87; i++ {
+		vAlue87 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue87)
+		for i := 0; i < vAlue87; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27398,32 +27398,32 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v88 := r.Intn(5)
-		this.Field3 = make([]NidOptNative, v88)
-		for i := 0; i < v88; i++ {
-			v89 := NewPopulatedNidOptNative(r, easy)
-			this.Field3[i] = *v89
+		vAlue88 := r.Intn(5)
+		this.Field3 = make([]NidOptNative, vAlue88)
+		for i := 0; i < vAlue88; i++ {
+			vAlue89 := NewPopulatedNidOptNative(r, easy)
+			this.Field3[i] = *vAlue89
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(5)
-		this.Field4 = make([]NinOptNative, v90)
-		for i := 0; i < v90; i++ {
-			v91 := NewPopulatedNinOptNative(r, easy)
-			this.Field4[i] = *v91
+		vAlue90 := r.Intn(5)
+		this.Field4 = make([]NinOptNative, vAlue90)
+		for i := 0; i < vAlue90; i++ {
+			vAlue91 := NewPopulatedNinOptNative(r, easy)
+			this.Field4[i] = *vAlue91
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
-		this.Field6 = make([]uint64, v92)
-		for i := 0; i < v92; i++ {
+		vAlue92 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue92)
+		for i := 0; i < vAlue92; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
-		this.Field7 = make([]int32, v93)
-		for i := 0; i < v93; i++ {
+		vAlue93 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue93)
+		for i := 0; i < vAlue93; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27431,34 +27431,34 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(5)
-		this.Field8 = make([]NidOptNative, v94)
-		for i := 0; i < v94; i++ {
-			v95 := NewPopulatedNidOptNative(r, easy)
-			this.Field8[i] = *v95
+		vAlue94 := r.Intn(5)
+		this.Field8 = make([]NidOptNative, vAlue94)
+		for i := 0; i < vAlue94; i++ {
+			vAlue95 := NewPopulatedNidOptNative(r, easy)
+			this.Field8[i] = *vAlue95
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
-		this.Field13 = make([]bool, v96)
-		for i := 0; i < v96; i++ {
+		vAlue96 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue96)
+		for i := 0; i < vAlue96; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
-		this.Field14 = make([]string, v97)
-		for i := 0; i < v97; i++ {
+		vAlue97 := r.Intn(10)
+		this.Field14 = make([]string, vAlue97)
+		for i := 0; i < vAlue97; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
-		this.Field15 = make([][]byte, v98)
-		for i := 0; i < v98; i++ {
-			v99 := r.Intn(100)
-			this.Field15[i] = make([]byte, v99)
-			for j := 0; j < v99; j++ {
+		vAlue98 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue98)
+		for i := 0; i < vAlue98; i++ {
+			vAlue99 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue99)
+			for j := 0; j < vAlue99; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -27472,9 +27472,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 	this := &NinRepStruct{}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
-		this.Field1 = make([]float64, v100)
-		for i := 0; i < v100; i++ {
+		vAlue100 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue100)
+		for i := 0; i < vAlue100; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -27482,9 +27482,9 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
-		this.Field2 = make([]float32, v101)
-		for i := 0; i < v101; i++ {
+		vAlue101 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue101)
+		for i := 0; i < vAlue101; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -27492,30 +27492,30 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(5)
-		this.Field3 = make([]*NidOptNative, v102)
-		for i := 0; i < v102; i++ {
+		vAlue102 := r.Intn(5)
+		this.Field3 = make([]*NidOptNative, vAlue102)
+		for i := 0; i < vAlue102; i++ {
 			this.Field3[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(5)
-		this.Field4 = make([]*NinOptNative, v103)
-		for i := 0; i < v103; i++ {
+		vAlue103 := r.Intn(5)
+		this.Field4 = make([]*NinOptNative, vAlue103)
+		for i := 0; i < vAlue103; i++ {
 			this.Field4[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
-		this.Field6 = make([]uint64, v104)
-		for i := 0; i < v104; i++ {
+		vAlue104 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue104)
+		for i := 0; i < vAlue104; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
-		this.Field7 = make([]int32, v105)
-		for i := 0; i < v105; i++ {
+		vAlue105 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue105)
+		for i := 0; i < vAlue105; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -27523,33 +27523,33 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(5)
-		this.Field8 = make([]*NidOptNative, v106)
-		for i := 0; i < v106; i++ {
+		vAlue106 := r.Intn(5)
+		this.Field8 = make([]*NidOptNative, vAlue106)
+		for i := 0; i < vAlue106; i++ {
 			this.Field8[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
-		this.Field13 = make([]bool, v107)
-		for i := 0; i < v107; i++ {
+		vAlue107 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue107)
+		for i := 0; i < vAlue107; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
-		this.Field14 = make([]string, v108)
-		for i := 0; i < v108; i++ {
+		vAlue108 := r.Intn(10)
+		this.Field14 = make([]string, vAlue108)
+		for i := 0; i < vAlue108; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
-		this.Field15 = make([][]byte, v109)
-		for i := 0; i < v109; i++ {
-			v110 := r.Intn(100)
-			this.Field15[i] = make([]byte, v110)
-			for j := 0; j < v110; j++ {
+		vAlue109 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue109)
+		for i := 0; i < vAlue109; i++ {
+			vAlue110 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue110)
+			for j := 0; j < vAlue110; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -27565,8 +27565,8 @@ func NewPopulatedNidEmbeddedStruct(r randyThetest, easy bool) *NidEmbeddedStruct
 	if r.Intn(5) != 0 {
 		this.NidOptNative = NewPopulatedNidOptNative(r, easy)
 	}
-	v111 := NewPopulatedNidOptNative(r, easy)
-	this.Field200 = *v111
+	vAlue111 := NewPopulatedNidOptNative(r, easy)
+	this.Field200 = *vAlue111
 	this.Field210 = bool(bool(r.Intn(2) == 0))
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -27583,8 +27583,8 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 		this.Field200 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v112 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v112
+		vAlue112 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue112
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -27594,14 +27594,14 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 
 func NewPopulatedNidNestedStruct(r randyThetest, easy bool) *NidNestedStruct {
 	this := &NidNestedStruct{}
-	v113 := NewPopulatedNidOptStruct(r, easy)
-	this.Field1 = *v113
+	vAlue113 := NewPopulatedNidOptStruct(r, easy)
+	this.Field1 = *vAlue113
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(5)
-		this.Field2 = make([]NidRepStruct, v114)
-		for i := 0; i < v114; i++ {
-			v115 := NewPopulatedNidRepStruct(r, easy)
-			this.Field2[i] = *v115
+		vAlue114 := r.Intn(5)
+		this.Field2 = make([]NidRepStruct, vAlue114)
+		for i := 0; i < vAlue114; i++ {
+			vAlue115 := NewPopulatedNidRepStruct(r, easy)
+			this.Field2[i] = *vAlue115
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27616,9 +27616,9 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 		this.Field1 = NewPopulatedNinOptStruct(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(5)
-		this.Field2 = make([]*NinRepStruct, v116)
-		for i := 0; i < v116; i++ {
+		vAlue116 := r.Intn(5)
+		this.Field2 = make([]*NinRepStruct, vAlue116)
+		for i := 0; i < vAlue116; i++ {
 			this.Field2[i] = NewPopulatedNinRepStruct(r, easy)
 		}
 	}
@@ -27630,10 +27630,10 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 
 func NewPopulatedNidOptCustom(r randyThetest, easy bool) *NidOptCustom {
 	this := &NidOptCustom{}
-	v117 := NewPopulatedUuid(r)
-	this.Id = *v117
-	v118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Value = *v118
+	vAlue117 := NewPopulatedUuid(r)
+	this.Id = *vAlue117
+	vAlue118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Value = *vAlue118
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27668,19 +27668,19 @@ func NewPopulatedNinOptCustom(r randyThetest, easy bool) *NinOptCustom {
 func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 	this := &NidRepCustom{}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
-		this.Id = make([]Uuid, v119)
-		for i := 0; i < v119; i++ {
-			v120 := NewPopulatedUuid(r)
-			this.Id[i] = *v120
+		vAlue119 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue119)
+		for i := 0; i < vAlue119; i++ {
+			vAlue120 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue120
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v121)
-		for i := 0; i < v121; i++ {
-			v122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v122
+		vAlue121 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue121)
+		for i := 0; i < vAlue121; i++ {
+			vAlue122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue122
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27692,19 +27692,19 @@ func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 func NewPopulatedNinRepCustom(r randyThetest, easy bool) *NinRepCustom {
 	this := &NinRepCustom{}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
-		this.Id = make([]Uuid, v123)
-		for i := 0; i < v123; i++ {
-			v124 := NewPopulatedUuid(r)
-			this.Id[i] = *v124
+		vAlue123 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue123)
+		for i := 0; i < vAlue123; i++ {
+			vAlue124 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue124
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v125)
-		for i := 0; i < v125; i++ {
-			v126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v126
+		vAlue125 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue125)
+		for i := 0; i < vAlue125; i++ {
+			vAlue126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue126
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -27718,45 +27718,45 @@ func NewPopulatedNinOptNativeUnion(r randyThetest, easy bool) *NinOptNativeUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v127 := float64(r.Float64())
+		vAlue127 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v127 *= -1
+			vAlue127 *= -1
 		}
-		this.Field1 = &v127
+		this.Field1 = &vAlue127
 	case 1:
-		v128 := float32(r.Float32())
+		vAlue128 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v128 *= -1
+			vAlue128 *= -1
 		}
-		this.Field2 = &v128
+		this.Field2 = &vAlue128
 	case 2:
-		v129 := int32(r.Int31())
+		vAlue129 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v129 *= -1
+			vAlue129 *= -1
 		}
-		this.Field3 = &v129
+		this.Field3 = &vAlue129
 	case 3:
-		v130 := int64(r.Int63())
+		vAlue130 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v130 *= -1
+			vAlue130 *= -1
 		}
-		this.Field4 = &v130
+		this.Field4 = &vAlue130
 	case 4:
-		v131 := uint32(r.Uint32())
-		this.Field5 = &v131
+		vAlue131 := uint32(r.Uint32())
+		this.Field5 = &vAlue131
 	case 5:
-		v132 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v132
+		vAlue132 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue132
 	case 6:
-		v133 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v133
+		vAlue133 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue133
 	case 7:
-		v134 := string(randStringThetest(r))
-		this.Field14 = &v134
+		vAlue134 := string(randStringThetest(r))
+		this.Field14 = &vAlue134
 	case 8:
-		v135 := r.Intn(100)
-		this.Field15 = make([]byte, v135)
-		for i := 0; i < v135; i++ {
+		vAlue135 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue135)
+		for i := 0; i < vAlue135; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -27768,40 +27768,40 @@ func NewPopulatedNinOptStructUnion(r randyThetest, easy bool) *NinOptStructUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v136 := float64(r.Float64())
+		vAlue136 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v136 *= -1
+			vAlue136 *= -1
 		}
-		this.Field1 = &v136
+		this.Field1 = &vAlue136
 	case 1:
-		v137 := float32(r.Float32())
+		vAlue137 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v137 *= -1
+			vAlue137 *= -1
 		}
-		this.Field2 = &v137
+		this.Field2 = &vAlue137
 	case 2:
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
 	case 3:
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	case 4:
-		v138 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v138
+		vAlue138 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue138
 	case 5:
-		v139 := int32(r.Int31())
+		vAlue139 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v139 *= -1
+			vAlue139 *= -1
 		}
-		this.Field7 = &v139
+		this.Field7 = &vAlue139
 	case 6:
-		v140 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v140
+		vAlue140 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue140
 	case 7:
-		v141 := string(randStringThetest(r))
-		this.Field14 = &v141
+		vAlue141 := string(randStringThetest(r))
+		this.Field14 = &vAlue141
 	case 8:
-		v142 := r.Intn(100)
-		this.Field15 = make([]byte, v142)
-		for i := 0; i < v142; i++ {
+		vAlue142 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue142)
+		for i := 0; i < vAlue142; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -27817,8 +27817,8 @@ func NewPopulatedNinEmbeddedStructUnion(r randyThetest, easy bool) *NinEmbeddedS
 	case 1:
 		this.Field200 = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v143 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v143
+		vAlue143 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue143
 	}
 	return this
 }
@@ -27853,10 +27853,10 @@ func NewPopulatedTree(r randyThetest, easy bool) *Tree {
 
 func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 	this := &OrBranch{}
-	v144 := NewPopulatedTree(r, easy)
-	this.Left = *v144
-	v145 := NewPopulatedTree(r, easy)
-	this.Right = *v145
+	vAlue144 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue144
+	vAlue145 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue145
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27865,10 +27865,10 @@ func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 
 func NewPopulatedAndBranch(r randyThetest, easy bool) *AndBranch {
 	this := &AndBranch{}
-	v146 := NewPopulatedTree(r, easy)
-	this.Left = *v146
-	v147 := NewPopulatedTree(r, easy)
-	this.Right = *v147
+	vAlue146 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue146
+	vAlue147 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue147
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27904,8 +27904,8 @@ func NewPopulatedDeepTree(r randyThetest, easy bool) *DeepTree {
 
 func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 	this := &ADeepBranch{}
-	v148 := NewPopulatedDeepTree(r, easy)
-	this.Down = *v148
+	vAlue148 := NewPopulatedDeepTree(r, easy)
+	this.Down = *vAlue148
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27914,10 +27914,10 @@ func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 
 func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 	this := &AndDeepBranch{}
-	v149 := NewPopulatedDeepTree(r, easy)
-	this.Left = *v149
-	v150 := NewPopulatedDeepTree(r, easy)
-	this.Right = *v150
+	vAlue149 := NewPopulatedDeepTree(r, easy)
+	this.Left = *vAlue149
+	vAlue150 := NewPopulatedDeepTree(r, easy)
+	this.Right = *vAlue150
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -27926,8 +27926,8 @@ func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 
 func NewPopulatedDeepLeaf(r randyThetest, easy bool) *DeepLeaf {
 	this := &DeepLeaf{}
-	v151 := NewPopulatedTree(r, easy)
-	this.Tree = *v151
+	vAlue151 := NewPopulatedTree(r, easy)
+	this.Tree = *vAlue151
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -27954,16 +27954,16 @@ func NewPopulatedNidOptEnum(r randyThetest, easy bool) *NidOptEnum {
 func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 	this := &NinOptEnum{}
 	if r.Intn(5) != 0 {
-		v152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v152
+		vAlue152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue152
 	}
 	if r.Intn(5) != 0 {
-		v153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v153
+		vAlue153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue153
 	}
 	if r.Intn(5) != 0 {
-		v154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v154
+		vAlue154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue154
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -27974,23 +27974,23 @@ func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 	this := &NidRepEnum{}
 	if r.Intn(5) != 0 {
-		v155 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v155)
-		for i := 0; i < v155; i++ {
+		vAlue155 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue155)
+		for i := 0; i < vAlue155; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v156 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v156)
-		for i := 0; i < v156; i++ {
+		vAlue156 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue156)
+		for i := 0; i < vAlue156; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v157 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v157)
-		for i := 0; i < v157; i++ {
+		vAlue157 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue157)
+		for i := 0; i < vAlue157; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -28003,23 +28003,23 @@ func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 	this := &NinRepEnum{}
 	if r.Intn(5) != 0 {
-		v158 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v158)
-		for i := 0; i < v158; i++ {
+		vAlue158 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue158)
+		for i := 0; i < vAlue158; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v159 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v159)
-		for i := 0; i < v159; i++ {
+		vAlue159 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue159)
+		for i := 0; i < vAlue159; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v160 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v160)
-		for i := 0; i < v160; i++ {
+		vAlue160 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue160)
+		for i := 0; i < vAlue160; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -28032,16 +28032,16 @@ func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault {
 	this := &NinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v161
+		vAlue161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue161
 	}
 	if r.Intn(5) != 0 {
-		v162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v162
+		vAlue162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue162
 	}
 	if r.Intn(5) != 0 {
-		v163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v163
+		vAlue163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue163
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -28052,16 +28052,16 @@ func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault
 func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum {
 	this := &AnotherNinOptEnum{}
 	if r.Intn(5) != 0 {
-		v164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v164
+		vAlue164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue164
 	}
 	if r.Intn(5) != 0 {
-		v165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v165
+		vAlue165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue165
 	}
 	if r.Intn(5) != 0 {
-		v166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v166
+		vAlue166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue166
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -28072,16 +28072,16 @@ func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum
 func NewPopulatedAnotherNinOptEnumDefault(r randyThetest, easy bool) *AnotherNinOptEnumDefault {
 	this := &AnotherNinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v167
+		vAlue167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue167
 	}
 	if r.Intn(5) != 0 {
-		v168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v168
+		vAlue168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue168
 	}
 	if r.Intn(5) != 0 {
-		v169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v169
+		vAlue169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue169
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -28099,9 +28099,9 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 	if r.Intn(2) == 0 {
 		this.Time2 *= -1
 	}
-	v170 := r.Intn(100)
-	this.Data = make([]byte, v170)
-	for i := 0; i < v170; i++ {
+	vAlue170 := r.Intn(100)
+	this.Data = make([]byte, vAlue170)
+	for i := 0; i < vAlue170; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28113,11 +28113,11 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 func NewPopulatedMyExtendable(r randyThetest, easy bool) *MyExtendable {
 	this := &MyExtendable{}
 	if r.Intn(5) != 0 {
-		v171 := int64(r.Int63())
+		vAlue171 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v171 *= -1
+			vAlue171 *= -1
 		}
-		this.Field1 = &v171
+		this.Field1 = &vAlue171
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -28143,18 +28143,18 @@ func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 		this.M = NewPopulatedMyExtendable(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v172 := int64(r.Int63())
+		vAlue172 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v172 *= -1
+			vAlue172 *= -1
 		}
-		this.Field2 = &v172
+		this.Field2 = &vAlue172
 	}
 	if r.Intn(5) != 0 {
-		v173 := int64(r.Int63())
+		vAlue173 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v173 *= -1
+			vAlue173 *= -1
 		}
-		this.Field13 = &v173
+		this.Field13 = &vAlue173
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -28184,15 +28184,15 @@ func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 	this := &NestedDefinition{}
 	if r.Intn(5) != 0 {
-		v174 := int64(r.Int63())
+		vAlue174 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v174 *= -1
+			vAlue174 *= -1
 		}
-		this.Field1 = &v174
+		this.Field1 = &vAlue174
 	}
 	if r.Intn(5) != 0 {
-		v175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.EnumField = &v175
+		vAlue175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.EnumField = &vAlue175
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -28209,8 +28209,8 @@ func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *NestedDefinition_NestedMessage {
 	this := &NestedDefinition_NestedMessage{}
 	if r.Intn(5) != 0 {
-		v176 := uint64(uint64(r.Uint32()))
-		this.NestedField1 = &v176
+		vAlue176 := uint64(uint64(r.Uint32()))
+		this.NestedField1 = &vAlue176
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -28224,8 +28224,8 @@ func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *Nest
 func NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r randyThetest, easy bool) *NestedDefinition_NestedMessage_NestedNestedMsg {
 	this := &NestedDefinition_NestedMessage_NestedNestedMsg{}
 	if r.Intn(5) != 0 {
-		v177 := string(randStringThetest(r))
-		this.NestedNestedField1 = &v177
+		vAlue177 := string(randStringThetest(r))
+		this.NestedNestedField1 = &vAlue177
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 11)
@@ -28239,8 +28239,8 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 		this.A = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.B = &v178
+		vAlue178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.B = &vAlue178
 	}
 	if r.Intn(5) != 0 {
 		this.C = NewPopulatedNestedDefinition_NestedMessage(r, easy)
@@ -28254,89 +28254,89 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDefault {
 	this := &NinOptNativeDefault{}
 	if r.Intn(5) != 0 {
-		v179 := float64(r.Float64())
+		vAlue179 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v179 *= -1
+			vAlue179 *= -1
 		}
-		this.Field1 = &v179
+		this.Field1 = &vAlue179
 	}
 	if r.Intn(5) != 0 {
-		v180 := float32(r.Float32())
+		vAlue180 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v180 *= -1
+			vAlue180 *= -1
 		}
-		this.Field2 = &v180
+		this.Field2 = &vAlue180
 	}
 	if r.Intn(5) != 0 {
-		v181 := int32(r.Int31())
+		vAlue181 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v181 *= -1
+			vAlue181 *= -1
 		}
-		this.Field3 = &v181
+		this.Field3 = &vAlue181
 	}
 	if r.Intn(5) != 0 {
-		v182 := int64(r.Int63())
+		vAlue182 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v182 *= -1
+			vAlue182 *= -1
 		}
-		this.Field4 = &v182
+		this.Field4 = &vAlue182
 	}
 	if r.Intn(5) != 0 {
-		v183 := uint32(r.Uint32())
-		this.Field5 = &v183
+		vAlue183 := uint32(r.Uint32())
+		this.Field5 = &vAlue183
 	}
 	if r.Intn(5) != 0 {
-		v184 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v184
+		vAlue184 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue184
 	}
 	if r.Intn(5) != 0 {
-		v185 := int32(r.Int31())
+		vAlue185 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v185 *= -1
+			vAlue185 *= -1
 		}
-		this.Field7 = &v185
+		this.Field7 = &vAlue185
 	}
 	if r.Intn(5) != 0 {
-		v186 := int64(r.Int63())
+		vAlue186 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v186 *= -1
+			vAlue186 *= -1
 		}
-		this.Field8 = &v186
+		this.Field8 = &vAlue186
 	}
 	if r.Intn(5) != 0 {
-		v187 := uint32(r.Uint32())
-		this.Field9 = &v187
+		vAlue187 := uint32(r.Uint32())
+		this.Field9 = &vAlue187
 	}
 	if r.Intn(5) != 0 {
-		v188 := int32(r.Int31())
+		vAlue188 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v188 *= -1
+			vAlue188 *= -1
 		}
-		this.Field10 = &v188
+		this.Field10 = &vAlue188
 	}
 	if r.Intn(5) != 0 {
-		v189 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v189
+		vAlue189 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue189
 	}
 	if r.Intn(5) != 0 {
-		v190 := int64(r.Int63())
+		vAlue190 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v190 *= -1
+			vAlue190 *= -1
 		}
-		this.Field12 = &v190
+		this.Field12 = &vAlue190
 	}
 	if r.Intn(5) != 0 {
-		v191 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v191
+		vAlue191 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue191
 	}
 	if r.Intn(5) != 0 {
-		v192 := string(randStringThetest(r))
-		this.Field14 = &v192
+		vAlue192 := string(randStringThetest(r))
+		this.Field14 = &vAlue192
 	}
 	if r.Intn(5) != 0 {
-		v193 := r.Intn(100)
-		this.Field15 = make([]byte, v193)
-		for i := 0; i < v193; i++ {
+		vAlue193 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue193)
+		for i := 0; i < vAlue193; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -28348,8 +28348,8 @@ func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDef
 
 func NewPopulatedCustomContainer(r randyThetest, easy bool) *CustomContainer {
 	this := &CustomContainer{}
-	v194 := NewPopulatedNidOptCustom(r, easy)
-	this.CustomStruct = *v194
+	vAlue194 := NewPopulatedNidOptCustom(r, easy)
+	this.CustomStruct = *vAlue194
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -28396,9 +28396,9 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 	}
 	this.FieldM = bool(bool(r.Intn(2) == 0))
 	this.FieldN = string(randStringThetest(r))
-	v195 := r.Intn(100)
-	this.FieldO = make([]byte, v195)
-	for i := 0; i < v195; i++ {
+	vAlue195 := r.Intn(100)
+	this.FieldO = make([]byte, vAlue195)
+	for i := 0; i < vAlue195; i++ {
 		this.FieldO[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28410,89 +28410,89 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNinOptNative {
 	this := &CustomNameNinOptNative{}
 	if r.Intn(5) != 0 {
-		v196 := float64(r.Float64())
+		vAlue196 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v196 *= -1
+			vAlue196 *= -1
 		}
-		this.FieldA = &v196
+		this.FieldA = &vAlue196
 	}
 	if r.Intn(5) != 0 {
-		v197 := float32(r.Float32())
+		vAlue197 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v197 *= -1
+			vAlue197 *= -1
 		}
-		this.FieldB = &v197
+		this.FieldB = &vAlue197
 	}
 	if r.Intn(5) != 0 {
-		v198 := int32(r.Int31())
+		vAlue198 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v198 *= -1
+			vAlue198 *= -1
 		}
-		this.FieldC = &v198
+		this.FieldC = &vAlue198
 	}
 	if r.Intn(5) != 0 {
-		v199 := int64(r.Int63())
+		vAlue199 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v199 *= -1
+			vAlue199 *= -1
 		}
-		this.FieldD = &v199
+		this.FieldD = &vAlue199
 	}
 	if r.Intn(5) != 0 {
-		v200 := uint32(r.Uint32())
-		this.FieldE = &v200
+		vAlue200 := uint32(r.Uint32())
+		this.FieldE = &vAlue200
 	}
 	if r.Intn(5) != 0 {
-		v201 := uint64(uint64(r.Uint32()))
-		this.FieldF = &v201
+		vAlue201 := uint64(uint64(r.Uint32()))
+		this.FieldF = &vAlue201
 	}
 	if r.Intn(5) != 0 {
-		v202 := int32(r.Int31())
+		vAlue202 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v202 *= -1
+			vAlue202 *= -1
 		}
-		this.FieldG = &v202
+		this.FieldG = &vAlue202
 	}
 	if r.Intn(5) != 0 {
-		v203 := int64(r.Int63())
+		vAlue203 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v203 *= -1
+			vAlue203 *= -1
 		}
-		this.FieldH = &v203
+		this.FieldH = &vAlue203
 	}
 	if r.Intn(5) != 0 {
-		v204 := uint32(r.Uint32())
-		this.FieldI = &v204
+		vAlue204 := uint32(r.Uint32())
+		this.FieldI = &vAlue204
 	}
 	if r.Intn(5) != 0 {
-		v205 := int32(r.Int31())
+		vAlue205 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v205 *= -1
+			vAlue205 *= -1
 		}
-		this.FieldJ = &v205
+		this.FieldJ = &vAlue205
 	}
 	if r.Intn(5) != 0 {
-		v206 := uint64(uint64(r.Uint32()))
-		this.FieldK = &v206
+		vAlue206 := uint64(uint64(r.Uint32()))
+		this.FieldK = &vAlue206
 	}
 	if r.Intn(5) != 0 {
-		v207 := int64(r.Int63())
+		vAlue207 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v207 *= -1
+			vAlue207 *= -1
 		}
-		this.FielL = &v207
+		this.FielL = &vAlue207
 	}
 	if r.Intn(5) != 0 {
-		v208 := bool(bool(r.Intn(2) == 0))
-		this.FieldM = &v208
+		vAlue208 := bool(bool(r.Intn(2) == 0))
+		this.FieldM = &vAlue208
 	}
 	if r.Intn(5) != 0 {
-		v209 := string(randStringThetest(r))
-		this.FieldN = &v209
+		vAlue209 := string(randStringThetest(r))
+		this.FieldN = &vAlue209
 	}
 	if r.Intn(5) != 0 {
-		v210 := r.Intn(100)
-		this.FieldO = make([]byte, v210)
-		for i := 0; i < v210; i++ {
+		vAlue210 := r.Intn(100)
+		this.FieldO = make([]byte, vAlue210)
+		for i := 0; i < vAlue210; i++ {
 			this.FieldO[i] = byte(r.Intn(256))
 		}
 	}
@@ -28505,9 +28505,9 @@ func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNinRepNative {
 	this := &CustomNameNinRepNative{}
 	if r.Intn(5) != 0 {
-		v211 := r.Intn(10)
-		this.FieldA = make([]float64, v211)
-		for i := 0; i < v211; i++ {
+		vAlue211 := r.Intn(10)
+		this.FieldA = make([]float64, vAlue211)
+		for i := 0; i < vAlue211; i++ {
 			this.FieldA[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.FieldA[i] *= -1
@@ -28515,9 +28515,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v212 := r.Intn(10)
-		this.FieldB = make([]float32, v212)
-		for i := 0; i < v212; i++ {
+		vAlue212 := r.Intn(10)
+		this.FieldB = make([]float32, vAlue212)
+		for i := 0; i < vAlue212; i++ {
 			this.FieldB[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.FieldB[i] *= -1
@@ -28525,9 +28525,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v213 := r.Intn(10)
-		this.FieldC = make([]int32, v213)
-		for i := 0; i < v213; i++ {
+		vAlue213 := r.Intn(10)
+		this.FieldC = make([]int32, vAlue213)
+		for i := 0; i < vAlue213; i++ {
 			this.FieldC[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldC[i] *= -1
@@ -28535,9 +28535,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v214 := r.Intn(10)
-		this.FieldD = make([]int64, v214)
-		for i := 0; i < v214; i++ {
+		vAlue214 := r.Intn(10)
+		this.FieldD = make([]int64, vAlue214)
+		for i := 0; i < vAlue214; i++ {
 			this.FieldD[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldD[i] *= -1
@@ -28545,23 +28545,23 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v215 := r.Intn(10)
-		this.FieldE = make([]uint32, v215)
-		for i := 0; i < v215; i++ {
+		vAlue215 := r.Intn(10)
+		this.FieldE = make([]uint32, vAlue215)
+		for i := 0; i < vAlue215; i++ {
 			this.FieldE[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v216 := r.Intn(10)
-		this.FieldF = make([]uint64, v216)
-		for i := 0; i < v216; i++ {
+		vAlue216 := r.Intn(10)
+		this.FieldF = make([]uint64, vAlue216)
+		for i := 0; i < vAlue216; i++ {
 			this.FieldF[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v217 := r.Intn(10)
-		this.FieldG = make([]int32, v217)
-		for i := 0; i < v217; i++ {
+		vAlue217 := r.Intn(10)
+		this.FieldG = make([]int32, vAlue217)
+		for i := 0; i < vAlue217; i++ {
 			this.FieldG[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldG[i] *= -1
@@ -28569,9 +28569,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v218 := r.Intn(10)
-		this.FieldH = make([]int64, v218)
-		for i := 0; i < v218; i++ {
+		vAlue218 := r.Intn(10)
+		this.FieldH = make([]int64, vAlue218)
+		for i := 0; i < vAlue218; i++ {
 			this.FieldH[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldH[i] *= -1
@@ -28579,16 +28579,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v219 := r.Intn(10)
-		this.FieldI = make([]uint32, v219)
-		for i := 0; i < v219; i++ {
+		vAlue219 := r.Intn(10)
+		this.FieldI = make([]uint32, vAlue219)
+		for i := 0; i < vAlue219; i++ {
 			this.FieldI[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v220 := r.Intn(10)
-		this.FieldJ = make([]int32, v220)
-		for i := 0; i < v220; i++ {
+		vAlue220 := r.Intn(10)
+		this.FieldJ = make([]int32, vAlue220)
+		for i := 0; i < vAlue220; i++ {
 			this.FieldJ[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldJ[i] *= -1
@@ -28596,16 +28596,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v221 := r.Intn(10)
-		this.FieldK = make([]uint64, v221)
-		for i := 0; i < v221; i++ {
+		vAlue221 := r.Intn(10)
+		this.FieldK = make([]uint64, vAlue221)
+		for i := 0; i < vAlue221; i++ {
 			this.FieldK[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v222 := r.Intn(10)
-		this.FieldL = make([]int64, v222)
-		for i := 0; i < v222; i++ {
+		vAlue222 := r.Intn(10)
+		this.FieldL = make([]int64, vAlue222)
+		for i := 0; i < vAlue222; i++ {
 			this.FieldL[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldL[i] *= -1
@@ -28613,26 +28613,26 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v223 := r.Intn(10)
-		this.FieldM = make([]bool, v223)
-		for i := 0; i < v223; i++ {
+		vAlue223 := r.Intn(10)
+		this.FieldM = make([]bool, vAlue223)
+		for i := 0; i < vAlue223; i++ {
 			this.FieldM[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v224 := r.Intn(10)
-		this.FieldN = make([]string, v224)
-		for i := 0; i < v224; i++ {
+		vAlue224 := r.Intn(10)
+		this.FieldN = make([]string, vAlue224)
+		for i := 0; i < vAlue224; i++ {
 			this.FieldN[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v225 := r.Intn(10)
-		this.FieldO = make([][]byte, v225)
-		for i := 0; i < v225; i++ {
-			v226 := r.Intn(100)
-			this.FieldO[i] = make([]byte, v226)
-			for j := 0; j < v226; j++ {
+		vAlue225 := r.Intn(10)
+		this.FieldO = make([][]byte, vAlue225)
+		for i := 0; i < vAlue225; i++ {
+			vAlue226 := r.Intn(100)
+			this.FieldO[i] = make([]byte, vAlue226)
+			for j := 0; j < vAlue226; j++ {
 				this.FieldO[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -28646,55 +28646,55 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinStruct(r randyThetest, easy bool) *CustomNameNinStruct {
 	this := &CustomNameNinStruct{}
 	if r.Intn(5) != 0 {
-		v227 := float64(r.Float64())
+		vAlue227 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v227 *= -1
+			vAlue227 *= -1
 		}
-		this.FieldA = &v227
+		this.FieldA = &vAlue227
 	}
 	if r.Intn(5) != 0 {
-		v228 := float32(r.Float32())
+		vAlue228 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v228 *= -1
+			vAlue228 *= -1
 		}
-		this.FieldB = &v228
+		this.FieldB = &vAlue228
 	}
 	if r.Intn(5) != 0 {
 		this.FieldC = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v229 := r.Intn(5)
-		this.FieldD = make([]*NinOptNative, v229)
-		for i := 0; i < v229; i++ {
+		vAlue229 := r.Intn(5)
+		this.FieldD = make([]*NinOptNative, vAlue229)
+		for i := 0; i < vAlue229; i++ {
 			this.FieldD[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v230 := uint64(uint64(r.Uint32()))
-		this.FieldE = &v230
+		vAlue230 := uint64(uint64(r.Uint32()))
+		this.FieldE = &vAlue230
 	}
 	if r.Intn(5) != 0 {
-		v231 := int32(r.Int31())
+		vAlue231 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v231 *= -1
+			vAlue231 *= -1
 		}
-		this.FieldF = &v231
+		this.FieldF = &vAlue231
 	}
 	if r.Intn(5) != 0 {
 		this.FieldG = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v232 := bool(bool(r.Intn(2) == 0))
-		this.FieldH = &v232
+		vAlue232 := bool(bool(r.Intn(2) == 0))
+		this.FieldH = &vAlue232
 	}
 	if r.Intn(5) != 0 {
-		v233 := string(randStringThetest(r))
-		this.FieldI = &v233
+		vAlue233 := string(randStringThetest(r))
+		this.FieldI = &vAlue233
 	}
 	if r.Intn(5) != 0 {
-		v234 := r.Intn(100)
-		this.FieldJ = make([]byte, v234)
-		for i := 0; i < v234; i++ {
+		vAlue234 := r.Intn(100)
+		this.FieldJ = make([]byte, vAlue234)
+		for i := 0; i < vAlue234; i++ {
 			this.FieldJ[i] = byte(r.Intn(256))
 		}
 	}
@@ -28713,19 +28713,19 @@ func NewPopulatedCustomNameCustomType(r randyThetest, easy bool) *CustomNameCust
 		this.FieldB = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	}
 	if r.Intn(5) != 0 {
-		v235 := r.Intn(10)
-		this.FieldC = make([]Uuid, v235)
-		for i := 0; i < v235; i++ {
-			v236 := NewPopulatedUuid(r)
-			this.FieldC[i] = *v236
+		vAlue235 := r.Intn(10)
+		this.FieldC = make([]Uuid, vAlue235)
+		for i := 0; i < vAlue235; i++ {
+			vAlue236 := NewPopulatedUuid(r)
+			this.FieldC[i] = *vAlue236
 		}
 	}
 	if r.Intn(5) != 0 {
-		v237 := r.Intn(10)
-		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, v237)
-		for i := 0; i < v237; i++ {
-			v238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.FieldD[i] = *v238
+		vAlue237 := r.Intn(10)
+		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue237)
+		for i := 0; i < vAlue237; i++ {
+			vAlue238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.FieldD[i] = *vAlue238
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28743,8 +28743,8 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 	case 1:
 		this.FieldA = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v239 := bool(bool(r.Intn(2) == 0))
-		this.FieldB = &v239
+		vAlue239 := bool(bool(r.Intn(2) == 0))
+		this.FieldB = &vAlue239
 	}
 	return this
 }
@@ -28752,13 +28752,13 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 	this := &CustomNameEnum{}
 	if r.Intn(5) != 0 {
-		v240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.FieldA = &v240
+		vAlue240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.FieldA = &vAlue240
 	}
 	if r.Intn(5) != 0 {
-		v241 := r.Intn(10)
-		this.FieldB = make([]TheTestEnum, v241)
-		for i := 0; i < v241; i++ {
+		vAlue241 := r.Intn(10)
+		this.FieldB = make([]TheTestEnum, vAlue241)
+		for i := 0; i < vAlue241; i++ {
 			this.FieldB[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
@@ -28771,11 +28771,11 @@ func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 	this := &NoExtensionsMap{}
 	if r.Intn(5) != 0 {
-		v242 := int64(r.Int63())
+		vAlue242 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v242 *= -1
+			vAlue242 *= -1
 		}
-		this.Field1 = &v242
+		this.Field1 = &vAlue242
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -28798,8 +28798,8 @@ func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 	this := &Unrecognized{}
 	if r.Intn(5) != 0 {
-		v243 := string(randStringThetest(r))
-		this.Field1 = &v243
+		vAlue243 := string(randStringThetest(r))
+		this.Field1 = &vAlue243
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -28809,15 +28809,15 @@ func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedWithInner {
 	this := &UnrecognizedWithInner{}
 	if r.Intn(5) != 0 {
-		v244 := r.Intn(5)
-		this.Embedded = make([]*UnrecognizedWithInner_Inner, v244)
-		for i := 0; i < v244; i++ {
+		vAlue244 := r.Intn(5)
+		this.Embedded = make([]*UnrecognizedWithInner_Inner, vAlue244)
+		for i := 0; i < vAlue244; i++ {
 			this.Embedded[i] = NewPopulatedUnrecognizedWithInner_Inner(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v245 := string(randStringThetest(r))
-		this.Field2 = &v245
+		vAlue245 := string(randStringThetest(r))
+		this.Field2 = &vAlue245
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -28828,8 +28828,8 @@ func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *UnrecognizedWithInner_Inner {
 	this := &UnrecognizedWithInner_Inner{}
 	if r.Intn(5) != 0 {
-		v246 := uint32(r.Uint32())
-		this.Field1 = &v246
+		vAlue246 := uint32(r.Uint32())
+		this.Field1 = &vAlue246
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -28838,11 +28838,11 @@ func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *Unrecog
 
 func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedWithEmbed {
 	this := &UnrecognizedWithEmbed{}
-	v247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
-	this.UnrecognizedWithEmbed_Embedded = *v247
+	vAlue247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
+	this.UnrecognizedWithEmbed_Embedded = *vAlue247
 	if r.Intn(5) != 0 {
-		v248 := string(randStringThetest(r))
-		this.Field2 = &v248
+		vAlue248 := string(randStringThetest(r))
+		this.Field2 = &vAlue248
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -28853,8 +28853,8 @@ func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *UnrecognizedWithEmbed_Embedded {
 	this := &UnrecognizedWithEmbed_Embedded{}
 	if r.Intn(5) != 0 {
-		v249 := uint32(r.Uint32())
-		this.Field1 = &v249
+		vAlue249 := uint32(r.Uint32())
+		this.Field1 = &vAlue249
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -28864,13 +28864,13 @@ func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *Unre
 func NewPopulatedNode(r randyThetest, easy bool) *Node {
 	this := &Node{}
 	if r.Intn(5) != 0 {
-		v250 := string(randStringThetest(r))
-		this.Label = &v250
+		vAlue250 := string(randStringThetest(r))
+		this.Label = &vAlue250
 	}
 	if r.Intn(5) == 0 {
-		v251 := r.Intn(5)
-		this.Children = make([]*Node, v251)
-		for i := 0; i < v251; i++ {
+		vAlue251 := r.Intn(5)
+		this.Children = make([]*Node, vAlue251)
+		for i := 0; i < vAlue251; i++ {
 			this.Children[i] = NewPopulatedNode(r, easy)
 		}
 	}
@@ -28893,8 +28893,8 @@ func NewPopulatedNonByteCustomType(r randyThetest, easy bool) *NonByteCustomType
 
 func NewPopulatedNidOptNonByteCustomType(r randyThetest, easy bool) *NidOptNonByteCustomType {
 	this := &NidOptNonByteCustomType{}
-	v252 := NewPopulatedT(r)
-	this.Field1 = *v252
+	vAlue252 := NewPopulatedT(r)
+	this.Field1 = *vAlue252
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -28915,11 +28915,11 @@ func NewPopulatedNinOptNonByteCustomType(r randyThetest, easy bool) *NinOptNonBy
 func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonByteCustomType {
 	this := &NidRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v253 := r.Intn(10)
-		this.Field1 = make([]T, v253)
-		for i := 0; i < v253; i++ {
-			v254 := NewPopulatedT(r)
-			this.Field1[i] = *v254
+		vAlue253 := r.Intn(10)
+		this.Field1 = make([]T, vAlue253)
+		for i := 0; i < vAlue253; i++ {
+			vAlue254 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue254
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28931,11 +28931,11 @@ func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonBy
 func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonByteCustomType {
 	this := &NinRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v255 := r.Intn(10)
-		this.Field1 = make([]T, v255)
-		for i := 0; i < v255; i++ {
-			v256 := NewPopulatedT(r)
-			this.Field1[i] = *v256
+		vAlue255 := r.Intn(10)
+		this.Field1 = make([]T, vAlue255)
+		for i := 0; i < vAlue255; i++ {
+			vAlue256 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue256
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -28947,8 +28947,8 @@ func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonBy
 func NewPopulatedProtoType(r randyThetest, easy bool) *ProtoType {
 	this := &ProtoType{}
 	if r.Intn(5) != 0 {
-		v257 := string(randStringThetest(r))
-		this.Field2 = &v257
+		vAlue257 := string(randStringThetest(r))
+		this.Field2 = &vAlue257
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
@@ -28975,9 +28975,9 @@ func randUTF8RuneThetest(r randyThetest) rune {
 	return rune(ru + 61)
 }
 func randStringThetest(r randyThetest) string {
-	v258 := r.Intn(100)
-	tmps := make([]rune, v258)
-	for i := 0; i < v258; i++ {
+	vAlue258 := r.Intn(100)
+	tmps := make([]rune, vAlue258)
+	for i := 0; i < vAlue258; i++ {
 		tmps[i] = randUTF8RuneThetest(r)
 	}
 	return string(tmps)
@@ -28999,11 +28999,11 @@ func randFieldThetest(dAtA []byte, r randyThetest, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
-		v259 := r.Int63()
+		vAlue259 := r.Int63()
 		if r.Intn(2) == 0 {
-			v259 *= -1
+			vAlue259 *= -1
 		}
-		dAtA = encodeVarintPopulateThetest(dAtA, uint64(v259))
+		dAtA = encodeVarintPopulateThetest(dAtA, uint64(vAlue259))
 	case 1:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -21531,9 +21531,9 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 	}
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -21545,89 +21545,89 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 	this := &NinOptNative{}
 	if r.Intn(5) != 0 {
-		v2 := float64(r.Float64())
+		vAlue2 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := float32(r.Float32())
+		vAlue3 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field2 = &v3
+		this.Field2 = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := int32(r.Int31())
+		vAlue4 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field3 = &v4
+		this.Field3 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
-		v5 := int64(r.Int63())
+		vAlue5 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		this.Field4 = &v5
+		this.Field4 = &vAlue5
 	}
 	if r.Intn(5) != 0 {
-		v6 := uint32(r.Uint32())
-		this.Field5 = &v6
+		vAlue6 := uint32(r.Uint32())
+		this.Field5 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v7
+		vAlue7 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue7
 	}
 	if r.Intn(5) != 0 {
-		v8 := int32(r.Int31())
+		vAlue8 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v8 *= -1
+			vAlue8 *= -1
 		}
-		this.Field7 = &v8
+		this.Field7 = &vAlue8
 	}
 	if r.Intn(5) != 0 {
-		v9 := int64(r.Int63())
+		vAlue9 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		this.Field8 = &v9
+		this.Field8 = &vAlue9
 	}
 	if r.Intn(5) != 0 {
-		v10 := uint32(r.Uint32())
-		this.Field9 = &v10
+		vAlue10 := uint32(r.Uint32())
+		this.Field9 = &vAlue10
 	}
 	if r.Intn(5) != 0 {
-		v11 := int32(r.Int31())
+		vAlue11 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v11 *= -1
+			vAlue11 *= -1
 		}
-		this.Field10 = &v11
+		this.Field10 = &vAlue11
 	}
 	if r.Intn(5) != 0 {
-		v12 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v12
+		vAlue12 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue12
 	}
 	if r.Intn(5) != 0 {
-		v13 := int64(r.Int63())
+		vAlue13 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v13 *= -1
+			vAlue13 *= -1
 		}
-		this.Field12 = &v13
+		this.Field12 = &vAlue13
 	}
 	if r.Intn(5) != 0 {
-		v14 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v14
+		vAlue14 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue14
 	}
 	if r.Intn(5) != 0 {
-		v15 := string(randStringThetest(r))
-		this.Field14 = &v15
+		vAlue15 := string(randStringThetest(r))
+		this.Field14 = &vAlue15
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(100)
-		this.Field15 = make([]byte, v16)
-		for i := 0; i < v16; i++ {
+		vAlue16 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue16)
+		for i := 0; i < vAlue16; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -21640,9 +21640,9 @@ func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 	this := &NidRepNative{}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
-		this.Field1 = make([]float64, v17)
-		for i := 0; i < v17; i++ {
+		vAlue17 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue17)
+		for i := 0; i < vAlue17; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -21650,9 +21650,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
-		this.Field2 = make([]float32, v18)
-		for i := 0; i < v18; i++ {
+		vAlue18 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue18)
+		for i := 0; i < vAlue18; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -21660,9 +21660,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
-		this.Field3 = make([]int32, v19)
-		for i := 0; i < v19; i++ {
+		vAlue19 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue19)
+		for i := 0; i < vAlue19; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -21670,9 +21670,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
-		this.Field4 = make([]int64, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -21680,23 +21680,23 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
-		this.Field5 = make([]uint32, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
-		this.Field6 = make([]uint64, v22)
-		for i := 0; i < v22; i++ {
+		vAlue22 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue22)
+		for i := 0; i < vAlue22; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
-		this.Field7 = make([]int32, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -21704,9 +21704,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
-		this.Field8 = make([]int64, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -21714,16 +21714,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
-		this.Field9 = make([]uint32, v25)
-		for i := 0; i < v25; i++ {
+		vAlue25 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue25)
+		for i := 0; i < vAlue25; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
-		this.Field10 = make([]int32, v26)
-		for i := 0; i < v26; i++ {
+		vAlue26 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue26)
+		for i := 0; i < vAlue26; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -21731,16 +21731,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
-		this.Field11 = make([]uint64, v27)
-		for i := 0; i < v27; i++ {
+		vAlue27 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue27)
+		for i := 0; i < vAlue27; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
-		this.Field12 = make([]int64, v28)
-		for i := 0; i < v28; i++ {
+		vAlue28 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue28)
+		for i := 0; i < vAlue28; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -21748,26 +21748,26 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
-		this.Field13 = make([]bool, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
-		this.Field14 = make([]string, v30)
-		for i := 0; i < v30; i++ {
+		vAlue30 := r.Intn(10)
+		this.Field14 = make([]string, vAlue30)
+		for i := 0; i < vAlue30; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
-		this.Field15 = make([][]byte, v31)
-		for i := 0; i < v31; i++ {
-			v32 := r.Intn(100)
-			this.Field15[i] = make([]byte, v32)
-			for j := 0; j < v32; j++ {
+		vAlue31 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue31)
+		for i := 0; i < vAlue31; i++ {
+			vAlue32 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue32)
+			for j := 0; j < vAlue32; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -21781,9 +21781,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 	this := &NinRepNative{}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
-		this.Field1 = make([]float64, v33)
-		for i := 0; i < v33; i++ {
+		vAlue33 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue33)
+		for i := 0; i < vAlue33; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -21791,9 +21791,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v34 := r.Intn(10)
-		this.Field2 = make([]float32, v34)
-		for i := 0; i < v34; i++ {
+		vAlue34 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue34)
+		for i := 0; i < vAlue34; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -21801,9 +21801,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
-		this.Field3 = make([]int32, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -21811,9 +21811,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
-		this.Field4 = make([]int64, v36)
-		for i := 0; i < v36; i++ {
+		vAlue36 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue36)
+		for i := 0; i < vAlue36; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -21821,23 +21821,23 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
-		this.Field5 = make([]uint32, v37)
-		for i := 0; i < v37; i++ {
+		vAlue37 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue37)
+		for i := 0; i < vAlue37; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
-		this.Field6 = make([]uint64, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
-		this.Field7 = make([]int32, v39)
-		for i := 0; i < v39; i++ {
+		vAlue39 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue39)
+		for i := 0; i < vAlue39; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -21845,9 +21845,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
-		this.Field8 = make([]int64, v40)
-		for i := 0; i < v40; i++ {
+		vAlue40 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue40)
+		for i := 0; i < vAlue40; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -21855,16 +21855,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
-		this.Field9 = make([]uint32, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
-		this.Field10 = make([]int32, v42)
-		for i := 0; i < v42; i++ {
+		vAlue42 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue42)
+		for i := 0; i < vAlue42; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -21872,16 +21872,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
-		this.Field11 = make([]uint64, v43)
-		for i := 0; i < v43; i++ {
+		vAlue43 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue43)
+		for i := 0; i < vAlue43; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
-		this.Field12 = make([]int64, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -21889,26 +21889,26 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
-		this.Field13 = make([]bool, v45)
-		for i := 0; i < v45; i++ {
+		vAlue45 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue45)
+		for i := 0; i < vAlue45; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
-		this.Field14 = make([]string, v46)
-		for i := 0; i < v46; i++ {
+		vAlue46 := r.Intn(10)
+		this.Field14 = make([]string, vAlue46)
+		for i := 0; i < vAlue46; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
-		this.Field15 = make([][]byte, v47)
-		for i := 0; i < v47; i++ {
-			v48 := r.Intn(100)
-			this.Field15[i] = make([]byte, v48)
-			for j := 0; j < v48; j++ {
+		vAlue47 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue47)
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue48)
+			for j := 0; j < vAlue48; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -21922,9 +21922,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNative {
 	this := &NidRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
-		this.Field1 = make([]float64, v49)
-		for i := 0; i < v49; i++ {
+		vAlue49 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue49)
+		for i := 0; i < vAlue49; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -21932,9 +21932,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
-		this.Field2 = make([]float32, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -21942,9 +21942,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
-		this.Field3 = make([]int32, v51)
-		for i := 0; i < v51; i++ {
+		vAlue51 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue51)
+		for i := 0; i < vAlue51; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -21952,9 +21952,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
-		this.Field4 = make([]int64, v52)
-		for i := 0; i < v52; i++ {
+		vAlue52 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue52)
+		for i := 0; i < vAlue52; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -21962,23 +21962,23 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
-		this.Field5 = make([]uint32, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
-		this.Field6 = make([]uint64, v54)
-		for i := 0; i < v54; i++ {
+		vAlue54 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue54)
+		for i := 0; i < vAlue54; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
-		this.Field7 = make([]int32, v55)
-		for i := 0; i < v55; i++ {
+		vAlue55 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue55)
+		for i := 0; i < vAlue55; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -21986,9 +21986,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
-		this.Field8 = make([]int64, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -21996,16 +21996,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
-		this.Field9 = make([]uint32, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
-		this.Field10 = make([]int32, v58)
-		for i := 0; i < v58; i++ {
+		vAlue58 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue58)
+		for i := 0; i < vAlue58; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -22013,16 +22013,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
-		this.Field11 = make([]uint64, v59)
-		for i := 0; i < v59; i++ {
+		vAlue59 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue59)
+		for i := 0; i < vAlue59; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
-		this.Field12 = make([]int64, v60)
-		for i := 0; i < v60; i++ {
+		vAlue60 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue60)
+		for i := 0; i < vAlue60; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -22030,9 +22030,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
-		this.Field13 = make([]bool, v61)
-		for i := 0; i < v61; i++ {
+		vAlue61 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue61)
+		for i := 0; i < vAlue61; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -22045,9 +22045,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNative {
 	this := &NinRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
-		this.Field1 = make([]float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -22055,9 +22055,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
-		this.Field2 = make([]float32, v63)
-		for i := 0; i < v63; i++ {
+		vAlue63 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue63)
+		for i := 0; i < vAlue63; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -22065,9 +22065,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
-		this.Field3 = make([]int32, v64)
-		for i := 0; i < v64; i++ {
+		vAlue64 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue64)
+		for i := 0; i < vAlue64; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -22075,9 +22075,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
-		this.Field4 = make([]int64, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -22085,23 +22085,23 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(10)
-		this.Field5 = make([]uint32, v66)
-		for i := 0; i < v66; i++ {
+		vAlue66 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
-		this.Field6 = make([]uint64, v67)
-		for i := 0; i < v67; i++ {
+		vAlue67 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue67)
+		for i := 0; i < vAlue67; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
-		this.Field7 = make([]int32, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -22109,9 +22109,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
-		this.Field8 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
+		vAlue69 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -22119,16 +22119,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
-		this.Field9 = make([]uint32, v70)
-		for i := 0; i < v70; i++ {
+		vAlue70 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue70)
+		for i := 0; i < vAlue70; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
-		this.Field10 = make([]int32, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -22136,16 +22136,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(10)
-		this.Field11 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
+		vAlue72 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v73 := r.Intn(10)
-		this.Field12 = make([]int64, v73)
-		for i := 0; i < v73; i++ {
+		vAlue73 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue73)
+		for i := 0; i < vAlue73; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -22153,9 +22153,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(10)
-		this.Field13 = make([]bool, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -22175,22 +22175,22 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 	if r.Intn(2) == 0 {
 		this.Field2 *= -1
 	}
-	v75 := NewPopulatedNidOptNative(r, easy)
-	this.Field3 = *v75
-	v76 := NewPopulatedNinOptNative(r, easy)
-	this.Field4 = *v76
+	vAlue75 := NewPopulatedNidOptNative(r, easy)
+	this.Field3 = *vAlue75
+	vAlue76 := NewPopulatedNinOptNative(r, easy)
+	this.Field4 = *vAlue76
 	this.Field6 = uint64(uint64(r.Uint32()))
 	this.Field7 = int32(r.Int31())
 	if r.Intn(2) == 0 {
 		this.Field7 *= -1
 	}
-	v77 := NewPopulatedNidOptNative(r, easy)
-	this.Field8 = *v77
+	vAlue77 := NewPopulatedNidOptNative(r, easy)
+	this.Field8 = *vAlue77
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v78 := r.Intn(100)
-	this.Field15 = make([]byte, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22202,18 +22202,18 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 	this := &NinOptStruct{}
 	if r.Intn(5) != 0 {
-		v79 := float64(r.Float64())
+		vAlue79 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		this.Field1 = &v79
+		this.Field1 = &vAlue79
 	}
 	if r.Intn(5) != 0 {
-		v80 := float32(r.Float32())
+		vAlue80 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v80 *= -1
+			vAlue80 *= -1
 		}
-		this.Field2 = &v80
+		this.Field2 = &vAlue80
 	}
 	if r.Intn(5) != 0 {
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
@@ -22222,31 +22222,31 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v81 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v81
+		vAlue81 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue81
 	}
 	if r.Intn(5) != 0 {
-		v82 := int32(r.Int31())
+		vAlue82 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v82 *= -1
+			vAlue82 *= -1
 		}
-		this.Field7 = &v82
+		this.Field7 = &vAlue82
 	}
 	if r.Intn(5) != 0 {
 		this.Field8 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v83 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v83
+		vAlue83 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue83
 	}
 	if r.Intn(5) != 0 {
-		v84 := string(randStringThetest(r))
-		this.Field14 = &v84
+		vAlue84 := string(randStringThetest(r))
+		this.Field14 = &vAlue84
 	}
 	if r.Intn(5) != 0 {
-		v85 := r.Intn(100)
-		this.Field15 = make([]byte, v85)
-		for i := 0; i < v85; i++ {
+		vAlue85 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue85)
+		for i := 0; i < vAlue85; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -22259,9 +22259,9 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 	this := &NidRepStruct{}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(10)
-		this.Field1 = make([]float64, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -22269,9 +22269,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(10)
-		this.Field2 = make([]float32, v87)
-		for i := 0; i < v87; i++ {
+		vAlue87 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue87)
+		for i := 0; i < vAlue87; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -22279,32 +22279,32 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v88 := r.Intn(5)
-		this.Field3 = make([]NidOptNative, v88)
-		for i := 0; i < v88; i++ {
-			v89 := NewPopulatedNidOptNative(r, easy)
-			this.Field3[i] = *v89
+		vAlue88 := r.Intn(5)
+		this.Field3 = make([]NidOptNative, vAlue88)
+		for i := 0; i < vAlue88; i++ {
+			vAlue89 := NewPopulatedNidOptNative(r, easy)
+			this.Field3[i] = *vAlue89
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(5)
-		this.Field4 = make([]NinOptNative, v90)
-		for i := 0; i < v90; i++ {
-			v91 := NewPopulatedNinOptNative(r, easy)
-			this.Field4[i] = *v91
+		vAlue90 := r.Intn(5)
+		this.Field4 = make([]NinOptNative, vAlue90)
+		for i := 0; i < vAlue90; i++ {
+			vAlue91 := NewPopulatedNinOptNative(r, easy)
+			this.Field4[i] = *vAlue91
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
-		this.Field6 = make([]uint64, v92)
-		for i := 0; i < v92; i++ {
+		vAlue92 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue92)
+		for i := 0; i < vAlue92; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
-		this.Field7 = make([]int32, v93)
-		for i := 0; i < v93; i++ {
+		vAlue93 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue93)
+		for i := 0; i < vAlue93; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -22312,34 +22312,34 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(5)
-		this.Field8 = make([]NidOptNative, v94)
-		for i := 0; i < v94; i++ {
-			v95 := NewPopulatedNidOptNative(r, easy)
-			this.Field8[i] = *v95
+		vAlue94 := r.Intn(5)
+		this.Field8 = make([]NidOptNative, vAlue94)
+		for i := 0; i < vAlue94; i++ {
+			vAlue95 := NewPopulatedNidOptNative(r, easy)
+			this.Field8[i] = *vAlue95
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
-		this.Field13 = make([]bool, v96)
-		for i := 0; i < v96; i++ {
+		vAlue96 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue96)
+		for i := 0; i < vAlue96; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
-		this.Field14 = make([]string, v97)
-		for i := 0; i < v97; i++ {
+		vAlue97 := r.Intn(10)
+		this.Field14 = make([]string, vAlue97)
+		for i := 0; i < vAlue97; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
-		this.Field15 = make([][]byte, v98)
-		for i := 0; i < v98; i++ {
-			v99 := r.Intn(100)
-			this.Field15[i] = make([]byte, v99)
-			for j := 0; j < v99; j++ {
+		vAlue98 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue98)
+		for i := 0; i < vAlue98; i++ {
+			vAlue99 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue99)
+			for j := 0; j < vAlue99; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -22353,9 +22353,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 	this := &NinRepStruct{}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
-		this.Field1 = make([]float64, v100)
-		for i := 0; i < v100; i++ {
+		vAlue100 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue100)
+		for i := 0; i < vAlue100; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -22363,9 +22363,9 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
-		this.Field2 = make([]float32, v101)
-		for i := 0; i < v101; i++ {
+		vAlue101 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue101)
+		for i := 0; i < vAlue101; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -22373,30 +22373,30 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(5)
-		this.Field3 = make([]*NidOptNative, v102)
-		for i := 0; i < v102; i++ {
+		vAlue102 := r.Intn(5)
+		this.Field3 = make([]*NidOptNative, vAlue102)
+		for i := 0; i < vAlue102; i++ {
 			this.Field3[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(5)
-		this.Field4 = make([]*NinOptNative, v103)
-		for i := 0; i < v103; i++ {
+		vAlue103 := r.Intn(5)
+		this.Field4 = make([]*NinOptNative, vAlue103)
+		for i := 0; i < vAlue103; i++ {
 			this.Field4[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
-		this.Field6 = make([]uint64, v104)
-		for i := 0; i < v104; i++ {
+		vAlue104 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue104)
+		for i := 0; i < vAlue104; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
-		this.Field7 = make([]int32, v105)
-		for i := 0; i < v105; i++ {
+		vAlue105 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue105)
+		for i := 0; i < vAlue105; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -22404,33 +22404,33 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(5)
-		this.Field8 = make([]*NidOptNative, v106)
-		for i := 0; i < v106; i++ {
+		vAlue106 := r.Intn(5)
+		this.Field8 = make([]*NidOptNative, vAlue106)
+		for i := 0; i < vAlue106; i++ {
 			this.Field8[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
-		this.Field13 = make([]bool, v107)
-		for i := 0; i < v107; i++ {
+		vAlue107 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue107)
+		for i := 0; i < vAlue107; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
-		this.Field14 = make([]string, v108)
-		for i := 0; i < v108; i++ {
+		vAlue108 := r.Intn(10)
+		this.Field14 = make([]string, vAlue108)
+		for i := 0; i < vAlue108; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
-		this.Field15 = make([][]byte, v109)
-		for i := 0; i < v109; i++ {
-			v110 := r.Intn(100)
-			this.Field15[i] = make([]byte, v110)
-			for j := 0; j < v110; j++ {
+		vAlue109 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue109)
+		for i := 0; i < vAlue109; i++ {
+			vAlue110 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue110)
+			for j := 0; j < vAlue110; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -22446,8 +22446,8 @@ func NewPopulatedNidEmbeddedStruct(r randyThetest, easy bool) *NidEmbeddedStruct
 	if r.Intn(5) != 0 {
 		this.NidOptNative = NewPopulatedNidOptNative(r, easy)
 	}
-	v111 := NewPopulatedNidOptNative(r, easy)
-	this.Field200 = *v111
+	vAlue111 := NewPopulatedNidOptNative(r, easy)
+	this.Field200 = *vAlue111
 	this.Field210 = bool(bool(r.Intn(2) == 0))
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -22464,8 +22464,8 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 		this.Field200 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v112 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v112
+		vAlue112 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue112
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -22475,14 +22475,14 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 
 func NewPopulatedNidNestedStruct(r randyThetest, easy bool) *NidNestedStruct {
 	this := &NidNestedStruct{}
-	v113 := NewPopulatedNidOptStruct(r, easy)
-	this.Field1 = *v113
+	vAlue113 := NewPopulatedNidOptStruct(r, easy)
+	this.Field1 = *vAlue113
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(5)
-		this.Field2 = make([]NidRepStruct, v114)
-		for i := 0; i < v114; i++ {
-			v115 := NewPopulatedNidRepStruct(r, easy)
-			this.Field2[i] = *v115
+		vAlue114 := r.Intn(5)
+		this.Field2 = make([]NidRepStruct, vAlue114)
+		for i := 0; i < vAlue114; i++ {
+			vAlue115 := NewPopulatedNidRepStruct(r, easy)
+			this.Field2[i] = *vAlue115
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22497,9 +22497,9 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 		this.Field1 = NewPopulatedNinOptStruct(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(5)
-		this.Field2 = make([]*NinRepStruct, v116)
-		for i := 0; i < v116; i++ {
+		vAlue116 := r.Intn(5)
+		this.Field2 = make([]*NinRepStruct, vAlue116)
+		for i := 0; i < vAlue116; i++ {
 			this.Field2[i] = NewPopulatedNinRepStruct(r, easy)
 		}
 	}
@@ -22511,10 +22511,10 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 
 func NewPopulatedNidOptCustom(r randyThetest, easy bool) *NidOptCustom {
 	this := &NidOptCustom{}
-	v117 := NewPopulatedUuid(r)
-	this.Id = *v117
-	v118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Value = *v118
+	vAlue117 := NewPopulatedUuid(r)
+	this.Id = *vAlue117
+	vAlue118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Value = *vAlue118
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22549,19 +22549,19 @@ func NewPopulatedNinOptCustom(r randyThetest, easy bool) *NinOptCustom {
 func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 	this := &NidRepCustom{}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
-		this.Id = make([]Uuid, v119)
-		for i := 0; i < v119; i++ {
-			v120 := NewPopulatedUuid(r)
-			this.Id[i] = *v120
+		vAlue119 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue119)
+		for i := 0; i < vAlue119; i++ {
+			vAlue120 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue120
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v121)
-		for i := 0; i < v121; i++ {
-			v122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v122
+		vAlue121 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue121)
+		for i := 0; i < vAlue121; i++ {
+			vAlue122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue122
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22573,19 +22573,19 @@ func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 func NewPopulatedNinRepCustom(r randyThetest, easy bool) *NinRepCustom {
 	this := &NinRepCustom{}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
-		this.Id = make([]Uuid, v123)
-		for i := 0; i < v123; i++ {
-			v124 := NewPopulatedUuid(r)
-			this.Id[i] = *v124
+		vAlue123 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue123)
+		for i := 0; i < vAlue123; i++ {
+			vAlue124 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue124
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v125)
-		for i := 0; i < v125; i++ {
-			v126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v126
+		vAlue125 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue125)
+		for i := 0; i < vAlue125; i++ {
+			vAlue126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue126
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22599,45 +22599,45 @@ func NewPopulatedNinOptNativeUnion(r randyThetest, easy bool) *NinOptNativeUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v127 := float64(r.Float64())
+		vAlue127 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v127 *= -1
+			vAlue127 *= -1
 		}
-		this.Field1 = &v127
+		this.Field1 = &vAlue127
 	case 1:
-		v128 := float32(r.Float32())
+		vAlue128 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v128 *= -1
+			vAlue128 *= -1
 		}
-		this.Field2 = &v128
+		this.Field2 = &vAlue128
 	case 2:
-		v129 := int32(r.Int31())
+		vAlue129 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v129 *= -1
+			vAlue129 *= -1
 		}
-		this.Field3 = &v129
+		this.Field3 = &vAlue129
 	case 3:
-		v130 := int64(r.Int63())
+		vAlue130 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v130 *= -1
+			vAlue130 *= -1
 		}
-		this.Field4 = &v130
+		this.Field4 = &vAlue130
 	case 4:
-		v131 := uint32(r.Uint32())
-		this.Field5 = &v131
+		vAlue131 := uint32(r.Uint32())
+		this.Field5 = &vAlue131
 	case 5:
-		v132 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v132
+		vAlue132 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue132
 	case 6:
-		v133 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v133
+		vAlue133 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue133
 	case 7:
-		v134 := string(randStringThetest(r))
-		this.Field14 = &v134
+		vAlue134 := string(randStringThetest(r))
+		this.Field14 = &vAlue134
 	case 8:
-		v135 := r.Intn(100)
-		this.Field15 = make([]byte, v135)
-		for i := 0; i < v135; i++ {
+		vAlue135 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue135)
+		for i := 0; i < vAlue135; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -22649,40 +22649,40 @@ func NewPopulatedNinOptStructUnion(r randyThetest, easy bool) *NinOptStructUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v136 := float64(r.Float64())
+		vAlue136 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v136 *= -1
+			vAlue136 *= -1
 		}
-		this.Field1 = &v136
+		this.Field1 = &vAlue136
 	case 1:
-		v137 := float32(r.Float32())
+		vAlue137 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v137 *= -1
+			vAlue137 *= -1
 		}
-		this.Field2 = &v137
+		this.Field2 = &vAlue137
 	case 2:
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
 	case 3:
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	case 4:
-		v138 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v138
+		vAlue138 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue138
 	case 5:
-		v139 := int32(r.Int31())
+		vAlue139 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v139 *= -1
+			vAlue139 *= -1
 		}
-		this.Field7 = &v139
+		this.Field7 = &vAlue139
 	case 6:
-		v140 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v140
+		vAlue140 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue140
 	case 7:
-		v141 := string(randStringThetest(r))
-		this.Field14 = &v141
+		vAlue141 := string(randStringThetest(r))
+		this.Field14 = &vAlue141
 	case 8:
-		v142 := r.Intn(100)
-		this.Field15 = make([]byte, v142)
-		for i := 0; i < v142; i++ {
+		vAlue142 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue142)
+		for i := 0; i < vAlue142; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -22698,8 +22698,8 @@ func NewPopulatedNinEmbeddedStructUnion(r randyThetest, easy bool) *NinEmbeddedS
 	case 1:
 		this.Field200 = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v143 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v143
+		vAlue143 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue143
 	}
 	return this
 }
@@ -22734,10 +22734,10 @@ func NewPopulatedTree(r randyThetest, easy bool) *Tree {
 
 func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 	this := &OrBranch{}
-	v144 := NewPopulatedTree(r, easy)
-	this.Left = *v144
-	v145 := NewPopulatedTree(r, easy)
-	this.Right = *v145
+	vAlue144 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue144
+	vAlue145 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue145
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22746,10 +22746,10 @@ func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 
 func NewPopulatedAndBranch(r randyThetest, easy bool) *AndBranch {
 	this := &AndBranch{}
-	v146 := NewPopulatedTree(r, easy)
-	this.Left = *v146
-	v147 := NewPopulatedTree(r, easy)
-	this.Right = *v147
+	vAlue146 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue146
+	vAlue147 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue147
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22785,8 +22785,8 @@ func NewPopulatedDeepTree(r randyThetest, easy bool) *DeepTree {
 
 func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 	this := &ADeepBranch{}
-	v148 := NewPopulatedDeepTree(r, easy)
-	this.Down = *v148
+	vAlue148 := NewPopulatedDeepTree(r, easy)
+	this.Down = *vAlue148
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22795,10 +22795,10 @@ func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 
 func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 	this := &AndDeepBranch{}
-	v149 := NewPopulatedDeepTree(r, easy)
-	this.Left = *v149
-	v150 := NewPopulatedDeepTree(r, easy)
-	this.Right = *v150
+	vAlue149 := NewPopulatedDeepTree(r, easy)
+	this.Left = *vAlue149
+	vAlue150 := NewPopulatedDeepTree(r, easy)
+	this.Right = *vAlue150
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22807,8 +22807,8 @@ func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 
 func NewPopulatedDeepLeaf(r randyThetest, easy bool) *DeepLeaf {
 	this := &DeepLeaf{}
-	v151 := NewPopulatedTree(r, easy)
-	this.Tree = *v151
+	vAlue151 := NewPopulatedTree(r, easy)
+	this.Tree = *vAlue151
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -22835,16 +22835,16 @@ func NewPopulatedNidOptEnum(r randyThetest, easy bool) *NidOptEnum {
 func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 	this := &NinOptEnum{}
 	if r.Intn(5) != 0 {
-		v152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v152
+		vAlue152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue152
 	}
 	if r.Intn(5) != 0 {
-		v153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v153
+		vAlue153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue153
 	}
 	if r.Intn(5) != 0 {
-		v154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v154
+		vAlue154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue154
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22855,23 +22855,23 @@ func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 	this := &NidRepEnum{}
 	if r.Intn(5) != 0 {
-		v155 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v155)
-		for i := 0; i < v155; i++ {
+		vAlue155 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue155)
+		for i := 0; i < vAlue155; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v156 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v156)
-		for i := 0; i < v156; i++ {
+		vAlue156 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue156)
+		for i := 0; i < vAlue156; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v157 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v157)
-		for i := 0; i < v157; i++ {
+		vAlue157 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue157)
+		for i := 0; i < vAlue157; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -22884,23 +22884,23 @@ func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 	this := &NinRepEnum{}
 	if r.Intn(5) != 0 {
-		v158 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v158)
-		for i := 0; i < v158; i++ {
+		vAlue158 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue158)
+		for i := 0; i < vAlue158; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v159 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v159)
-		for i := 0; i < v159; i++ {
+		vAlue159 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue159)
+		for i := 0; i < vAlue159; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v160 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v160)
-		for i := 0; i < v160; i++ {
+		vAlue160 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue160)
+		for i := 0; i < vAlue160; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -22913,16 +22913,16 @@ func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault {
 	this := &NinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v161
+		vAlue161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue161
 	}
 	if r.Intn(5) != 0 {
-		v162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v162
+		vAlue162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue162
 	}
 	if r.Intn(5) != 0 {
-		v163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v163
+		vAlue163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue163
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22933,16 +22933,16 @@ func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault
 func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum {
 	this := &AnotherNinOptEnum{}
 	if r.Intn(5) != 0 {
-		v164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v164
+		vAlue164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue164
 	}
 	if r.Intn(5) != 0 {
-		v165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v165
+		vAlue165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue165
 	}
 	if r.Intn(5) != 0 {
-		v166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v166
+		vAlue166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue166
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22953,16 +22953,16 @@ func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum
 func NewPopulatedAnotherNinOptEnumDefault(r randyThetest, easy bool) *AnotherNinOptEnumDefault {
 	this := &AnotherNinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v167
+		vAlue167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue167
 	}
 	if r.Intn(5) != 0 {
-		v168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v168
+		vAlue168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue168
 	}
 	if r.Intn(5) != 0 {
-		v169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v169
+		vAlue169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue169
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22980,9 +22980,9 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 	if r.Intn(2) == 0 {
 		this.Time2 *= -1
 	}
-	v170 := r.Intn(100)
-	this.Data = make([]byte, v170)
-	for i := 0; i < v170; i++ {
+	vAlue170 := r.Intn(100)
+	this.Data = make([]byte, vAlue170)
+	for i := 0; i < vAlue170; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22994,11 +22994,11 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 func NewPopulatedMyExtendable(r randyThetest, easy bool) *MyExtendable {
 	this := &MyExtendable{}
 	if r.Intn(5) != 0 {
-		v171 := int64(r.Int63())
+		vAlue171 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v171 *= -1
+			vAlue171 *= -1
 		}
-		this.Field1 = &v171
+		this.Field1 = &vAlue171
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -23021,18 +23021,18 @@ func NewPopulatedMyExtendable(r randyThetest, easy bool) *MyExtendable {
 func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 	this := &OtherExtenable{}
 	if r.Intn(5) != 0 {
-		v172 := int64(r.Int63())
+		vAlue172 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v172 *= -1
+			vAlue172 *= -1
 		}
-		this.Field2 = &v172
+		this.Field2 = &vAlue172
 	}
 	if r.Intn(5) != 0 {
-		v173 := int64(r.Int63())
+		vAlue173 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v173 *= -1
+			vAlue173 *= -1
 		}
-		this.Field13 = &v173
+		this.Field13 = &vAlue173
 	}
 	if r.Intn(5) != 0 {
 		this.M = NewPopulatedMyExtendable(r, easy)
@@ -23065,15 +23065,15 @@ func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 	this := &NestedDefinition{}
 	if r.Intn(5) != 0 {
-		v174 := int64(r.Int63())
+		vAlue174 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v174 *= -1
+			vAlue174 *= -1
 		}
-		this.Field1 = &v174
+		this.Field1 = &vAlue174
 	}
 	if r.Intn(5) != 0 {
-		v175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.EnumField = &v175
+		vAlue175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.EnumField = &vAlue175
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -23090,8 +23090,8 @@ func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *NestedDefinition_NestedMessage {
 	this := &NestedDefinition_NestedMessage{}
 	if r.Intn(5) != 0 {
-		v176 := uint64(uint64(r.Uint32()))
-		this.NestedField1 = &v176
+		vAlue176 := uint64(uint64(r.Uint32()))
+		this.NestedField1 = &vAlue176
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -23105,8 +23105,8 @@ func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *Nest
 func NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r randyThetest, easy bool) *NestedDefinition_NestedMessage_NestedNestedMsg {
 	this := &NestedDefinition_NestedMessage_NestedNestedMsg{}
 	if r.Intn(5) != 0 {
-		v177 := string(randStringThetest(r))
-		this.NestedNestedField1 = &v177
+		vAlue177 := string(randStringThetest(r))
+		this.NestedNestedField1 = &vAlue177
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 11)
@@ -23120,8 +23120,8 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 		this.A = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.B = &v178
+		vAlue178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.B = &vAlue178
 	}
 	if r.Intn(5) != 0 {
 		this.C = NewPopulatedNestedDefinition_NestedMessage(r, easy)
@@ -23135,89 +23135,89 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDefault {
 	this := &NinOptNativeDefault{}
 	if r.Intn(5) != 0 {
-		v179 := float64(r.Float64())
+		vAlue179 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v179 *= -1
+			vAlue179 *= -1
 		}
-		this.Field1 = &v179
+		this.Field1 = &vAlue179
 	}
 	if r.Intn(5) != 0 {
-		v180 := float32(r.Float32())
+		vAlue180 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v180 *= -1
+			vAlue180 *= -1
 		}
-		this.Field2 = &v180
+		this.Field2 = &vAlue180
 	}
 	if r.Intn(5) != 0 {
-		v181 := int32(r.Int31())
+		vAlue181 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v181 *= -1
+			vAlue181 *= -1
 		}
-		this.Field3 = &v181
+		this.Field3 = &vAlue181
 	}
 	if r.Intn(5) != 0 {
-		v182 := int64(r.Int63())
+		vAlue182 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v182 *= -1
+			vAlue182 *= -1
 		}
-		this.Field4 = &v182
+		this.Field4 = &vAlue182
 	}
 	if r.Intn(5) != 0 {
-		v183 := uint32(r.Uint32())
-		this.Field5 = &v183
+		vAlue183 := uint32(r.Uint32())
+		this.Field5 = &vAlue183
 	}
 	if r.Intn(5) != 0 {
-		v184 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v184
+		vAlue184 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue184
 	}
 	if r.Intn(5) != 0 {
-		v185 := int32(r.Int31())
+		vAlue185 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v185 *= -1
+			vAlue185 *= -1
 		}
-		this.Field7 = &v185
+		this.Field7 = &vAlue185
 	}
 	if r.Intn(5) != 0 {
-		v186 := int64(r.Int63())
+		vAlue186 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v186 *= -1
+			vAlue186 *= -1
 		}
-		this.Field8 = &v186
+		this.Field8 = &vAlue186
 	}
 	if r.Intn(5) != 0 {
-		v187 := uint32(r.Uint32())
-		this.Field9 = &v187
+		vAlue187 := uint32(r.Uint32())
+		this.Field9 = &vAlue187
 	}
 	if r.Intn(5) != 0 {
-		v188 := int32(r.Int31())
+		vAlue188 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v188 *= -1
+			vAlue188 *= -1
 		}
-		this.Field10 = &v188
+		this.Field10 = &vAlue188
 	}
 	if r.Intn(5) != 0 {
-		v189 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v189
+		vAlue189 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue189
 	}
 	if r.Intn(5) != 0 {
-		v190 := int64(r.Int63())
+		vAlue190 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v190 *= -1
+			vAlue190 *= -1
 		}
-		this.Field12 = &v190
+		this.Field12 = &vAlue190
 	}
 	if r.Intn(5) != 0 {
-		v191 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v191
+		vAlue191 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue191
 	}
 	if r.Intn(5) != 0 {
-		v192 := string(randStringThetest(r))
-		this.Field14 = &v192
+		vAlue192 := string(randStringThetest(r))
+		this.Field14 = &vAlue192
 	}
 	if r.Intn(5) != 0 {
-		v193 := r.Intn(100)
-		this.Field15 = make([]byte, v193)
-		for i := 0; i < v193; i++ {
+		vAlue193 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue193)
+		for i := 0; i < vAlue193; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -23229,8 +23229,8 @@ func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDef
 
 func NewPopulatedCustomContainer(r randyThetest, easy bool) *CustomContainer {
 	this := &CustomContainer{}
-	v194 := NewPopulatedNidOptCustom(r, easy)
-	this.CustomStruct = *v194
+	vAlue194 := NewPopulatedNidOptCustom(r, easy)
+	this.CustomStruct = *vAlue194
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -23277,9 +23277,9 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 	}
 	this.FieldM = bool(bool(r.Intn(2) == 0))
 	this.FieldN = string(randStringThetest(r))
-	v195 := r.Intn(100)
-	this.FieldO = make([]byte, v195)
-	for i := 0; i < v195; i++ {
+	vAlue195 := r.Intn(100)
+	this.FieldO = make([]byte, vAlue195)
+	for i := 0; i < vAlue195; i++ {
 		this.FieldO[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23291,89 +23291,89 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNinOptNative {
 	this := &CustomNameNinOptNative{}
 	if r.Intn(5) != 0 {
-		v196 := float64(r.Float64())
+		vAlue196 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v196 *= -1
+			vAlue196 *= -1
 		}
-		this.FieldA = &v196
+		this.FieldA = &vAlue196
 	}
 	if r.Intn(5) != 0 {
-		v197 := float32(r.Float32())
+		vAlue197 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v197 *= -1
+			vAlue197 *= -1
 		}
-		this.FieldB = &v197
+		this.FieldB = &vAlue197
 	}
 	if r.Intn(5) != 0 {
-		v198 := int32(r.Int31())
+		vAlue198 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v198 *= -1
+			vAlue198 *= -1
 		}
-		this.FieldC = &v198
+		this.FieldC = &vAlue198
 	}
 	if r.Intn(5) != 0 {
-		v199 := int64(r.Int63())
+		vAlue199 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v199 *= -1
+			vAlue199 *= -1
 		}
-		this.FieldD = &v199
+		this.FieldD = &vAlue199
 	}
 	if r.Intn(5) != 0 {
-		v200 := uint32(r.Uint32())
-		this.FieldE = &v200
+		vAlue200 := uint32(r.Uint32())
+		this.FieldE = &vAlue200
 	}
 	if r.Intn(5) != 0 {
-		v201 := uint64(uint64(r.Uint32()))
-		this.FieldF = &v201
+		vAlue201 := uint64(uint64(r.Uint32()))
+		this.FieldF = &vAlue201
 	}
 	if r.Intn(5) != 0 {
-		v202 := int32(r.Int31())
+		vAlue202 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v202 *= -1
+			vAlue202 *= -1
 		}
-		this.FieldG = &v202
+		this.FieldG = &vAlue202
 	}
 	if r.Intn(5) != 0 {
-		v203 := int64(r.Int63())
+		vAlue203 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v203 *= -1
+			vAlue203 *= -1
 		}
-		this.FieldH = &v203
+		this.FieldH = &vAlue203
 	}
 	if r.Intn(5) != 0 {
-		v204 := uint32(r.Uint32())
-		this.FieldI = &v204
+		vAlue204 := uint32(r.Uint32())
+		this.FieldI = &vAlue204
 	}
 	if r.Intn(5) != 0 {
-		v205 := int32(r.Int31())
+		vAlue205 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v205 *= -1
+			vAlue205 *= -1
 		}
-		this.FieldJ = &v205
+		this.FieldJ = &vAlue205
 	}
 	if r.Intn(5) != 0 {
-		v206 := uint64(uint64(r.Uint32()))
-		this.FieldK = &v206
+		vAlue206 := uint64(uint64(r.Uint32()))
+		this.FieldK = &vAlue206
 	}
 	if r.Intn(5) != 0 {
-		v207 := int64(r.Int63())
+		vAlue207 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v207 *= -1
+			vAlue207 *= -1
 		}
-		this.FielL = &v207
+		this.FielL = &vAlue207
 	}
 	if r.Intn(5) != 0 {
-		v208 := bool(bool(r.Intn(2) == 0))
-		this.FieldM = &v208
+		vAlue208 := bool(bool(r.Intn(2) == 0))
+		this.FieldM = &vAlue208
 	}
 	if r.Intn(5) != 0 {
-		v209 := string(randStringThetest(r))
-		this.FieldN = &v209
+		vAlue209 := string(randStringThetest(r))
+		this.FieldN = &vAlue209
 	}
 	if r.Intn(5) != 0 {
-		v210 := r.Intn(100)
-		this.FieldO = make([]byte, v210)
-		for i := 0; i < v210; i++ {
+		vAlue210 := r.Intn(100)
+		this.FieldO = make([]byte, vAlue210)
+		for i := 0; i < vAlue210; i++ {
 			this.FieldO[i] = byte(r.Intn(256))
 		}
 	}
@@ -23386,9 +23386,9 @@ func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNinRepNative {
 	this := &CustomNameNinRepNative{}
 	if r.Intn(5) != 0 {
-		v211 := r.Intn(10)
-		this.FieldA = make([]float64, v211)
-		for i := 0; i < v211; i++ {
+		vAlue211 := r.Intn(10)
+		this.FieldA = make([]float64, vAlue211)
+		for i := 0; i < vAlue211; i++ {
 			this.FieldA[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.FieldA[i] *= -1
@@ -23396,9 +23396,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v212 := r.Intn(10)
-		this.FieldB = make([]float32, v212)
-		for i := 0; i < v212; i++ {
+		vAlue212 := r.Intn(10)
+		this.FieldB = make([]float32, vAlue212)
+		for i := 0; i < vAlue212; i++ {
 			this.FieldB[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.FieldB[i] *= -1
@@ -23406,9 +23406,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v213 := r.Intn(10)
-		this.FieldC = make([]int32, v213)
-		for i := 0; i < v213; i++ {
+		vAlue213 := r.Intn(10)
+		this.FieldC = make([]int32, vAlue213)
+		for i := 0; i < vAlue213; i++ {
 			this.FieldC[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldC[i] *= -1
@@ -23416,9 +23416,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v214 := r.Intn(10)
-		this.FieldD = make([]int64, v214)
-		for i := 0; i < v214; i++ {
+		vAlue214 := r.Intn(10)
+		this.FieldD = make([]int64, vAlue214)
+		for i := 0; i < vAlue214; i++ {
 			this.FieldD[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldD[i] *= -1
@@ -23426,23 +23426,23 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v215 := r.Intn(10)
-		this.FieldE = make([]uint32, v215)
-		for i := 0; i < v215; i++ {
+		vAlue215 := r.Intn(10)
+		this.FieldE = make([]uint32, vAlue215)
+		for i := 0; i < vAlue215; i++ {
 			this.FieldE[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v216 := r.Intn(10)
-		this.FieldF = make([]uint64, v216)
-		for i := 0; i < v216; i++ {
+		vAlue216 := r.Intn(10)
+		this.FieldF = make([]uint64, vAlue216)
+		for i := 0; i < vAlue216; i++ {
 			this.FieldF[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v217 := r.Intn(10)
-		this.FieldG = make([]int32, v217)
-		for i := 0; i < v217; i++ {
+		vAlue217 := r.Intn(10)
+		this.FieldG = make([]int32, vAlue217)
+		for i := 0; i < vAlue217; i++ {
 			this.FieldG[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldG[i] *= -1
@@ -23450,9 +23450,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v218 := r.Intn(10)
-		this.FieldH = make([]int64, v218)
-		for i := 0; i < v218; i++ {
+		vAlue218 := r.Intn(10)
+		this.FieldH = make([]int64, vAlue218)
+		for i := 0; i < vAlue218; i++ {
 			this.FieldH[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldH[i] *= -1
@@ -23460,16 +23460,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v219 := r.Intn(10)
-		this.FieldI = make([]uint32, v219)
-		for i := 0; i < v219; i++ {
+		vAlue219 := r.Intn(10)
+		this.FieldI = make([]uint32, vAlue219)
+		for i := 0; i < vAlue219; i++ {
 			this.FieldI[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v220 := r.Intn(10)
-		this.FieldJ = make([]int32, v220)
-		for i := 0; i < v220; i++ {
+		vAlue220 := r.Intn(10)
+		this.FieldJ = make([]int32, vAlue220)
+		for i := 0; i < vAlue220; i++ {
 			this.FieldJ[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldJ[i] *= -1
@@ -23477,16 +23477,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v221 := r.Intn(10)
-		this.FieldK = make([]uint64, v221)
-		for i := 0; i < v221; i++ {
+		vAlue221 := r.Intn(10)
+		this.FieldK = make([]uint64, vAlue221)
+		for i := 0; i < vAlue221; i++ {
 			this.FieldK[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v222 := r.Intn(10)
-		this.FieldL = make([]int64, v222)
-		for i := 0; i < v222; i++ {
+		vAlue222 := r.Intn(10)
+		this.FieldL = make([]int64, vAlue222)
+		for i := 0; i < vAlue222; i++ {
 			this.FieldL[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldL[i] *= -1
@@ -23494,26 +23494,26 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v223 := r.Intn(10)
-		this.FieldM = make([]bool, v223)
-		for i := 0; i < v223; i++ {
+		vAlue223 := r.Intn(10)
+		this.FieldM = make([]bool, vAlue223)
+		for i := 0; i < vAlue223; i++ {
 			this.FieldM[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v224 := r.Intn(10)
-		this.FieldN = make([]string, v224)
-		for i := 0; i < v224; i++ {
+		vAlue224 := r.Intn(10)
+		this.FieldN = make([]string, vAlue224)
+		for i := 0; i < vAlue224; i++ {
 			this.FieldN[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v225 := r.Intn(10)
-		this.FieldO = make([][]byte, v225)
-		for i := 0; i < v225; i++ {
-			v226 := r.Intn(100)
-			this.FieldO[i] = make([]byte, v226)
-			for j := 0; j < v226; j++ {
+		vAlue225 := r.Intn(10)
+		this.FieldO = make([][]byte, vAlue225)
+		for i := 0; i < vAlue225; i++ {
+			vAlue226 := r.Intn(100)
+			this.FieldO[i] = make([]byte, vAlue226)
+			for j := 0; j < vAlue226; j++ {
 				this.FieldO[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -23527,55 +23527,55 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinStruct(r randyThetest, easy bool) *CustomNameNinStruct {
 	this := &CustomNameNinStruct{}
 	if r.Intn(5) != 0 {
-		v227 := float64(r.Float64())
+		vAlue227 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v227 *= -1
+			vAlue227 *= -1
 		}
-		this.FieldA = &v227
+		this.FieldA = &vAlue227
 	}
 	if r.Intn(5) != 0 {
-		v228 := float32(r.Float32())
+		vAlue228 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v228 *= -1
+			vAlue228 *= -1
 		}
-		this.FieldB = &v228
+		this.FieldB = &vAlue228
 	}
 	if r.Intn(5) != 0 {
 		this.FieldC = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v229 := r.Intn(5)
-		this.FieldD = make([]*NinOptNative, v229)
-		for i := 0; i < v229; i++ {
+		vAlue229 := r.Intn(5)
+		this.FieldD = make([]*NinOptNative, vAlue229)
+		for i := 0; i < vAlue229; i++ {
 			this.FieldD[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v230 := uint64(uint64(r.Uint32()))
-		this.FieldE = &v230
+		vAlue230 := uint64(uint64(r.Uint32()))
+		this.FieldE = &vAlue230
 	}
 	if r.Intn(5) != 0 {
-		v231 := int32(r.Int31())
+		vAlue231 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v231 *= -1
+			vAlue231 *= -1
 		}
-		this.FieldF = &v231
+		this.FieldF = &vAlue231
 	}
 	if r.Intn(5) != 0 {
 		this.FieldG = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v232 := bool(bool(r.Intn(2) == 0))
-		this.FieldH = &v232
+		vAlue232 := bool(bool(r.Intn(2) == 0))
+		this.FieldH = &vAlue232
 	}
 	if r.Intn(5) != 0 {
-		v233 := string(randStringThetest(r))
-		this.FieldI = &v233
+		vAlue233 := string(randStringThetest(r))
+		this.FieldI = &vAlue233
 	}
 	if r.Intn(5) != 0 {
-		v234 := r.Intn(100)
-		this.FieldJ = make([]byte, v234)
-		for i := 0; i < v234; i++ {
+		vAlue234 := r.Intn(100)
+		this.FieldJ = make([]byte, vAlue234)
+		for i := 0; i < vAlue234; i++ {
 			this.FieldJ[i] = byte(r.Intn(256))
 		}
 	}
@@ -23594,19 +23594,19 @@ func NewPopulatedCustomNameCustomType(r randyThetest, easy bool) *CustomNameCust
 		this.FieldB = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	}
 	if r.Intn(5) != 0 {
-		v235 := r.Intn(10)
-		this.FieldC = make([]Uuid, v235)
-		for i := 0; i < v235; i++ {
-			v236 := NewPopulatedUuid(r)
-			this.FieldC[i] = *v236
+		vAlue235 := r.Intn(10)
+		this.FieldC = make([]Uuid, vAlue235)
+		for i := 0; i < vAlue235; i++ {
+			vAlue236 := NewPopulatedUuid(r)
+			this.FieldC[i] = *vAlue236
 		}
 	}
 	if r.Intn(5) != 0 {
-		v237 := r.Intn(10)
-		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, v237)
-		for i := 0; i < v237; i++ {
-			v238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.FieldD[i] = *v238
+		vAlue237 := r.Intn(10)
+		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue237)
+		for i := 0; i < vAlue237; i++ {
+			vAlue238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.FieldD[i] = *vAlue238
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23624,8 +23624,8 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 	case 1:
 		this.FieldA = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v239 := bool(bool(r.Intn(2) == 0))
-		this.FieldB = &v239
+		vAlue239 := bool(bool(r.Intn(2) == 0))
+		this.FieldB = &vAlue239
 	}
 	return this
 }
@@ -23633,13 +23633,13 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 	this := &CustomNameEnum{}
 	if r.Intn(5) != 0 {
-		v240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.FieldA = &v240
+		vAlue240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.FieldA = &vAlue240
 	}
 	if r.Intn(5) != 0 {
-		v241 := r.Intn(10)
-		this.FieldB = make([]TheTestEnum, v241)
-		for i := 0; i < v241; i++ {
+		vAlue241 := r.Intn(10)
+		this.FieldB = make([]TheTestEnum, vAlue241)
+		for i := 0; i < vAlue241; i++ {
 			this.FieldB[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
@@ -23652,11 +23652,11 @@ func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 	this := &NoExtensionsMap{}
 	if r.Intn(5) != 0 {
-		v242 := int64(r.Int63())
+		vAlue242 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v242 *= -1
+			vAlue242 *= -1
 		}
-		this.Field1 = &v242
+		this.Field1 = &vAlue242
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -23679,8 +23679,8 @@ func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 	this := &Unrecognized{}
 	if r.Intn(5) != 0 {
-		v243 := string(randStringThetest(r))
-		this.Field1 = &v243
+		vAlue243 := string(randStringThetest(r))
+		this.Field1 = &vAlue243
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -23690,15 +23690,15 @@ func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedWithInner {
 	this := &UnrecognizedWithInner{}
 	if r.Intn(5) != 0 {
-		v244 := r.Intn(5)
-		this.Embedded = make([]*UnrecognizedWithInner_Inner, v244)
-		for i := 0; i < v244; i++ {
+		vAlue244 := r.Intn(5)
+		this.Embedded = make([]*UnrecognizedWithInner_Inner, vAlue244)
+		for i := 0; i < vAlue244; i++ {
 			this.Embedded[i] = NewPopulatedUnrecognizedWithInner_Inner(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v245 := string(randStringThetest(r))
-		this.Field2 = &v245
+		vAlue245 := string(randStringThetest(r))
+		this.Field2 = &vAlue245
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -23709,8 +23709,8 @@ func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *UnrecognizedWithInner_Inner {
 	this := &UnrecognizedWithInner_Inner{}
 	if r.Intn(5) != 0 {
-		v246 := uint32(r.Uint32())
-		this.Field1 = &v246
+		vAlue246 := uint32(r.Uint32())
+		this.Field1 = &vAlue246
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -23719,11 +23719,11 @@ func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *Unrecog
 
 func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedWithEmbed {
 	this := &UnrecognizedWithEmbed{}
-	v247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
-	this.UnrecognizedWithEmbed_Embedded = *v247
+	vAlue247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
+	this.UnrecognizedWithEmbed_Embedded = *vAlue247
 	if r.Intn(5) != 0 {
-		v248 := string(randStringThetest(r))
-		this.Field2 = &v248
+		vAlue248 := string(randStringThetest(r))
+		this.Field2 = &vAlue248
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -23734,8 +23734,8 @@ func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *UnrecognizedWithEmbed_Embedded {
 	this := &UnrecognizedWithEmbed_Embedded{}
 	if r.Intn(5) != 0 {
-		v249 := uint32(r.Uint32())
-		this.Field1 = &v249
+		vAlue249 := uint32(r.Uint32())
+		this.Field1 = &vAlue249
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -23745,13 +23745,13 @@ func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *Unre
 func NewPopulatedNode(r randyThetest, easy bool) *Node {
 	this := &Node{}
 	if r.Intn(5) != 0 {
-		v250 := string(randStringThetest(r))
-		this.Label = &v250
+		vAlue250 := string(randStringThetest(r))
+		this.Label = &vAlue250
 	}
 	if r.Intn(5) == 0 {
-		v251 := r.Intn(5)
-		this.Children = make([]*Node, v251)
-		for i := 0; i < v251; i++ {
+		vAlue251 := r.Intn(5)
+		this.Children = make([]*Node, vAlue251)
+		for i := 0; i < vAlue251; i++ {
 			this.Children[i] = NewPopulatedNode(r, easy)
 		}
 	}
@@ -23774,8 +23774,8 @@ func NewPopulatedNonByteCustomType(r randyThetest, easy bool) *NonByteCustomType
 
 func NewPopulatedNidOptNonByteCustomType(r randyThetest, easy bool) *NidOptNonByteCustomType {
 	this := &NidOptNonByteCustomType{}
-	v252 := NewPopulatedT(r)
-	this.Field1 = *v252
+	vAlue252 := NewPopulatedT(r)
+	this.Field1 = *vAlue252
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -23796,11 +23796,11 @@ func NewPopulatedNinOptNonByteCustomType(r randyThetest, easy bool) *NinOptNonBy
 func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonByteCustomType {
 	this := &NidRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v253 := r.Intn(10)
-		this.Field1 = make([]T, v253)
-		for i := 0; i < v253; i++ {
-			v254 := NewPopulatedT(r)
-			this.Field1[i] = *v254
+		vAlue253 := r.Intn(10)
+		this.Field1 = make([]T, vAlue253)
+		for i := 0; i < vAlue253; i++ {
+			vAlue254 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue254
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23812,11 +23812,11 @@ func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonBy
 func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonByteCustomType {
 	this := &NinRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v255 := r.Intn(10)
-		this.Field1 = make([]T, v255)
-		for i := 0; i < v255; i++ {
-			v256 := NewPopulatedT(r)
-			this.Field1[i] = *v256
+		vAlue255 := r.Intn(10)
+		this.Field1 = make([]T, vAlue255)
+		for i := 0; i < vAlue255; i++ {
+			vAlue256 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue256
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23828,8 +23828,8 @@ func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonBy
 func NewPopulatedProtoType(r randyThetest, easy bool) *ProtoType {
 	this := &ProtoType{}
 	if r.Intn(5) != 0 {
-		v257 := string(randStringThetest(r))
-		this.Field2 = &v257
+		vAlue257 := string(randStringThetest(r))
+		this.Field2 = &vAlue257
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
@@ -23856,9 +23856,9 @@ func randUTF8RuneThetest(r randyThetest) rune {
 	return rune(ru + 61)
 }
 func randStringThetest(r randyThetest) string {
-	v258 := r.Intn(100)
-	tmps := make([]rune, v258)
-	for i := 0; i < v258; i++ {
+	vAlue258 := r.Intn(100)
+	tmps := make([]rune, vAlue258)
+	for i := 0; i < vAlue258; i++ {
 		tmps[i] = randUTF8RuneThetest(r)
 	}
 	return string(tmps)
@@ -23880,11 +23880,11 @@ func randFieldThetest(dAtA []byte, r randyThetest, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
-		v259 := r.Int63()
+		vAlue259 := r.Int63()
 		if r.Intn(2) == 0 {
-			v259 *= -1
+			vAlue259 *= -1
 		}
-		dAtA = encodeVarintPopulateThetest(dAtA, uint64(v259))
+		dAtA = encodeVarintPopulateThetest(dAtA, uint64(vAlue259))
 	case 1:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/data/data.pb.go
+++ b/test/data/data.pb.go
@@ -244,9 +244,9 @@ func randUTF8RuneData(r randyData) rune {
 	return rune(ru + 61)
 }
 func randStringData(r randyData) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneData(r)
 	}
 	return string(tmps)
@@ -268,11 +268,11 @@ func randFieldData(dAtA []byte, r randyData, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateData(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateData(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateData(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateData(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/enumdecl/enumdecl.pb.go
+++ b/test/enumdecl/enumdecl.pb.go
@@ -244,9 +244,9 @@ func randUTF8RuneEnumdecl(r randyEnumdecl) rune {
 	return rune(ru + 61)
 }
 func randStringEnumdecl(r randyEnumdecl) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneEnumdecl(r)
 	}
 	return string(tmps)
@@ -268,11 +268,11 @@ func randFieldEnumdecl(dAtA []byte, r randyEnumdecl, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateEnumdecl(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateEnumdecl(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateEnumdecl(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateEnumdecl(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/enumdecl_all/enumdeclall.pb.go
+++ b/test/enumdecl_all/enumdeclall.pb.go
@@ -294,9 +294,9 @@ func randUTF8RuneEnumdeclall(r randyEnumdeclall) rune {
 	return rune(ru + 61)
 }
 func randStringEnumdeclall(r randyEnumdeclall) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneEnumdeclall(r)
 	}
 	return string(tmps)
@@ -318,11 +318,11 @@ func randFieldEnumdeclall(dAtA []byte, r randyEnumdeclall, fieldNumber int, wire
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateEnumdeclall(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateEnumdeclall(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateEnumdeclall(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateEnumdeclall(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/enumstringer/enumstringer.pb.go
+++ b/test/enumstringer/enumstringer.pb.go
@@ -528,8 +528,8 @@ func NewPopulatedNidOptEnum(r randyEnumstringer, easy bool) *NidOptEnum {
 func NewPopulatedNinOptEnum(r randyEnumstringer, easy bool) *NinOptEnum {
 	this := &NinOptEnum{}
 	if r.Intn(5) != 0 {
-		v1 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v1
+		vAlue1 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedEnumstringer(r, 2)
@@ -540,9 +540,9 @@ func NewPopulatedNinOptEnum(r randyEnumstringer, easy bool) *NinOptEnum {
 func NewPopulatedNidRepEnum(r randyEnumstringer, easy bool) *NidRepEnum {
 	this := &NidRepEnum{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
@@ -555,9 +555,9 @@ func NewPopulatedNidRepEnum(r randyEnumstringer, easy bool) *NidRepEnum {
 func NewPopulatedNinRepEnum(r randyEnumstringer, easy bool) *NinRepEnum {
 	this := &NinRepEnum{}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v3)
-		for i := 0; i < v3; i++ {
+		vAlue3 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue3)
+		for i := 0; i < vAlue3; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
@@ -586,9 +586,9 @@ func randUTF8RuneEnumstringer(r randyEnumstringer) rune {
 	return rune(ru + 61)
 }
 func randStringEnumstringer(r randyEnumstringer) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneEnumstringer(r)
 	}
 	return string(tmps)
@@ -610,11 +610,11 @@ func randFieldEnumstringer(dAtA []byte, r randyEnumstringer, fieldNumber int, wi
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateEnumstringer(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateEnumstringer(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateEnumstringer(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateEnumstringer(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/example/example.pb.go
+++ b/test/example/example.pb.go
@@ -1602,8 +1602,8 @@ func NewPopulatedA(r randyExample, easy bool) *A {
 	if r.Intn(2) == 0 {
 		this.Number *= -1
 	}
-	v1 := github_com_gogo_protobuf_test.NewPopulatedUuid(r)
-	this.Id = *v1
+	vAlue1 := github_com_gogo_protobuf_test.NewPopulatedUuid(r)
+	this.Id = *vAlue1
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedExample(r, 4)
 	}
@@ -1612,14 +1612,14 @@ func NewPopulatedA(r randyExample, easy bool) *A {
 
 func NewPopulatedB(r randyExample, easy bool) *B {
 	this := &B{}
-	v2 := NewPopulatedA(r, easy)
-	this.A = *v2
+	vAlue2 := NewPopulatedA(r, easy)
+	this.A = *vAlue2
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
-		this.G = make([]github_com_gogo_protobuf_test_custom.Uint128, v3)
-		for i := 0; i < v3; i++ {
-			v4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.G[i] = *v4
+		vAlue3 := r.Intn(10)
+		this.G = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue3)
+		for i := 0; i < vAlue3; i++ {
+			vAlue4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.G[i] = *vAlue4
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -1631,11 +1631,11 @@ func NewPopulatedB(r randyExample, easy bool) *B {
 func NewPopulatedC(r randyExample, easy bool) *C {
 	this := &C{}
 	if r.Intn(5) != 0 {
-		v5 := int64(r.Int63())
+		vAlue5 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		this.MySize = &v5
+		this.MySize = &vAlue5
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedExample(r, 2)
@@ -1675,8 +1675,8 @@ func NewPopulatedE(r randyExample, easy bool) *E {
 func NewPopulatedR(r randyExample, easy bool) *R {
 	this := &R{}
 	if r.Intn(5) != 0 {
-		v6 := uint32(r.Uint32())
-		this.Recognized = &v6
+		vAlue6 := uint32(r.Uint32())
+		this.Recognized = &vAlue6
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -1686,11 +1686,11 @@ func NewPopulatedR(r randyExample, easy bool) *R {
 func NewPopulatedCastType(r randyExample, easy bool) *CastType {
 	this := &CastType{}
 	if r.Intn(5) != 0 {
-		v7 := int32(r.Int63())
+		vAlue7 := int32(r.Int63())
 		if r.Intn(2) == 0 {
-			v7 *= -1
+			vAlue7 *= -1
 		}
-		this.Int32 = &v7
+		this.Int32 = &vAlue7
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedExample(r, 2)
@@ -1717,9 +1717,9 @@ func randUTF8RuneExample(r randyExample) rune {
 	return rune(ru + 61)
 }
 func randStringExample(r randyExample) string {
-	v8 := r.Intn(100)
-	tmps := make([]rune, v8)
-	for i := 0; i < v8; i++ {
+	vAlue8 := r.Intn(100)
+	tmps := make([]rune, vAlue8)
+	for i := 0; i < vAlue8; i++ {
 		tmps[i] = randUTF8RuneExample(r)
 	}
 	return string(tmps)
@@ -1741,11 +1741,11 @@ func randFieldExample(dAtA []byte, r randyExample, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateExample(dAtA, uint64(key))
-		v9 := r.Int63()
+		vAlue9 := r.Int63()
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		dAtA = encodeVarintPopulateExample(dAtA, uint64(v9))
+		dAtA = encodeVarintPopulateExample(dAtA, uint64(vAlue9))
 	case 1:
 		dAtA = encodeVarintPopulateExample(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/filedotname/file.dot.pb.go
+++ b/test/filedotname/file.dot.pb.go
@@ -470,8 +470,8 @@ func valueToGoStringFileDot(v interface{}, typ string) string {
 func NewPopulatedM(r randyFileDot, easy bool) *M {
 	this := &M{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringFileDot(r))
-		this.A = &v1
+		vAlue1 := string(randStringFileDot(r))
+		this.A = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedFileDot(r, 2)
@@ -498,9 +498,9 @@ func randUTF8RuneFileDot(r randyFileDot) rune {
 	return rune(ru + 61)
 }
 func randStringFileDot(r randyFileDot) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneFileDot(r)
 	}
 	return string(tmps)
@@ -522,11 +522,11 @@ func randFieldFileDot(dAtA []byte, r randyFileDot, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateFileDot(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateFileDot(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateFileDot(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateFileDot(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/group/group.pb.go
+++ b/test/group/group.pb.go
@@ -839,9 +839,9 @@ func valueToGoStringGroup(v interface{}, typ string) string {
 func NewPopulatedGroups1(r randyGroup, easy bool) *Groups1 {
 	this := &Groups1{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(5)
-		this.G = make([]*Groups1_G, v1)
-		for i := 0; i < v1; i++ {
+		vAlue1 := r.Intn(5)
+		this.G = make([]*Groups1_G, vAlue1)
+		for i := 0; i < vAlue1; i++ {
 			this.G[i] = NewPopulatedGroups1_G(r, easy)
 		}
 	}
@@ -854,18 +854,18 @@ func NewPopulatedGroups1(r randyGroup, easy bool) *Groups1 {
 func NewPopulatedGroups1_G(r randyGroup, easy bool) *Groups1_G {
 	this := &Groups1_G{}
 	if r.Intn(5) != 0 {
-		v2 := int64(r.Int63())
+		vAlue2 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := float64(r.Float64())
+		vAlue3 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field2 = &v3
+		this.Field2 = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedGroup(r, 3)
@@ -887,16 +887,16 @@ func NewPopulatedGroups2(r randyGroup, easy bool) *Groups2 {
 func NewPopulatedGroups2_G(r randyGroup, easy bool) *Groups2_G {
 	this := &Groups2_G{}
 	if r.Intn(5) != 0 {
-		v4 := int64(r.Int63())
+		vAlue4 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field1 = &v4
+		this.Field1 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
-		this.Field2 = make([]float64, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(10)
+		this.Field2 = make([]float64, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.Field2[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -928,9 +928,9 @@ func randUTF8RuneGroup(r randyGroup) rune {
 	return rune(ru + 61)
 }
 func randStringGroup(r randyGroup) string {
-	v6 := r.Intn(100)
-	tmps := make([]rune, v6)
-	for i := 0; i < v6; i++ {
+	vAlue6 := r.Intn(100)
+	tmps := make([]rune, vAlue6)
+	for i := 0; i < vAlue6; i++ {
 		tmps[i] = randUTF8RuneGroup(r)
 	}
 	return string(tmps)
@@ -952,11 +952,11 @@ func randFieldGroup(dAtA []byte, r randyGroup, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateGroup(dAtA, uint64(key))
-		v7 := r.Int63()
+		vAlue7 := r.Int63()
 		if r.Intn(2) == 0 {
-			v7 *= -1
+			vAlue7 *= -1
 		}
-		dAtA = encodeVarintPopulateGroup(dAtA, uint64(v7))
+		dAtA = encodeVarintPopulateGroup(dAtA, uint64(vAlue7))
 	case 1:
 		dAtA = encodeVarintPopulateGroup(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/importcustom-issue389/imported/a.pb.go
+++ b/test/importcustom-issue389/imported/a.pb.go
@@ -189,9 +189,9 @@ func randUTF8RuneA(r randyA) rune {
 	return rune(ru + 61)
 }
 func randStringA(r randyA) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneA(r)
 	}
 	return string(tmps)
@@ -213,11 +213,11 @@ func randFieldA(dAtA []byte, r randyA, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateA(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateA(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateA(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateA(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/importcustom-issue389/importing/c.pb.go
+++ b/test/importcustom-issue389/importing/c.pb.go
@@ -199,9 +199,9 @@ func randUTF8RuneC(r randyC) rune {
 	return rune(ru + 61)
 }
 func randStringC(r randyC) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneC(r)
 	}
 	return string(tmps)
@@ -223,11 +223,11 @@ func randFieldC(dAtA []byte, r randyC, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateC(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateC(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateC(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateC(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/importduplicate/importduplicate.pb.go
+++ b/test/importduplicate/importduplicate.pb.go
@@ -193,9 +193,9 @@ func NewPopulatedMapAndSortKeys(r randyImportduplicate, easy bool) *MapAndSortKe
 		this.Key = sortkeys.NewPopulatedObject(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.KeyValue = make(map[int32]string)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.KeyValue[int32(r.Int31())] = randStringImportduplicate(r)
 		}
 	}
@@ -227,9 +227,9 @@ func randUTF8RuneImportduplicate(r randyImportduplicate) rune {
 	return rune(ru + 61)
 }
 func randStringImportduplicate(r randyImportduplicate) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneImportduplicate(r)
 	}
 	return string(tmps)
@@ -251,11 +251,11 @@ func randFieldImportduplicate(dAtA []byte, r randyImportduplicate, fieldNumber i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateImportduplicate(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateImportduplicate(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateImportduplicate(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateImportduplicate(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/importduplicate/proto/proto.pb.go
+++ b/test/importduplicate/proto/proto.pb.go
@@ -142,9 +142,9 @@ func randUTF8RuneProto(r randyProto) rune {
 	return rune(ru + 61)
 }
 func randStringProto(r randyProto) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneProto(r)
 	}
 	return string(tmps)
@@ -166,11 +166,11 @@ func randFieldProto(dAtA []byte, r randyProto, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateProto(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateProto(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateProto(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateProto(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/importduplicate/sortkeys/sortable.pb.go
+++ b/test/importduplicate/sortkeys/sortable.pb.go
@@ -143,9 +143,9 @@ func randUTF8RuneSortable(r randySortable) rune {
 	return rune(ru + 61)
 }
 func randStringSortable(r randySortable) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneSortable(r)
 	}
 	return string(tmps)
@@ -167,11 +167,11 @@ func randFieldSortable(dAtA []byte, r randySortable, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateSortable(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateSortable(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateSortable(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateSortable(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/indeximport-issue72/index/index.pb.go
+++ b/test/indeximport-issue72/index/index.pb.go
@@ -195,12 +195,12 @@ func encodeVarintIndex(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedIndexQuery(r randyIndex, easy bool) *IndexQuery {
 	this := &IndexQuery{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringIndex(r))
-		this.Key = &v1
+		vAlue1 := string(randStringIndex(r))
+		this.Key = &vAlue1
 	}
 	if r.Intn(5) != 0 {
-		v2 := string(randStringIndex(r))
-		this.Value = &v2
+		vAlue2 := string(randStringIndex(r))
+		this.Value = &vAlue2
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedIndex(r, 3)
@@ -227,9 +227,9 @@ func randUTF8RuneIndex(r randyIndex) rune {
 	return rune(ru + 61)
 }
 func randStringIndex(r randyIndex) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneIndex(r)
 	}
 	return string(tmps)
@@ -251,11 +251,11 @@ func randFieldIndex(dAtA []byte, r randyIndex, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIndex(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateIndex(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateIndex(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateIndex(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/indeximport-issue72/indeximport.pb.go
+++ b/test/indeximport-issue72/indeximport.pb.go
@@ -180,9 +180,9 @@ func encodeVarintIndeximport(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedIndexQueries(r randyIndeximport, easy bool) *IndexQueries {
 	this := &IndexQueries{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(5)
-		this.Queries = make([]*index.IndexQuery, v1)
-		for i := 0; i < v1; i++ {
+		vAlue1 := r.Intn(5)
+		this.Queries = make([]*index.IndexQuery, vAlue1)
+		for i := 0; i < vAlue1; i++ {
 			this.Queries[i] = index.NewPopulatedIndexQuery(r, easy)
 		}
 	}
@@ -211,9 +211,9 @@ func randUTF8RuneIndeximport(r randyIndeximport) rune {
 	return rune(ru + 61)
 }
 func randStringIndeximport(r randyIndeximport) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneIndeximport(r)
 	}
 	return string(tmps)
@@ -235,11 +235,11 @@ func randFieldIndeximport(dAtA []byte, r randyIndeximport, fieldNumber int, wire
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIndeximport(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateIndeximport(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateIndeximport(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateIndeximport(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/int64support/object.pb.go
+++ b/test/int64support/object.pb.go
@@ -220,11 +220,11 @@ func encodeVarintObject(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedObject(r randyObject, easy bool) *Object {
 	this := &Object{}
 	if r.Intn(5) != 0 {
-		v1 := int64(r.Int63())
+		vAlue1 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.OptionalNumber = &v1
+		this.OptionalNumber = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -250,9 +250,9 @@ func randUTF8RuneObject(r randyObject) rune {
 	return rune(ru + 61)
 }
 func randStringObject(r randyObject) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneObject(r)
 	}
 	return string(tmps)
@@ -274,11 +274,11 @@ func randFieldObject(dAtA []byte, r randyObject, fieldNumber int, wire int) []by
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateObject(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateObject(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateObject(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateObject(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue260/issue260.pb.go
+++ b/test/issue260/issue260.pb.go
@@ -523,8 +523,8 @@ func NewPopulatedDroppedWithoutGetters(r randyIssue260, easy bool) *DroppedWitho
 	if r.Intn(2) == 0 {
 		this.Width *= -1
 	}
-	v1 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-	this.Timestamp = *v1
+	vAlue1 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+	this.Timestamp = *vAlue1
 	if !easy && r.Intn(10) != 0 {
 	}
 	return this
@@ -561,9 +561,9 @@ func randUTF8RuneIssue260(r randyIssue260) rune {
 	return rune(ru + 61)
 }
 func randStringIssue260(r randyIssue260) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneIssue260(r)
 	}
 	return string(tmps)
@@ -585,11 +585,11 @@ func randFieldIssue260(dAtA []byte, r randyIssue260, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue260(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue260(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateIssue260(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateIssue260(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue312/events/events.pb.go
+++ b/test/issue312/events/events.pb.go
@@ -143,8 +143,8 @@ func valueToGoStringEvents(v interface{}, typ string) string {
 func NewPopulatedSubtype(r randyEvents, easy bool) *Subtype {
 	this := &Subtype{}
 	if r.Intn(5) != 0 {
-		v1 := issue312.TaskState([]int32{6, 0, 1}[r.Intn(3)])
-		this.State = &v1
+		vAlue1 := issue312.TaskState([]int32{6, 0, 1}[r.Intn(3)])
+		this.State = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedEvents(r, 5)
@@ -171,9 +171,9 @@ func randUTF8RuneEvents(r randyEvents) rune {
 	return rune(ru + 61)
 }
 func randStringEvents(r randyEvents) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneEvents(r)
 	}
 	return string(tmps)
@@ -195,11 +195,11 @@ func randFieldEvents(dAtA []byte, r randyEvents, fieldNumber int, wire int) []by
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateEvents(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateEvents(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateEvents(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateEvents(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue322/issue322.pb.go
+++ b/test/issue322/issue322.pb.go
@@ -407,9 +407,9 @@ func randUTF8RuneIssue322(r randyIssue322) rune {
 	return rune(ru + 61)
 }
 func randStringIssue322(r randyIssue322) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneIssue322(r)
 	}
 	return string(tmps)
@@ -431,11 +431,11 @@ func randFieldIssue322(dAtA []byte, r randyIssue322, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue322(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue322(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateIssue322(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateIssue322(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue330/issue330.pb.go
+++ b/test/issue330/issue330.pb.go
@@ -189,9 +189,9 @@ func randUTF8RuneIssue330(r randyIssue330) rune {
 	return rune(ru + 61)
 }
 func randStringIssue330(r randyIssue330) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneIssue330(r)
 	}
 	return string(tmps)
@@ -213,11 +213,11 @@ func randFieldIssue330(dAtA []byte, r randyIssue330, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue330(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue330(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateIssue330(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateIssue330(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue42order/issue42.pb.go
+++ b/test/issue42order/issue42.pb.go
@@ -245,15 +245,15 @@ func encodeVarintIssue42(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedUnorderedFields(r randyIssue42, easy bool) *UnorderedFields {
 	this := &UnorderedFields{}
 	if r.Intn(5) != 0 {
-		v1 := uint64(uint64(r.Uint32()))
-		this.B = &v1
+		vAlue1 := uint64(uint64(r.Uint32()))
+		this.B = &vAlue1
 	}
 	if r.Intn(5) != 0 {
-		v2 := int64(r.Int63())
+		vAlue2 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.A = &v2
+		this.A = &vAlue2
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedIssue42(r, 11)
@@ -264,15 +264,15 @@ func NewPopulatedUnorderedFields(r randyIssue42, easy bool) *UnorderedFields {
 func NewPopulatedOrderedFields(r randyIssue42, easy bool) *OrderedFields {
 	this := &OrderedFields{}
 	if r.Intn(5) != 0 {
-		v3 := uint64(uint64(r.Uint32()))
-		this.B = &v3
+		vAlue3 := uint64(uint64(r.Uint32()))
+		this.B = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := int64(r.Int63())
+		vAlue4 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.A = &v4
+		this.A = &vAlue4
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedIssue42(r, 11)
@@ -299,9 +299,9 @@ func randUTF8RuneIssue42(r randyIssue42) rune {
 	return rune(ru + 61)
 }
 func randStringIssue42(r randyIssue42) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneIssue42(r)
 	}
 	return string(tmps)
@@ -323,11 +323,11 @@ func randFieldIssue42(dAtA []byte, r randyIssue42, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue42(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue42(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateIssue42(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateIssue42(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue498/issue498.pb.go
+++ b/test/issue498/issue498.pb.go
@@ -246,14 +246,14 @@ func encodeVarintIssue498(dAtA []byte, offset int, v uint64) int {
 }
 func NewPopulatedMessage(r randyIssue498, easy bool) *Message {
 	this := &Message{}
-	v1 := uint8(r.Uint32())
-	this.Uint8 = &v1
-	v2 := uint16(r.Uint32())
-	this.Uint16 = &v2
-	v3 := int8(r.Uint32())
-	this.Int8 = &v3
-	v4 := int16(r.Uint32())
-	this.Int16 = &v4
+	vAlue1 := uint8(r.Uint32())
+	this.Uint8 = &vAlue1
+	vAlue2 := uint16(r.Uint32())
+	this.Uint16 = &vAlue2
+	vAlue3 := int8(r.Uint32())
+	this.Int8 = &vAlue3
+	vAlue4 := int16(r.Uint32())
+	this.Int16 = &vAlue4
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedIssue498(r, 5)
 	}
@@ -279,9 +279,9 @@ func randUTF8RuneIssue498(r randyIssue498) rune {
 	return rune(ru + 61)
 }
 func randStringIssue498(r randyIssue498) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneIssue498(r)
 	}
 	return string(tmps)
@@ -303,11 +303,11 @@ func randFieldIssue498(dAtA []byte, r randyIssue498, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue498(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue498(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateIssue498(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateIssue498(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue503/issue503.pb.go
+++ b/test/issue503/issue503.pb.go
@@ -330,33 +330,33 @@ func encodeVarintIssue503(dAtA []byte, offset int, v uint64) int {
 }
 func NewPopulatedFoo(r randyIssue503, easy bool) *Foo {
 	this := &Foo{}
-	v1 := r.Intn(10)
-	this.Num1 = make([]int64, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(10)
+	this.Num1 = make([]int64, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Num1[i] = int64(r.Int63())
 		if r.Intn(2) == 0 {
 			this.Num1[i] *= -1
 		}
 	}
-	v2 := r.Intn(10)
-	this.Num2 = make([]int32, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(10)
+	this.Num2 = make([]int32, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Num2[i] = int32(r.Int31())
 		if r.Intn(2) == 0 {
 			this.Num2[i] *= -1
 		}
 	}
-	v3 := r.Intn(10)
-	this.Str1 = make([]string, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(10)
+	this.Str1 = make([]string, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		this.Str1[i] = string(randStringIssue503(r))
 	}
-	v4 := r.Intn(10)
-	this.Dat1 = make([][]byte, v4)
-	for i := 0; i < v4; i++ {
-		v5 := r.Intn(100)
-		this.Dat1[i] = make([]byte, v5)
-		for j := 0; j < v5; j++ {
+	vAlue4 := r.Intn(10)
+	this.Dat1 = make([][]byte, vAlue4)
+	for i := 0; i < vAlue4; i++ {
+		vAlue5 := r.Intn(100)
+		this.Dat1[i] = make([]byte, vAlue5)
+		for j := 0; j < vAlue5; j++ {
 			this.Dat1[i][j] = byte(r.Intn(256))
 		}
 	}
@@ -385,9 +385,9 @@ func randUTF8RuneIssue503(r randyIssue503) rune {
 	return rune(ru + 61)
 }
 func randStringIssue503(r randyIssue503) string {
-	v6 := r.Intn(100)
-	tmps := make([]rune, v6)
-	for i := 0; i < v6; i++ {
+	vAlue6 := r.Intn(100)
+	tmps := make([]rune, vAlue6)
+	for i := 0; i < vAlue6; i++ {
 		tmps[i] = randUTF8RuneIssue503(r)
 	}
 	return string(tmps)
@@ -409,11 +409,11 @@ func randFieldIssue503(dAtA []byte, r randyIssue503, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue503(dAtA, uint64(key))
-		v7 := r.Int63()
+		vAlue7 := r.Int63()
 		if r.Intn(2) == 0 {
-			v7 *= -1
+			vAlue7 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue503(dAtA, uint64(v7))
+		dAtA = encodeVarintPopulateIssue503(dAtA, uint64(vAlue7))
 	case 1:
 		dAtA = encodeVarintPopulateIssue503(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue530/issue530.pb.go
+++ b/test/issue530/issue530.pb.go
@@ -1477,73 +1477,73 @@ func encodeVarintIssue530(dAtA []byte, offset int, v uint64) int {
 }
 func NewPopulatedFoo5(r randyIssue530, easy bool) *Foo5 {
 	this := &Foo5{}
-	v1 := NewPopulatedBar1(r, easy)
-	this.Bar1 = *v1
+	vAlue1 := NewPopulatedBar1(r, easy)
+	this.Bar1 = *vAlue1
 	if r.Intn(5) != 0 {
 		this.Bar2 = NewPopulatedBar1(r, easy)
 	}
-	v2 := NewPopulatedBar2(r, easy)
-	this.Bar3 = *v2
+	vAlue2 := NewPopulatedBar2(r, easy)
+	this.Bar3 = *vAlue2
 	if r.Intn(5) != 0 {
 		this.Bar4 = NewPopulatedBar2(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(5)
-		this.Bars1 = make([]Bar1, v3)
-		for i := 0; i < v3; i++ {
-			v4 := NewPopulatedBar1(r, easy)
-			this.Bars1[i] = *v4
+		vAlue3 := r.Intn(5)
+		this.Bars1 = make([]Bar1, vAlue3)
+		for i := 0; i < vAlue3; i++ {
+			vAlue4 := NewPopulatedBar1(r, easy)
+			this.Bars1[i] = *vAlue4
 		}
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(5)
-		this.Bars2 = make([]*Bar1, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(5)
+		this.Bars2 = make([]*Bar1, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.Bars2[i] = NewPopulatedBar1(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(5)
-		this.Bars3 = make([]Bar2, v6)
-		for i := 0; i < v6; i++ {
-			v7 := NewPopulatedBar2(r, easy)
-			this.Bars3[i] = *v7
+		vAlue6 := r.Intn(5)
+		this.Bars3 = make([]Bar2, vAlue6)
+		for i := 0; i < vAlue6; i++ {
+			vAlue7 := NewPopulatedBar2(r, easy)
+			this.Bars3[i] = *vAlue7
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(5)
-		this.Bars4 = make([]*Bar2, v8)
-		for i := 0; i < v8; i++ {
+		vAlue8 := r.Intn(5)
+		this.Bars4 = make([]*Bar2, vAlue8)
+		for i := 0; i < vAlue8; i++ {
 			this.Bars4[i] = NewPopulatedBar2(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := r.Intn(5)
-		this.Barrs1 = make([]Bar3, v9)
-		for i := 0; i < v9; i++ {
-			v10 := NewPopulatedBar3(r, easy)
-			this.Barrs1[i] = *v10
+		vAlue9 := r.Intn(5)
+		this.Barrs1 = make([]Bar3, vAlue9)
+		for i := 0; i < vAlue9; i++ {
+			vAlue10 := NewPopulatedBar3(r, easy)
+			this.Barrs1[i] = *vAlue10
 		}
 	}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(5)
-		this.Barrs2 = make([]Bar5, v11)
-		for i := 0; i < v11; i++ {
-			v12 := NewPopulatedBar5(r, easy)
-			this.Barrs2[i] = *v12
+		vAlue11 := r.Intn(5)
+		this.Barrs2 = make([]Bar5, vAlue11)
+		for i := 0; i < vAlue11; i++ {
+			vAlue12 := NewPopulatedBar5(r, easy)
+			this.Barrs2[i] = *vAlue12
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.Barmap1 = make(map[string]*Bar3)
-		for i := 0; i < v13; i++ {
+		for i := 0; i < vAlue13; i++ {
 			this.Barmap1[randStringIssue530(r)] = NewPopulatedBar3(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(10)
+		vAlue14 := r.Intn(10)
 		this.Barmap2 = make(map[string]*Bar5)
-		for i := 0; i < v14; i++ {
+		for i := 0; i < vAlue14; i++ {
 			this.Barmap2[randStringIssue530(r)] = NewPopulatedBar5(r, easy)
 		}
 	}
@@ -1563,8 +1563,8 @@ func NewPopulatedBar1(r randyIssue530, easy bool) *Bar1 {
 func NewPopulatedBar2(r randyIssue530, easy bool) *Bar2 {
 	this := &Bar2{}
 	if r.Intn(5) != 0 {
-		v15 := string(randStringIssue530(r))
-		this.Str = &v15
+		vAlue15 := string(randStringIssue530(r))
+		this.Str = &vAlue15
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -1574,19 +1574,19 @@ func NewPopulatedBar2(r randyIssue530, easy bool) *Bar2 {
 func NewPopulatedBar3(r randyIssue530, easy bool) *Bar3 {
 	this := &Bar3{}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(5)
-		this.Bars4 = make([]Bar4, v16)
-		for i := 0; i < v16; i++ {
-			v17 := NewPopulatedBar4(r, easy)
-			this.Bars4[i] = *v17
+		vAlue16 := r.Intn(5)
+		this.Bars4 = make([]Bar4, vAlue16)
+		for i := 0; i < vAlue16; i++ {
+			vAlue17 := NewPopulatedBar4(r, easy)
+			this.Bars4[i] = *vAlue17
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(5)
-		this.Bars2 = make([]Bar2, v18)
-		for i := 0; i < v18; i++ {
-			v19 := NewPopulatedBar2(r, easy)
-			this.Bars2[i] = *v19
+		vAlue18 := r.Intn(5)
+		this.Bars2 = make([]Bar2, vAlue18)
+		for i := 0; i < vAlue18; i++ {
+			vAlue19 := NewPopulatedBar2(r, easy)
+			this.Bars2[i] = *vAlue19
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -1605,16 +1605,16 @@ func NewPopulatedBar4(r randyIssue530, easy bool) *Bar4 {
 func NewPopulatedBar5(r randyIssue530, easy bool) *Bar5 {
 	this := &Bar5{}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(5)
-		this.Bars2 = make([]*Bar2, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(5)
+		this.Bars2 = make([]*Bar2, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Bars2[i] = NewPopulatedBar2(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(5)
-		this.Bars1 = make([]*Bar1, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(5)
+		this.Bars1 = make([]*Bar1, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Bars1[i] = NewPopulatedBar1(r, easy)
 		}
 	}
@@ -1626,24 +1626,24 @@ func NewPopulatedBar5(r randyIssue530, easy bool) *Bar5 {
 func NewPopulatedBar7(r randyIssue530, easy bool) *Bar7 {
 	this := &Bar7{}
 	if r.Intn(5) == 0 {
-		v22 := r.Intn(5)
-		this.Bars71 = make([]Bar7, v22)
-		for i := 0; i < v22; i++ {
-			v23 := NewPopulatedBar7(r, easy)
-			this.Bars71[i] = *v23
+		vAlue22 := r.Intn(5)
+		this.Bars71 = make([]Bar7, vAlue22)
+		for i := 0; i < vAlue22; i++ {
+			vAlue23 := NewPopulatedBar7(r, easy)
+			this.Bars71[i] = *vAlue23
 		}
 	}
 	if r.Intn(5) == 0 {
-		v24 := r.Intn(5)
-		this.Bars72 = make([]*Bar7, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(5)
+		this.Bars72 = make([]*Bar7, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Bars72[i] = NewPopulatedBar7(r, easy)
 		}
 	}
 	this.Str1 = string(randStringIssue530(r))
 	if r.Intn(5) != 0 {
-		v25 := string(randStringIssue530(r))
-		this.Str2 = &v25
+		vAlue25 := string(randStringIssue530(r))
+		this.Str2 = &vAlue25
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -1653,11 +1653,11 @@ func NewPopulatedBar7(r randyIssue530, easy bool) *Bar7 {
 func NewPopulatedBar8(r randyIssue530, easy bool) *Bar8 {
 	this := &Bar8{}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(5)
-		this.Bars1 = make([]Bar9, v26)
-		for i := 0; i < v26; i++ {
-			v27 := NewPopulatedBar9(r, easy)
-			this.Bars1[i] = *v27
+		vAlue26 := r.Intn(5)
+		this.Bars1 = make([]Bar9, vAlue26)
+		for i := 0; i < vAlue26; i++ {
+			vAlue27 := NewPopulatedBar9(r, easy)
+			this.Bars1[i] = *vAlue27
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -1692,9 +1692,9 @@ func randUTF8RuneIssue530(r randyIssue530) rune {
 	return rune(ru + 61)
 }
 func randStringIssue530(r randyIssue530) string {
-	v28 := r.Intn(100)
-	tmps := make([]rune, v28)
-	for i := 0; i < v28; i++ {
+	vAlue28 := r.Intn(100)
+	tmps := make([]rune, vAlue28)
+	for i := 0; i < vAlue28; i++ {
 		tmps[i] = randUTF8RuneIssue530(r)
 	}
 	return string(tmps)
@@ -1716,11 +1716,11 @@ func randFieldIssue530(dAtA []byte, r randyIssue530, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateIssue530(dAtA, uint64(key))
-		v29 := r.Int63()
+		vAlue29 := r.Int63()
 		if r.Intn(2) == 0 {
-			v29 *= -1
+			vAlue29 *= -1
 		}
-		dAtA = encodeVarintPopulateIssue530(dAtA, uint64(v29))
+		dAtA = encodeVarintPopulateIssue530(dAtA, uint64(vAlue29))
 	case 1:
 		dAtA = encodeVarintPopulateIssue530(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/issue8/proto.pb.go
+++ b/test/issue8/proto.pb.go
@@ -114,8 +114,8 @@ func (this *Foo) Equal(that interface{}) bool {
 }
 func NewPopulatedFoo(r randyProto, easy bool) *Foo {
 	this := &Foo{}
-	v1 := uint64(uint64(r.Uint32()))
-	this.Bar = &v1
+	vAlue1 := uint64(uint64(r.Uint32()))
+	this.Bar = &vAlue1
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedProto(r, 2)
 	}
@@ -141,9 +141,9 @@ func randUTF8RuneProto(r randyProto) rune {
 	return rune(ru + 61)
 }
 func randStringProto(r randyProto) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneProto(r)
 	}
 	return string(tmps)
@@ -165,11 +165,11 @@ func randFieldProto(dAtA []byte, r randyProto, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateProto(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateProto(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateProto(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateProto(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapdefaults/combos/both/map.pb.go
+++ b/test/mapdefaults/combos/both/map.pb.go
@@ -886,9 +886,9 @@ func encodeVarintMap(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 	this := &MapTest{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.StrStr = make(map[string]string)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.StrStr[randStringMap(r)] = randStringMap(r)
 		}
 	}
@@ -901,9 +901,9 @@ func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 func NewPopulatedFakeMap(r randyMap, easy bool) *FakeMap {
 	this := &FakeMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(5)
-		this.Entries = make([]*FakeMapEntry, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(5)
+		this.Entries = make([]*FakeMapEntry, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Entries[i] = NewPopulatedFakeMapEntry(r, easy)
 		}
 	}
@@ -943,9 +943,9 @@ func randUTF8RuneMap(r randyMap) rune {
 	return rune(ru + 61)
 }
 func randStringMap(r randyMap) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneMap(r)
 	}
 	return string(tmps)
@@ -967,11 +967,11 @@ func randFieldMap(dAtA []byte, r randyMap, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateMap(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateMap(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapdefaults/combos/marshaler/map.pb.go
+++ b/test/mapdefaults/combos/marshaler/map.pb.go
@@ -885,9 +885,9 @@ func encodeVarintMap(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 	this := &MapTest{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.StrStr = make(map[string]string)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.StrStr[randStringMap(r)] = randStringMap(r)
 		}
 	}
@@ -900,9 +900,9 @@ func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 func NewPopulatedFakeMap(r randyMap, easy bool) *FakeMap {
 	this := &FakeMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(5)
-		this.Entries = make([]*FakeMapEntry, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(5)
+		this.Entries = make([]*FakeMapEntry, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Entries[i] = NewPopulatedFakeMapEntry(r, easy)
 		}
 	}
@@ -942,9 +942,9 @@ func randUTF8RuneMap(r randyMap) rune {
 	return rune(ru + 61)
 }
 func randStringMap(r randyMap) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneMap(r)
 	}
 	return string(tmps)
@@ -966,11 +966,11 @@ func randFieldMap(dAtA []byte, r randyMap, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateMap(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateMap(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapdefaults/combos/neither/map.pb.go
+++ b/test/mapdefaults/combos/neither/map.pb.go
@@ -712,9 +712,9 @@ func valueToGoStringMap(v interface{}, typ string) string {
 func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 	this := &MapTest{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.StrStr = make(map[string]string)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.StrStr[randStringMap(r)] = randStringMap(r)
 		}
 	}
@@ -727,9 +727,9 @@ func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 func NewPopulatedFakeMap(r randyMap, easy bool) *FakeMap {
 	this := &FakeMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(5)
-		this.Entries = make([]*FakeMapEntry, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(5)
+		this.Entries = make([]*FakeMapEntry, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Entries[i] = NewPopulatedFakeMapEntry(r, easy)
 		}
 	}
@@ -769,9 +769,9 @@ func randUTF8RuneMap(r randyMap) rune {
 	return rune(ru + 61)
 }
 func randStringMap(r randyMap) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneMap(r)
 	}
 	return string(tmps)
@@ -793,11 +793,11 @@ func randFieldMap(dAtA []byte, r randyMap, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateMap(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateMap(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapdefaults/combos/unmarshaler/map.pb.go
+++ b/test/mapdefaults/combos/unmarshaler/map.pb.go
@@ -713,9 +713,9 @@ func valueToGoStringMap(v interface{}, typ string) string {
 func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 	this := &MapTest{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.StrStr = make(map[string]string)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.StrStr[randStringMap(r)] = randStringMap(r)
 		}
 	}
@@ -728,9 +728,9 @@ func NewPopulatedMapTest(r randyMap, easy bool) *MapTest {
 func NewPopulatedFakeMap(r randyMap, easy bool) *FakeMap {
 	this := &FakeMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(5)
-		this.Entries = make([]*FakeMapEntry, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(5)
+		this.Entries = make([]*FakeMapEntry, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Entries[i] = NewPopulatedFakeMapEntry(r, easy)
 		}
 	}
@@ -770,9 +770,9 @@ func randUTF8RuneMap(r randyMap) rune {
 	return rune(ru + 61)
 }
 func randStringMap(r randyMap) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneMap(r)
 	}
 	return string(tmps)
@@ -794,11 +794,11 @@ func randFieldMap(dAtA []byte, r randyMap, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateMap(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateMap(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateMap(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapsproto2/combos/both/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/both/mapsproto2.pb.go
@@ -3352,11 +3352,11 @@ func encodeVarintMapsproto2(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 	this := &FloatingPoint{}
 	if r.Intn(5) != 0 {
-		v1 := float64(r.Float64())
+		vAlue1 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.F = &v1
+		this.F = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedMapsproto2(r, 2)
@@ -3367,30 +3367,30 @@ func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 	this := &CustomMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.Nullable128S = make(map[string]*github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.Nullable128S[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test_custom.Uint128)(github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Uint128S = make(map[string]github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Uint128S[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test_custom.Uint128)(*github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.NullableIds = make(map[string]*github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.NullableIds[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test.Uuid)(github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.Ids = make(map[string]github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v5; i++ {
+		for i := 0; i < vAlue5; i++ {
 			this.Ids[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test.Uuid)(*github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
@@ -3403,163 +3403,163 @@ func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(10)
+		vAlue6 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v6; i++ {
-			v7 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v7] = float64(r.Float64())
+		for i := 0; i < vAlue6; i++ {
+			vAlue7 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue7] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v7] *= -1
+				this.StringToDoubleMap[vAlue7] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v8; i++ {
-			v9 := randStringMapsproto2(r)
-			this.StringToFloatMap[v9] = float32(r.Float32())
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue9] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v9] *= -1
+				this.StringToFloatMap[vAlue9] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v10; i++ {
-			v11 := int32(r.Int31())
-			this.Int32Map[v11] = int32(r.Int31())
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := int32(r.Int31())
+			this.Int32Map[vAlue11] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v11] *= -1
+				this.Int32Map[vAlue11] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v12; i++ {
-			v13 := int64(r.Int63())
-			this.Int64Map[v13] = int64(r.Int63())
+		for i := 0; i < vAlue12; i++ {
+			vAlue13 := int64(r.Int63())
+			this.Int64Map[vAlue13] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v13] *= -1
+				this.Int64Map[vAlue13] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(10)
+		vAlue14 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v14; i++ {
-			v15 := uint32(r.Uint32())
-			this.Uint32Map[v15] = uint32(r.Uint32())
+		for i := 0; i < vAlue14; i++ {
+			vAlue15 := uint32(r.Uint32())
+			this.Uint32Map[vAlue15] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(10)
+		vAlue16 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v16; i++ {
-			v17 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v17] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue16; i++ {
+			vAlue17 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue17] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
+		vAlue18 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v18; i++ {
-			v19 := int32(r.Int31())
-			this.Sint32Map[v19] = int32(r.Int31())
+		for i := 0; i < vAlue18; i++ {
+			vAlue19 := int32(r.Int31())
+			this.Sint32Map[vAlue19] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v19] *= -1
+				this.Sint32Map[vAlue19] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
+		vAlue20 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v20; i++ {
-			v21 := int64(r.Int63())
-			this.Sint64Map[v21] = int64(r.Int63())
+		for i := 0; i < vAlue20; i++ {
+			vAlue21 := int64(r.Int63())
+			this.Sint64Map[vAlue21] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v21] *= -1
+				this.Sint64Map[vAlue21] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
+		vAlue22 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v22; i++ {
-			v23 := uint32(r.Uint32())
-			this.Fixed32Map[v23] = uint32(r.Uint32())
+		for i := 0; i < vAlue22; i++ {
+			vAlue23 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue23] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
+		vAlue24 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v24; i++ {
-			v25 := int32(r.Int31())
-			this.Sfixed32Map[v25] = int32(r.Int31())
+		for i := 0; i < vAlue24; i++ {
+			vAlue25 := int32(r.Int31())
+			this.Sfixed32Map[vAlue25] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v25] *= -1
+				this.Sfixed32Map[vAlue25] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
+		vAlue26 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v26; i++ {
-			v27 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v27] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue26; i++ {
+			vAlue27 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue27] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
+		vAlue28 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v28; i++ {
-			v29 := int64(r.Int63())
-			this.Sfixed64Map[v29] = int64(r.Int63())
+		for i := 0; i < vAlue28; i++ {
+			vAlue29 := int64(r.Int63())
+			this.Sfixed64Map[vAlue29] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v29] *= -1
+				this.Sfixed64Map[vAlue29] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
+		vAlue30 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v30; i++ {
-			v31 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v31] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue31] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v32; i++ {
+		for i := 0; i < vAlue32; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
+		vAlue33 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v33; i++ {
-			v34 := r.Intn(100)
-			v35 := randStringMapsproto2(r)
-			this.StringToBytesMap[v35] = make([]byte, v34)
-			for i := 0; i < v34; i++ {
-				this.StringToBytesMap[v35][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := r.Intn(100)
+			vAlue35 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue35] = make([]byte, vAlue34)
+			for i := 0; i < vAlue34; i++ {
+				this.StringToBytesMap[vAlue35][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v37; i++ {
+		for i := 0; i < vAlue37; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -3572,163 +3572,163 @@ func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyMapsproto2, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
+		vAlue38 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v38; i++ {
-			v39 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v39] = float64(r.Float64())
+		for i := 0; i < vAlue38; i++ {
+			vAlue39 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue39] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v39] *= -1
+				this.StringToDoubleMap[vAlue39] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
+		vAlue40 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v40; i++ {
-			v41 := randStringMapsproto2(r)
-			this.StringToFloatMap[v41] = float32(r.Float32())
+		for i := 0; i < vAlue40; i++ {
+			vAlue41 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue41] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v41] *= -1
+				this.StringToFloatMap[vAlue41] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
+		vAlue42 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v42; i++ {
-			v43 := int32(r.Int31())
-			this.Int32Map[v43] = int32(r.Int31())
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := int32(r.Int31())
+			this.Int32Map[vAlue43] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v43] *= -1
+				this.Int32Map[vAlue43] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
+		vAlue44 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v44; i++ {
-			v45 := int64(r.Int63())
-			this.Int64Map[v45] = int64(r.Int63())
+		for i := 0; i < vAlue44; i++ {
+			vAlue45 := int64(r.Int63())
+			this.Int64Map[vAlue45] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v45] *= -1
+				this.Int64Map[vAlue45] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
+		vAlue46 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v46; i++ {
-			v47 := uint32(r.Uint32())
-			this.Uint32Map[v47] = uint32(r.Uint32())
+		for i := 0; i < vAlue46; i++ {
+			vAlue47 := uint32(r.Uint32())
+			this.Uint32Map[vAlue47] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(10)
+		vAlue48 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v48; i++ {
-			v49 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v49] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue49] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
+		vAlue50 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v50; i++ {
-			v51 := int32(r.Int31())
-			this.Sint32Map[v51] = int32(r.Int31())
+		for i := 0; i < vAlue50; i++ {
+			vAlue51 := int32(r.Int31())
+			this.Sint32Map[vAlue51] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v51] *= -1
+				this.Sint32Map[vAlue51] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
+		vAlue52 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v52; i++ {
-			v53 := int64(r.Int63())
-			this.Sint64Map[v53] = int64(r.Int63())
+		for i := 0; i < vAlue52; i++ {
+			vAlue53 := int64(r.Int63())
+			this.Sint64Map[vAlue53] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v53] *= -1
+				this.Sint64Map[vAlue53] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
+		vAlue54 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v54; i++ {
-			v55 := uint32(r.Uint32())
-			this.Fixed32Map[v55] = uint32(r.Uint32())
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue55] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
+		vAlue56 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v56; i++ {
-			v57 := int32(r.Int31())
-			this.Sfixed32Map[v57] = int32(r.Int31())
+		for i := 0; i < vAlue56; i++ {
+			vAlue57 := int32(r.Int31())
+			this.Sfixed32Map[vAlue57] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v57] *= -1
+				this.Sfixed32Map[vAlue57] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
+		vAlue58 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v58; i++ {
-			v59 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v59] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue59] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
+		vAlue60 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v60; i++ {
-			v61 := int64(r.Int63())
-			this.Sfixed64Map[v61] = int64(r.Int63())
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := int64(r.Int63())
+			this.Sfixed64Map[vAlue61] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v61] *= -1
+				this.Sfixed64Map[vAlue61] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
+		vAlue62 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v62; i++ {
-			v63 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v63] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue62; i++ {
+			vAlue63 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue63] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v64; i++ {
+		for i := 0; i < vAlue64; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
+		vAlue65 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v65; i++ {
-			v66 := r.Intn(100)
-			v67 := randStringMapsproto2(r)
-			this.StringToBytesMap[v67] = make([]byte, v66)
-			for i := 0; i < v66; i++ {
-				this.StringToBytesMap[v67][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue65; i++ {
+			vAlue66 := r.Intn(100)
+			vAlue67 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue67] = make([]byte, vAlue66)
+			for i := 0; i < vAlue66; i++ {
+				this.StringToBytesMap[vAlue67][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -3757,9 +3757,9 @@ func randUTF8RuneMapsproto2(r randyMapsproto2) rune {
 	return rune(ru + 61)
 }
 func randStringMapsproto2(r randyMapsproto2) string {
-	v70 := r.Intn(100)
-	tmps := make([]rune, v70)
-	for i := 0; i < v70; i++ {
+	vAlue70 := r.Intn(100)
+	tmps := make([]rune, vAlue70)
+	for i := 0; i < vAlue70; i++ {
 		tmps[i] = randUTF8RuneMapsproto2(r)
 	}
 	return string(tmps)
@@ -3781,11 +3781,11 @@ func randFieldMapsproto2(dAtA []byte, r randyMapsproto2, fieldNumber int, wire i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
-		v71 := r.Int63()
+		vAlue71 := r.Int63()
 		if r.Intn(2) == 0 {
-			v71 *= -1
+			vAlue71 *= -1
 		}
-		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(v71))
+		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(vAlue71))
 	case 1:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
@@ -3351,11 +3351,11 @@ func encodeVarintMapsproto2(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 	this := &FloatingPoint{}
 	if r.Intn(5) != 0 {
-		v1 := float64(r.Float64())
+		vAlue1 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.F = &v1
+		this.F = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedMapsproto2(r, 2)
@@ -3366,30 +3366,30 @@ func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 	this := &CustomMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.Nullable128S = make(map[string]*github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.Nullable128S[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test_custom.Uint128)(github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Uint128S = make(map[string]github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Uint128S[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test_custom.Uint128)(*github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.NullableIds = make(map[string]*github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.NullableIds[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test.Uuid)(github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.Ids = make(map[string]github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v5; i++ {
+		for i := 0; i < vAlue5; i++ {
 			this.Ids[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test.Uuid)(*github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
@@ -3402,163 +3402,163 @@ func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(10)
+		vAlue6 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v6; i++ {
-			v7 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v7] = float64(r.Float64())
+		for i := 0; i < vAlue6; i++ {
+			vAlue7 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue7] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v7] *= -1
+				this.StringToDoubleMap[vAlue7] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v8; i++ {
-			v9 := randStringMapsproto2(r)
-			this.StringToFloatMap[v9] = float32(r.Float32())
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue9] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v9] *= -1
+				this.StringToFloatMap[vAlue9] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v10; i++ {
-			v11 := int32(r.Int31())
-			this.Int32Map[v11] = int32(r.Int31())
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := int32(r.Int31())
+			this.Int32Map[vAlue11] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v11] *= -1
+				this.Int32Map[vAlue11] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v12; i++ {
-			v13 := int64(r.Int63())
-			this.Int64Map[v13] = int64(r.Int63())
+		for i := 0; i < vAlue12; i++ {
+			vAlue13 := int64(r.Int63())
+			this.Int64Map[vAlue13] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v13] *= -1
+				this.Int64Map[vAlue13] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(10)
+		vAlue14 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v14; i++ {
-			v15 := uint32(r.Uint32())
-			this.Uint32Map[v15] = uint32(r.Uint32())
+		for i := 0; i < vAlue14; i++ {
+			vAlue15 := uint32(r.Uint32())
+			this.Uint32Map[vAlue15] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(10)
+		vAlue16 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v16; i++ {
-			v17 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v17] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue16; i++ {
+			vAlue17 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue17] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
+		vAlue18 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v18; i++ {
-			v19 := int32(r.Int31())
-			this.Sint32Map[v19] = int32(r.Int31())
+		for i := 0; i < vAlue18; i++ {
+			vAlue19 := int32(r.Int31())
+			this.Sint32Map[vAlue19] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v19] *= -1
+				this.Sint32Map[vAlue19] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
+		vAlue20 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v20; i++ {
-			v21 := int64(r.Int63())
-			this.Sint64Map[v21] = int64(r.Int63())
+		for i := 0; i < vAlue20; i++ {
+			vAlue21 := int64(r.Int63())
+			this.Sint64Map[vAlue21] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v21] *= -1
+				this.Sint64Map[vAlue21] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
+		vAlue22 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v22; i++ {
-			v23 := uint32(r.Uint32())
-			this.Fixed32Map[v23] = uint32(r.Uint32())
+		for i := 0; i < vAlue22; i++ {
+			vAlue23 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue23] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
+		vAlue24 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v24; i++ {
-			v25 := int32(r.Int31())
-			this.Sfixed32Map[v25] = int32(r.Int31())
+		for i := 0; i < vAlue24; i++ {
+			vAlue25 := int32(r.Int31())
+			this.Sfixed32Map[vAlue25] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v25] *= -1
+				this.Sfixed32Map[vAlue25] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
+		vAlue26 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v26; i++ {
-			v27 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v27] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue26; i++ {
+			vAlue27 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue27] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
+		vAlue28 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v28; i++ {
-			v29 := int64(r.Int63())
-			this.Sfixed64Map[v29] = int64(r.Int63())
+		for i := 0; i < vAlue28; i++ {
+			vAlue29 := int64(r.Int63())
+			this.Sfixed64Map[vAlue29] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v29] *= -1
+				this.Sfixed64Map[vAlue29] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
+		vAlue30 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v30; i++ {
-			v31 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v31] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue31] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v32; i++ {
+		for i := 0; i < vAlue32; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
+		vAlue33 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v33; i++ {
-			v34 := r.Intn(100)
-			v35 := randStringMapsproto2(r)
-			this.StringToBytesMap[v35] = make([]byte, v34)
-			for i := 0; i < v34; i++ {
-				this.StringToBytesMap[v35][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := r.Intn(100)
+			vAlue35 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue35] = make([]byte, vAlue34)
+			for i := 0; i < vAlue34; i++ {
+				this.StringToBytesMap[vAlue35][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v37; i++ {
+		for i := 0; i < vAlue37; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -3571,163 +3571,163 @@ func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyMapsproto2, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
+		vAlue38 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v38; i++ {
-			v39 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v39] = float64(r.Float64())
+		for i := 0; i < vAlue38; i++ {
+			vAlue39 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue39] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v39] *= -1
+				this.StringToDoubleMap[vAlue39] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
+		vAlue40 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v40; i++ {
-			v41 := randStringMapsproto2(r)
-			this.StringToFloatMap[v41] = float32(r.Float32())
+		for i := 0; i < vAlue40; i++ {
+			vAlue41 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue41] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v41] *= -1
+				this.StringToFloatMap[vAlue41] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
+		vAlue42 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v42; i++ {
-			v43 := int32(r.Int31())
-			this.Int32Map[v43] = int32(r.Int31())
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := int32(r.Int31())
+			this.Int32Map[vAlue43] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v43] *= -1
+				this.Int32Map[vAlue43] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
+		vAlue44 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v44; i++ {
-			v45 := int64(r.Int63())
-			this.Int64Map[v45] = int64(r.Int63())
+		for i := 0; i < vAlue44; i++ {
+			vAlue45 := int64(r.Int63())
+			this.Int64Map[vAlue45] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v45] *= -1
+				this.Int64Map[vAlue45] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
+		vAlue46 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v46; i++ {
-			v47 := uint32(r.Uint32())
-			this.Uint32Map[v47] = uint32(r.Uint32())
+		for i := 0; i < vAlue46; i++ {
+			vAlue47 := uint32(r.Uint32())
+			this.Uint32Map[vAlue47] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(10)
+		vAlue48 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v48; i++ {
-			v49 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v49] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue49] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
+		vAlue50 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v50; i++ {
-			v51 := int32(r.Int31())
-			this.Sint32Map[v51] = int32(r.Int31())
+		for i := 0; i < vAlue50; i++ {
+			vAlue51 := int32(r.Int31())
+			this.Sint32Map[vAlue51] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v51] *= -1
+				this.Sint32Map[vAlue51] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
+		vAlue52 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v52; i++ {
-			v53 := int64(r.Int63())
-			this.Sint64Map[v53] = int64(r.Int63())
+		for i := 0; i < vAlue52; i++ {
+			vAlue53 := int64(r.Int63())
+			this.Sint64Map[vAlue53] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v53] *= -1
+				this.Sint64Map[vAlue53] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
+		vAlue54 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v54; i++ {
-			v55 := uint32(r.Uint32())
-			this.Fixed32Map[v55] = uint32(r.Uint32())
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue55] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
+		vAlue56 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v56; i++ {
-			v57 := int32(r.Int31())
-			this.Sfixed32Map[v57] = int32(r.Int31())
+		for i := 0; i < vAlue56; i++ {
+			vAlue57 := int32(r.Int31())
+			this.Sfixed32Map[vAlue57] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v57] *= -1
+				this.Sfixed32Map[vAlue57] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
+		vAlue58 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v58; i++ {
-			v59 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v59] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue59] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
+		vAlue60 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v60; i++ {
-			v61 := int64(r.Int63())
-			this.Sfixed64Map[v61] = int64(r.Int63())
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := int64(r.Int63())
+			this.Sfixed64Map[vAlue61] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v61] *= -1
+				this.Sfixed64Map[vAlue61] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
+		vAlue62 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v62; i++ {
-			v63 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v63] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue62; i++ {
+			vAlue63 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue63] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v64; i++ {
+		for i := 0; i < vAlue64; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
+		vAlue65 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v65; i++ {
-			v66 := r.Intn(100)
-			v67 := randStringMapsproto2(r)
-			this.StringToBytesMap[v67] = make([]byte, v66)
-			for i := 0; i < v66; i++ {
-				this.StringToBytesMap[v67][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue65; i++ {
+			vAlue66 := r.Intn(100)
+			vAlue67 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue67] = make([]byte, vAlue66)
+			for i := 0; i < vAlue66; i++ {
+				this.StringToBytesMap[vAlue67][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -3756,9 +3756,9 @@ func randUTF8RuneMapsproto2(r randyMapsproto2) rune {
 	return rune(ru + 61)
 }
 func randStringMapsproto2(r randyMapsproto2) string {
-	v70 := r.Intn(100)
-	tmps := make([]rune, v70)
-	for i := 0; i < v70; i++ {
+	vAlue70 := r.Intn(100)
+	tmps := make([]rune, vAlue70)
+	for i := 0; i < vAlue70; i++ {
 		tmps[i] = randUTF8RuneMapsproto2(r)
 	}
 	return string(tmps)
@@ -3780,11 +3780,11 @@ func randFieldMapsproto2(dAtA []byte, r randyMapsproto2, fieldNumber int, wire i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
-		v71 := r.Int63()
+		vAlue71 := r.Int63()
 		if r.Intn(2) == 0 {
-			v71 *= -1
+			vAlue71 *= -1
 		}
-		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(v71))
+		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(vAlue71))
 	case 1:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapsproto2/combos/neither/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/neither/mapsproto2.pb.go
@@ -2396,11 +2396,11 @@ func valueToGoStringMapsproto2(v interface{}, typ string) string {
 func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 	this := &FloatingPoint{}
 	if r.Intn(5) != 0 {
-		v1 := float64(r.Float64())
+		vAlue1 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.F = &v1
+		this.F = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedMapsproto2(r, 2)
@@ -2411,30 +2411,30 @@ func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 	this := &CustomMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.Nullable128S = make(map[string]*github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.Nullable128S[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test_custom.Uint128)(github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Uint128S = make(map[string]github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Uint128S[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test_custom.Uint128)(*github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.NullableIds = make(map[string]*github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.NullableIds[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test.Uuid)(github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.Ids = make(map[string]github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v5; i++ {
+		for i := 0; i < vAlue5; i++ {
 			this.Ids[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test.Uuid)(*github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
@@ -2447,163 +2447,163 @@ func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(10)
+		vAlue6 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v6; i++ {
-			v7 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v7] = float64(r.Float64())
+		for i := 0; i < vAlue6; i++ {
+			vAlue7 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue7] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v7] *= -1
+				this.StringToDoubleMap[vAlue7] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v8; i++ {
-			v9 := randStringMapsproto2(r)
-			this.StringToFloatMap[v9] = float32(r.Float32())
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue9] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v9] *= -1
+				this.StringToFloatMap[vAlue9] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v10; i++ {
-			v11 := int32(r.Int31())
-			this.Int32Map[v11] = int32(r.Int31())
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := int32(r.Int31())
+			this.Int32Map[vAlue11] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v11] *= -1
+				this.Int32Map[vAlue11] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v12; i++ {
-			v13 := int64(r.Int63())
-			this.Int64Map[v13] = int64(r.Int63())
+		for i := 0; i < vAlue12; i++ {
+			vAlue13 := int64(r.Int63())
+			this.Int64Map[vAlue13] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v13] *= -1
+				this.Int64Map[vAlue13] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(10)
+		vAlue14 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v14; i++ {
-			v15 := uint32(r.Uint32())
-			this.Uint32Map[v15] = uint32(r.Uint32())
+		for i := 0; i < vAlue14; i++ {
+			vAlue15 := uint32(r.Uint32())
+			this.Uint32Map[vAlue15] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(10)
+		vAlue16 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v16; i++ {
-			v17 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v17] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue16; i++ {
+			vAlue17 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue17] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
+		vAlue18 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v18; i++ {
-			v19 := int32(r.Int31())
-			this.Sint32Map[v19] = int32(r.Int31())
+		for i := 0; i < vAlue18; i++ {
+			vAlue19 := int32(r.Int31())
+			this.Sint32Map[vAlue19] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v19] *= -1
+				this.Sint32Map[vAlue19] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
+		vAlue20 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v20; i++ {
-			v21 := int64(r.Int63())
-			this.Sint64Map[v21] = int64(r.Int63())
+		for i := 0; i < vAlue20; i++ {
+			vAlue21 := int64(r.Int63())
+			this.Sint64Map[vAlue21] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v21] *= -1
+				this.Sint64Map[vAlue21] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
+		vAlue22 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v22; i++ {
-			v23 := uint32(r.Uint32())
-			this.Fixed32Map[v23] = uint32(r.Uint32())
+		for i := 0; i < vAlue22; i++ {
+			vAlue23 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue23] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
+		vAlue24 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v24; i++ {
-			v25 := int32(r.Int31())
-			this.Sfixed32Map[v25] = int32(r.Int31())
+		for i := 0; i < vAlue24; i++ {
+			vAlue25 := int32(r.Int31())
+			this.Sfixed32Map[vAlue25] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v25] *= -1
+				this.Sfixed32Map[vAlue25] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
+		vAlue26 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v26; i++ {
-			v27 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v27] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue26; i++ {
+			vAlue27 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue27] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
+		vAlue28 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v28; i++ {
-			v29 := int64(r.Int63())
-			this.Sfixed64Map[v29] = int64(r.Int63())
+		for i := 0; i < vAlue28; i++ {
+			vAlue29 := int64(r.Int63())
+			this.Sfixed64Map[vAlue29] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v29] *= -1
+				this.Sfixed64Map[vAlue29] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
+		vAlue30 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v30; i++ {
-			v31 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v31] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue31] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v32; i++ {
+		for i := 0; i < vAlue32; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
+		vAlue33 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v33; i++ {
-			v34 := r.Intn(100)
-			v35 := randStringMapsproto2(r)
-			this.StringToBytesMap[v35] = make([]byte, v34)
-			for i := 0; i < v34; i++ {
-				this.StringToBytesMap[v35][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := r.Intn(100)
+			vAlue35 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue35] = make([]byte, vAlue34)
+			for i := 0; i < vAlue34; i++ {
+				this.StringToBytesMap[vAlue35][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v37; i++ {
+		for i := 0; i < vAlue37; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -2616,163 +2616,163 @@ func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyMapsproto2, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
+		vAlue38 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v38; i++ {
-			v39 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v39] = float64(r.Float64())
+		for i := 0; i < vAlue38; i++ {
+			vAlue39 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue39] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v39] *= -1
+				this.StringToDoubleMap[vAlue39] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
+		vAlue40 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v40; i++ {
-			v41 := randStringMapsproto2(r)
-			this.StringToFloatMap[v41] = float32(r.Float32())
+		for i := 0; i < vAlue40; i++ {
+			vAlue41 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue41] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v41] *= -1
+				this.StringToFloatMap[vAlue41] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
+		vAlue42 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v42; i++ {
-			v43 := int32(r.Int31())
-			this.Int32Map[v43] = int32(r.Int31())
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := int32(r.Int31())
+			this.Int32Map[vAlue43] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v43] *= -1
+				this.Int32Map[vAlue43] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
+		vAlue44 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v44; i++ {
-			v45 := int64(r.Int63())
-			this.Int64Map[v45] = int64(r.Int63())
+		for i := 0; i < vAlue44; i++ {
+			vAlue45 := int64(r.Int63())
+			this.Int64Map[vAlue45] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v45] *= -1
+				this.Int64Map[vAlue45] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
+		vAlue46 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v46; i++ {
-			v47 := uint32(r.Uint32())
-			this.Uint32Map[v47] = uint32(r.Uint32())
+		for i := 0; i < vAlue46; i++ {
+			vAlue47 := uint32(r.Uint32())
+			this.Uint32Map[vAlue47] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(10)
+		vAlue48 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v48; i++ {
-			v49 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v49] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue49] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
+		vAlue50 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v50; i++ {
-			v51 := int32(r.Int31())
-			this.Sint32Map[v51] = int32(r.Int31())
+		for i := 0; i < vAlue50; i++ {
+			vAlue51 := int32(r.Int31())
+			this.Sint32Map[vAlue51] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v51] *= -1
+				this.Sint32Map[vAlue51] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
+		vAlue52 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v52; i++ {
-			v53 := int64(r.Int63())
-			this.Sint64Map[v53] = int64(r.Int63())
+		for i := 0; i < vAlue52; i++ {
+			vAlue53 := int64(r.Int63())
+			this.Sint64Map[vAlue53] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v53] *= -1
+				this.Sint64Map[vAlue53] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
+		vAlue54 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v54; i++ {
-			v55 := uint32(r.Uint32())
-			this.Fixed32Map[v55] = uint32(r.Uint32())
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue55] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
+		vAlue56 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v56; i++ {
-			v57 := int32(r.Int31())
-			this.Sfixed32Map[v57] = int32(r.Int31())
+		for i := 0; i < vAlue56; i++ {
+			vAlue57 := int32(r.Int31())
+			this.Sfixed32Map[vAlue57] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v57] *= -1
+				this.Sfixed32Map[vAlue57] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
+		vAlue58 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v58; i++ {
-			v59 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v59] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue59] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
+		vAlue60 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v60; i++ {
-			v61 := int64(r.Int63())
-			this.Sfixed64Map[v61] = int64(r.Int63())
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := int64(r.Int63())
+			this.Sfixed64Map[vAlue61] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v61] *= -1
+				this.Sfixed64Map[vAlue61] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
+		vAlue62 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v62; i++ {
-			v63 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v63] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue62; i++ {
+			vAlue63 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue63] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v64; i++ {
+		for i := 0; i < vAlue64; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
+		vAlue65 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v65; i++ {
-			v66 := r.Intn(100)
-			v67 := randStringMapsproto2(r)
-			this.StringToBytesMap[v67] = make([]byte, v66)
-			for i := 0; i < v66; i++ {
-				this.StringToBytesMap[v67][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue65; i++ {
+			vAlue66 := r.Intn(100)
+			vAlue67 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue67] = make([]byte, vAlue66)
+			for i := 0; i < vAlue66; i++ {
+				this.StringToBytesMap[vAlue67][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -2801,9 +2801,9 @@ func randUTF8RuneMapsproto2(r randyMapsproto2) rune {
 	return rune(ru + 61)
 }
 func randStringMapsproto2(r randyMapsproto2) string {
-	v70 := r.Intn(100)
-	tmps := make([]rune, v70)
-	for i := 0; i < v70; i++ {
+	vAlue70 := r.Intn(100)
+	tmps := make([]rune, vAlue70)
+	for i := 0; i < vAlue70; i++ {
 		tmps[i] = randUTF8RuneMapsproto2(r)
 	}
 	return string(tmps)
@@ -2825,11 +2825,11 @@ func randFieldMapsproto2(dAtA []byte, r randyMapsproto2, fieldNumber int, wire i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
-		v71 := r.Int63()
+		vAlue71 := r.Int63()
 		if r.Intn(2) == 0 {
-			v71 *= -1
+			vAlue71 *= -1
 		}
-		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(v71))
+		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(vAlue71))
 	case 1:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
@@ -2400,11 +2400,11 @@ func valueToGoStringMapsproto2(v interface{}, typ string) string {
 func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 	this := &FloatingPoint{}
 	if r.Intn(5) != 0 {
-		v1 := float64(r.Float64())
+		vAlue1 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.F = &v1
+		this.F = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedMapsproto2(r, 2)
@@ -2415,30 +2415,30 @@ func NewPopulatedFloatingPoint(r randyMapsproto2, easy bool) *FloatingPoint {
 func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 	this := &CustomMap{}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
+		vAlue2 := r.Intn(10)
 		this.Nullable128S = make(map[string]*github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v2; i++ {
+		for i := 0; i < vAlue2; i++ {
 			this.Nullable128S[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test_custom.Uint128)(github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Uint128S = make(map[string]github_com_gogo_protobuf_test_custom.Uint128)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Uint128S[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test_custom.Uint128)(*github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.NullableIds = make(map[string]*github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.NullableIds[randStringMapsproto2(r)] = (*github_com_gogo_protobuf_test.Uuid)(github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.Ids = make(map[string]github_com_gogo_protobuf_test.Uuid)
-		for i := 0; i < v5; i++ {
+		for i := 0; i < vAlue5; i++ {
 			this.Ids[randStringMapsproto2(r)] = (github_com_gogo_protobuf_test.Uuid)(*github_com_gogo_protobuf_test.NewPopulatedUuid(r))
 		}
 	}
@@ -2451,163 +2451,163 @@ func NewPopulatedCustomMap(r randyMapsproto2, easy bool) *CustomMap {
 func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(10)
+		vAlue6 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v6; i++ {
-			v7 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v7] = float64(r.Float64())
+		for i := 0; i < vAlue6; i++ {
+			vAlue7 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue7] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v7] *= -1
+				this.StringToDoubleMap[vAlue7] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
+		vAlue8 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v8; i++ {
-			v9 := randStringMapsproto2(r)
-			this.StringToFloatMap[v9] = float32(r.Float32())
+		for i := 0; i < vAlue8; i++ {
+			vAlue9 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue9] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v9] *= -1
+				this.StringToFloatMap[vAlue9] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
+		vAlue10 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v10; i++ {
-			v11 := int32(r.Int31())
-			this.Int32Map[v11] = int32(r.Int31())
+		for i := 0; i < vAlue10; i++ {
+			vAlue11 := int32(r.Int31())
+			this.Int32Map[vAlue11] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v11] *= -1
+				this.Int32Map[vAlue11] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
+		vAlue12 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v12; i++ {
-			v13 := int64(r.Int63())
-			this.Int64Map[v13] = int64(r.Int63())
+		for i := 0; i < vAlue12; i++ {
+			vAlue13 := int64(r.Int63())
+			this.Int64Map[vAlue13] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v13] *= -1
+				this.Int64Map[vAlue13] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(10)
+		vAlue14 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v14; i++ {
-			v15 := uint32(r.Uint32())
-			this.Uint32Map[v15] = uint32(r.Uint32())
+		for i := 0; i < vAlue14; i++ {
+			vAlue15 := uint32(r.Uint32())
+			this.Uint32Map[vAlue15] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(10)
+		vAlue16 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v16; i++ {
-			v17 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v17] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue16; i++ {
+			vAlue17 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue17] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
+		vAlue18 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v18; i++ {
-			v19 := int32(r.Int31())
-			this.Sint32Map[v19] = int32(r.Int31())
+		for i := 0; i < vAlue18; i++ {
+			vAlue19 := int32(r.Int31())
+			this.Sint32Map[vAlue19] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v19] *= -1
+				this.Sint32Map[vAlue19] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
+		vAlue20 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v20; i++ {
-			v21 := int64(r.Int63())
-			this.Sint64Map[v21] = int64(r.Int63())
+		for i := 0; i < vAlue20; i++ {
+			vAlue21 := int64(r.Int63())
+			this.Sint64Map[vAlue21] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v21] *= -1
+				this.Sint64Map[vAlue21] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
+		vAlue22 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v22; i++ {
-			v23 := uint32(r.Uint32())
-			this.Fixed32Map[v23] = uint32(r.Uint32())
+		for i := 0; i < vAlue22; i++ {
+			vAlue23 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue23] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
+		vAlue24 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v24; i++ {
-			v25 := int32(r.Int31())
-			this.Sfixed32Map[v25] = int32(r.Int31())
+		for i := 0; i < vAlue24; i++ {
+			vAlue25 := int32(r.Int31())
+			this.Sfixed32Map[vAlue25] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v25] *= -1
+				this.Sfixed32Map[vAlue25] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
+		vAlue26 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v26; i++ {
-			v27 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v27] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue26; i++ {
+			vAlue27 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue27] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
+		vAlue28 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v28; i++ {
-			v29 := int64(r.Int63())
-			this.Sfixed64Map[v29] = int64(r.Int63())
+		for i := 0; i < vAlue28; i++ {
+			vAlue29 := int64(r.Int63())
+			this.Sfixed64Map[vAlue29] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v29] *= -1
+				this.Sfixed64Map[vAlue29] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
+		vAlue30 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v30; i++ {
-			v31 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v31] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue31] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v32; i++ {
+		for i := 0; i < vAlue32; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
+		vAlue33 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v33; i++ {
-			v34 := r.Intn(100)
-			v35 := randStringMapsproto2(r)
-			this.StringToBytesMap[v35] = make([]byte, v34)
-			for i := 0; i < v34; i++ {
-				this.StringToBytesMap[v35][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := r.Intn(100)
+			vAlue35 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue35] = make([]byte, vAlue34)
+			for i := 0; i < vAlue34; i++ {
+				this.StringToBytesMap[vAlue35][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v37; i++ {
+		for i := 0; i < vAlue37; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -2620,163 +2620,163 @@ func NewPopulatedAllMaps(r randyMapsproto2, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyMapsproto2, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
+		vAlue38 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v38; i++ {
-			v39 := randStringMapsproto2(r)
-			this.StringToDoubleMap[v39] = float64(r.Float64())
+		for i := 0; i < vAlue38; i++ {
+			vAlue39 := randStringMapsproto2(r)
+			this.StringToDoubleMap[vAlue39] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v39] *= -1
+				this.StringToDoubleMap[vAlue39] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
+		vAlue40 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v40; i++ {
-			v41 := randStringMapsproto2(r)
-			this.StringToFloatMap[v41] = float32(r.Float32())
+		for i := 0; i < vAlue40; i++ {
+			vAlue41 := randStringMapsproto2(r)
+			this.StringToFloatMap[vAlue41] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v41] *= -1
+				this.StringToFloatMap[vAlue41] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
+		vAlue42 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v42; i++ {
-			v43 := int32(r.Int31())
-			this.Int32Map[v43] = int32(r.Int31())
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := int32(r.Int31())
+			this.Int32Map[vAlue43] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v43] *= -1
+				this.Int32Map[vAlue43] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
+		vAlue44 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v44; i++ {
-			v45 := int64(r.Int63())
-			this.Int64Map[v45] = int64(r.Int63())
+		for i := 0; i < vAlue44; i++ {
+			vAlue45 := int64(r.Int63())
+			this.Int64Map[vAlue45] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v45] *= -1
+				this.Int64Map[vAlue45] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
+		vAlue46 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v46; i++ {
-			v47 := uint32(r.Uint32())
-			this.Uint32Map[v47] = uint32(r.Uint32())
+		for i := 0; i < vAlue46; i++ {
+			vAlue47 := uint32(r.Uint32())
+			this.Uint32Map[vAlue47] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(10)
+		vAlue48 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v48; i++ {
-			v49 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v49] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue49] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
+		vAlue50 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v50; i++ {
-			v51 := int32(r.Int31())
-			this.Sint32Map[v51] = int32(r.Int31())
+		for i := 0; i < vAlue50; i++ {
+			vAlue51 := int32(r.Int31())
+			this.Sint32Map[vAlue51] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v51] *= -1
+				this.Sint32Map[vAlue51] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
+		vAlue52 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v52; i++ {
-			v53 := int64(r.Int63())
-			this.Sint64Map[v53] = int64(r.Int63())
+		for i := 0; i < vAlue52; i++ {
+			vAlue53 := int64(r.Int63())
+			this.Sint64Map[vAlue53] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v53] *= -1
+				this.Sint64Map[vAlue53] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
+		vAlue54 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v54; i++ {
-			v55 := uint32(r.Uint32())
-			this.Fixed32Map[v55] = uint32(r.Uint32())
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue55] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
+		vAlue56 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v56; i++ {
-			v57 := int32(r.Int31())
-			this.Sfixed32Map[v57] = int32(r.Int31())
+		for i := 0; i < vAlue56; i++ {
+			vAlue57 := int32(r.Int31())
+			this.Sfixed32Map[vAlue57] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v57] *= -1
+				this.Sfixed32Map[vAlue57] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
+		vAlue58 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v58; i++ {
-			v59 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v59] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue59] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
+		vAlue60 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v60; i++ {
-			v61 := int64(r.Int63())
-			this.Sfixed64Map[v61] = int64(r.Int63())
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := int64(r.Int63())
+			this.Sfixed64Map[vAlue61] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v61] *= -1
+				this.Sfixed64Map[vAlue61] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
+		vAlue62 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v62; i++ {
-			v63 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v63] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue62; i++ {
+			vAlue63 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue63] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v64; i++ {
+		for i := 0; i < vAlue64; i++ {
 			this.StringMap[randStringMapsproto2(r)] = randStringMapsproto2(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
+		vAlue65 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v65; i++ {
-			v66 := r.Intn(100)
-			v67 := randStringMapsproto2(r)
-			this.StringToBytesMap[v67] = make([]byte, v66)
-			for i := 0; i < v66; i++ {
-				this.StringToBytesMap[v67][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue65; i++ {
+			vAlue66 := r.Intn(100)
+			vAlue67 := randStringMapsproto2(r)
+			this.StringToBytesMap[vAlue67] = make([]byte, vAlue66)
+			for i := 0; i < vAlue66; i++ {
+				this.StringToBytesMap[vAlue67][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToEnumMap[randStringMapsproto2(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.StringToMsgMap[randStringMapsproto2(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -2805,9 +2805,9 @@ func randUTF8RuneMapsproto2(r randyMapsproto2) rune {
 	return rune(ru + 61)
 }
 func randStringMapsproto2(r randyMapsproto2) string {
-	v70 := r.Intn(100)
-	tmps := make([]rune, v70)
-	for i := 0; i < v70; i++ {
+	vAlue70 := r.Intn(100)
+	tmps := make([]rune, vAlue70)
+	for i := 0; i < vAlue70; i++ {
 		tmps[i] = randUTF8RuneMapsproto2(r)
 	}
 	return string(tmps)
@@ -2829,11 +2829,11 @@ func randFieldMapsproto2(dAtA []byte, r randyMapsproto2, fieldNumber int, wire i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
-		v71 := r.Int63()
+		vAlue71 := r.Int63()
 		if r.Intn(2) == 0 {
-			v71 *= -1
+			vAlue71 *= -1
 		}
-		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(v71))
+		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(vAlue71))
 	case 1:
 		dAtA = encodeVarintPopulateMapsproto2(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/moredefaults/md.pb.go
+++ b/test/moredefaults/md.pb.go
@@ -253,8 +253,8 @@ func (this *MoreDefaultsA) Equal(that interface{}) bool {
 func NewPopulatedMoreDefaultsB(r randyMd, easy bool) *MoreDefaultsB {
 	this := &MoreDefaultsB{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringMd(r))
-		this.Field1 = &v1
+		vAlue1 := string(randStringMd(r))
+		this.Field1 = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedMd(r, 2)
@@ -265,11 +265,11 @@ func NewPopulatedMoreDefaultsB(r randyMd, easy bool) *MoreDefaultsB {
 func NewPopulatedMoreDefaultsA(r randyMd, easy bool) *MoreDefaultsA {
 	this := &MoreDefaultsA{}
 	if r.Intn(5) != 0 {
-		v2 := int64(r.Int63())
+		vAlue2 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	this.Field2 = int64(r.Int63())
 	if r.Intn(2) == 0 {
@@ -278,13 +278,13 @@ func NewPopulatedMoreDefaultsA(r randyMd, easy bool) *MoreDefaultsA {
 	if r.Intn(5) != 0 {
 		this.B1 = NewPopulatedMoreDefaultsB(r, easy)
 	}
-	v3 := NewPopulatedMoreDefaultsB(r, easy)
-	this.B2 = *v3
+	vAlue3 := NewPopulatedMoreDefaultsB(r, easy)
+	this.B2 = *vAlue3
 	if r.Intn(5) != 0 {
 		this.A1 = example.NewPopulatedA(r, easy)
 	}
-	v4 := example.NewPopulatedA(r, easy)
-	this.A2 = *v4
+	vAlue4 := example.NewPopulatedA(r, easy)
+	this.A2 = *vAlue4
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedMd(r, 7)
 	}
@@ -310,9 +310,9 @@ func randUTF8RuneMd(r randyMd) rune {
 	return rune(ru + 61)
 }
 func randStringMd(r randyMd) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneMd(r)
 	}
 	return string(tmps)
@@ -334,11 +334,11 @@ func randFieldMd(dAtA []byte, r randyMd, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateMd(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateMd(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateMd(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateMd(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof/combos/both/one.pb.go
+++ b/test/oneof/combos/both/one.pb.go
@@ -4683,8 +4683,8 @@ func encodeVarintOne(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedSubby(r randyOne, easy bool) *Subby {
 	this := &Subby{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringOne(r))
-		this.Sub = &v1
+		vAlue1 := string(randStringOne(r))
+		this.Sub = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedOne(r, 2)
@@ -4831,9 +4831,9 @@ func NewPopulatedAllTypesOneOf_Field14(r randyOne, easy bool) *AllTypesOneOf_Fie
 }
 func NewPopulatedAllTypesOneOf_Field15(r randyOne, easy bool) *AllTypesOneOf_Field15 {
 	this := &AllTypesOneOf_Field15{}
-	v2 := r.Intn(100)
-	this.Field15 = make([]byte, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4900,9 +4900,9 @@ func NewPopulatedTwoOneofs_Field34(r randyOne, easy bool) *TwoOneofs_Field34 {
 }
 func NewPopulatedTwoOneofs_Field35(r randyOne, easy bool) *TwoOneofs_Field35 {
 	this := &TwoOneofs_Field35{}
-	v3 := r.Intn(100)
-	this.Field35 = make([]byte, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	this.Field35 = make([]byte, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		this.Field35[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4938,8 +4938,8 @@ func NewPopulatedCustomOneof_Stringy(r randyOne, easy bool) *CustomOneof_Stringy
 }
 func NewPopulatedCustomOneof_CustomType(r randyOne, easy bool) *CustomOneof_CustomType {
 	this := &CustomOneof_CustomType{}
-	v4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.CustomType = *v4
+	vAlue4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.CustomType = *vAlue4
 	return this
 }
 func NewPopulatedCustomOneof_CastType(r randyOne, easy bool) *CustomOneof_CastType {
@@ -4975,9 +4975,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -4999,11 +4999,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof/combos/marshaler/one.pb.go
+++ b/test/oneof/combos/marshaler/one.pb.go
@@ -4682,8 +4682,8 @@ func encodeVarintOne(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedSubby(r randyOne, easy bool) *Subby {
 	this := &Subby{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringOne(r))
-		this.Sub = &v1
+		vAlue1 := string(randStringOne(r))
+		this.Sub = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedOne(r, 2)
@@ -4830,9 +4830,9 @@ func NewPopulatedAllTypesOneOf_Field14(r randyOne, easy bool) *AllTypesOneOf_Fie
 }
 func NewPopulatedAllTypesOneOf_Field15(r randyOne, easy bool) *AllTypesOneOf_Field15 {
 	this := &AllTypesOneOf_Field15{}
-	v2 := r.Intn(100)
-	this.Field15 = make([]byte, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4899,9 +4899,9 @@ func NewPopulatedTwoOneofs_Field34(r randyOne, easy bool) *TwoOneofs_Field34 {
 }
 func NewPopulatedTwoOneofs_Field35(r randyOne, easy bool) *TwoOneofs_Field35 {
 	this := &TwoOneofs_Field35{}
-	v3 := r.Intn(100)
-	this.Field35 = make([]byte, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	this.Field35 = make([]byte, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		this.Field35[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4937,8 +4937,8 @@ func NewPopulatedCustomOneof_Stringy(r randyOne, easy bool) *CustomOneof_Stringy
 }
 func NewPopulatedCustomOneof_CustomType(r randyOne, easy bool) *CustomOneof_CustomType {
 	this := &CustomOneof_CustomType{}
-	v4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.CustomType = *v4
+	vAlue4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.CustomType = *vAlue4
 	return this
 }
 func NewPopulatedCustomOneof_CastType(r randyOne, easy bool) *CustomOneof_CastType {
@@ -4974,9 +4974,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -4998,11 +4998,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof/combos/neither/one.pb.go
+++ b/test/oneof/combos/neither/one.pb.go
@@ -4099,8 +4099,8 @@ func valueToGoStringOne(v interface{}, typ string) string {
 func NewPopulatedSubby(r randyOne, easy bool) *Subby {
 	this := &Subby{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringOne(r))
-		this.Sub = &v1
+		vAlue1 := string(randStringOne(r))
+		this.Sub = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedOne(r, 2)
@@ -4247,9 +4247,9 @@ func NewPopulatedAllTypesOneOf_Field14(r randyOne, easy bool) *AllTypesOneOf_Fie
 }
 func NewPopulatedAllTypesOneOf_Field15(r randyOne, easy bool) *AllTypesOneOf_Field15 {
 	this := &AllTypesOneOf_Field15{}
-	v2 := r.Intn(100)
-	this.Field15 = make([]byte, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4316,9 +4316,9 @@ func NewPopulatedTwoOneofs_Field34(r randyOne, easy bool) *TwoOneofs_Field34 {
 }
 func NewPopulatedTwoOneofs_Field35(r randyOne, easy bool) *TwoOneofs_Field35 {
 	this := &TwoOneofs_Field35{}
-	v3 := r.Intn(100)
-	this.Field35 = make([]byte, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	this.Field35 = make([]byte, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		this.Field35[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4354,8 +4354,8 @@ func NewPopulatedCustomOneof_Stringy(r randyOne, easy bool) *CustomOneof_Stringy
 }
 func NewPopulatedCustomOneof_CustomType(r randyOne, easy bool) *CustomOneof_CustomType {
 	this := &CustomOneof_CustomType{}
-	v4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.CustomType = *v4
+	vAlue4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.CustomType = *vAlue4
 	return this
 }
 func NewPopulatedCustomOneof_CastType(r randyOne, easy bool) *CustomOneof_CastType {
@@ -4391,9 +4391,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -4415,11 +4415,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof/combos/unmarshaler/one.pb.go
+++ b/test/oneof/combos/unmarshaler/one.pb.go
@@ -4101,8 +4101,8 @@ func valueToGoStringOne(v interface{}, typ string) string {
 func NewPopulatedSubby(r randyOne, easy bool) *Subby {
 	this := &Subby{}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringOne(r))
-		this.Sub = &v1
+		vAlue1 := string(randStringOne(r))
+		this.Sub = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedOne(r, 2)
@@ -4249,9 +4249,9 @@ func NewPopulatedAllTypesOneOf_Field14(r randyOne, easy bool) *AllTypesOneOf_Fie
 }
 func NewPopulatedAllTypesOneOf_Field15(r randyOne, easy bool) *AllTypesOneOf_Field15 {
 	this := &AllTypesOneOf_Field15{}
-	v2 := r.Intn(100)
-	this.Field15 = make([]byte, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4318,9 +4318,9 @@ func NewPopulatedTwoOneofs_Field34(r randyOne, easy bool) *TwoOneofs_Field34 {
 }
 func NewPopulatedTwoOneofs_Field35(r randyOne, easy bool) *TwoOneofs_Field35 {
 	this := &TwoOneofs_Field35{}
-	v3 := r.Intn(100)
-	this.Field35 = make([]byte, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	this.Field35 = make([]byte, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		this.Field35[i] = byte(r.Intn(256))
 	}
 	return this
@@ -4356,8 +4356,8 @@ func NewPopulatedCustomOneof_Stringy(r randyOne, easy bool) *CustomOneof_Stringy
 }
 func NewPopulatedCustomOneof_CustomType(r randyOne, easy bool) *CustomOneof_CustomType {
 	this := &CustomOneof_CustomType{}
-	v4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.CustomType = *v4
+	vAlue4 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.CustomType = *vAlue4
 	return this
 }
 func NewPopulatedCustomOneof_CastType(r randyOne, easy bool) *CustomOneof_CastType {
@@ -4393,9 +4393,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -4417,11 +4417,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof3/combos/both/one.pb.go
+++ b/test/oneof3/combos/both/one.pb.go
@@ -2950,9 +2950,9 @@ func NewPopulatedSampleOneOf_Field14(r randyOne, easy bool) *SampleOneOf_Field14
 }
 func NewPopulatedSampleOneOf_Field15(r randyOne, easy bool) *SampleOneOf_Field15 {
 	this := &SampleOneOf_Field15{}
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -2982,9 +2982,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -3006,11 +3006,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof3/combos/marshaler/one.pb.go
+++ b/test/oneof3/combos/marshaler/one.pb.go
@@ -2949,9 +2949,9 @@ func NewPopulatedSampleOneOf_Field14(r randyOne, easy bool) *SampleOneOf_Field14
 }
 func NewPopulatedSampleOneOf_Field15(r randyOne, easy bool) *SampleOneOf_Field15 {
 	this := &SampleOneOf_Field15{}
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -2981,9 +2981,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -3005,11 +3005,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof3/combos/neither/one.pb.go
+++ b/test/oneof3/combos/neither/one.pb.go
@@ -2628,9 +2628,9 @@ func NewPopulatedSampleOneOf_Field14(r randyOne, easy bool) *SampleOneOf_Field14
 }
 func NewPopulatedSampleOneOf_Field15(r randyOne, easy bool) *SampleOneOf_Field15 {
 	this := &SampleOneOf_Field15{}
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -2660,9 +2660,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -2684,11 +2684,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneof3/combos/unmarshaler/one.pb.go
+++ b/test/oneof3/combos/unmarshaler/one.pb.go
@@ -2630,9 +2630,9 @@ func NewPopulatedSampleOneOf_Field14(r randyOne, easy bool) *SampleOneOf_Field14
 }
 func NewPopulatedSampleOneOf_Field15(r randyOne, easy bool) *SampleOneOf_Field15 {
 	this := &SampleOneOf_Field15{}
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	return this
@@ -2662,9 +2662,9 @@ func randUTF8RuneOne(r randyOne) rune {
 	return rune(ru + 61)
 }
 func randStringOne(r randyOne) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneOne(r)
 	}
 	return string(tmps)
@@ -2686,11 +2686,11 @@ func randFieldOne(dAtA []byte, r randyOne, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateOne(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateOne(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateOne(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/oneofembed/oneofembed.pb.go
+++ b/test/oneofembed/oneofembed.pb.go
@@ -482,9 +482,9 @@ func randUTF8RuneOneofembed(r randyOneofembed) rune {
 	return rune(ru + 61)
 }
 func randStringOneofembed(r randyOneofembed) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneOneofembed(r)
 	}
 	return string(tmps)
@@ -506,11 +506,11 @@ func randFieldOneofembed(dAtA []byte, r randyOneofembed, fieldNumber int, wire i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateOneofembed(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateOneofembed(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateOneofembed(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateOneofembed(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/packed/packed.pb.go
+++ b/test/packed/packed.pb.go
@@ -600,9 +600,9 @@ var fileDescriptor_2c9922eb15f14bbb = []byte{
 func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 	this := &NinRepNative{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(10)
-		this.Field1 = make([]float64, v1)
-		for i := 0; i < v1; i++ {
+		vAlue1 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue1)
+		for i := 0; i < vAlue1; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -610,9 +610,9 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
-		this.Field2 = make([]float32, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -620,9 +620,9 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
-		this.Field3 = make([]int32, v3)
-		for i := 0; i < v3; i++ {
+		vAlue3 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue3)
+		for i := 0; i < vAlue3; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -630,9 +630,9 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
-		this.Field4 = make([]int64, v4)
-		for i := 0; i < v4; i++ {
+		vAlue4 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue4)
+		for i := 0; i < vAlue4; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -640,23 +640,23 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
-		this.Field5 = make([]uint32, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(10)
-		this.Field6 = make([]uint64, v6)
-		for i := 0; i < v6; i++ {
+		vAlue6 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue6)
+		for i := 0; i < vAlue6; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
-		this.Field7 = make([]int32, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -664,9 +664,9 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
-		this.Field8 = make([]int64, v8)
-		for i := 0; i < v8; i++ {
+		vAlue8 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue8)
+		for i := 0; i < vAlue8; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -674,16 +674,16 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := r.Intn(10)
-		this.Field9 = make([]uint32, v9)
-		for i := 0; i < v9; i++ {
+		vAlue9 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue9)
+		for i := 0; i < vAlue9; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
-		this.Field10 = make([]int32, v10)
-		for i := 0; i < v10; i++ {
+		vAlue10 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue10)
+		for i := 0; i < vAlue10; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -691,16 +691,16 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
-		this.Field11 = make([]uint64, v11)
-		for i := 0; i < v11; i++ {
+		vAlue11 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue11)
+		for i := 0; i < vAlue11; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(10)
-		this.Field12 = make([]int64, v12)
-		for i := 0; i < v12; i++ {
+		vAlue12 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue12)
+		for i := 0; i < vAlue12; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -708,9 +708,9 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
-		this.Field13 = make([]bool, v13)
-		for i := 0; i < v13; i++ {
+		vAlue13 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue13)
+		for i := 0; i < vAlue13; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -723,9 +723,9 @@ func NewPopulatedNinRepNative(r randyPacked, easy bool) *NinRepNative {
 func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNative {
 	this := &NinRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(10)
-		this.Field1 = make([]float64, v14)
-		for i := 0; i < v14; i++ {
+		vAlue14 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue14)
+		for i := 0; i < vAlue14; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -733,9 +733,9 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v15 := r.Intn(10)
-		this.Field2 = make([]float32, v15)
-		for i := 0; i < v15; i++ {
+		vAlue15 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue15)
+		for i := 0; i < vAlue15; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -743,9 +743,9 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(10)
-		this.Field3 = make([]int32, v16)
-		for i := 0; i < v16; i++ {
+		vAlue16 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue16)
+		for i := 0; i < vAlue16; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -753,9 +753,9 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
-		this.Field4 = make([]int64, v17)
-		for i := 0; i < v17; i++ {
+		vAlue17 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue17)
+		for i := 0; i < vAlue17; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -763,23 +763,23 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
-		this.Field5 = make([]uint32, v18)
-		for i := 0; i < v18; i++ {
+		vAlue18 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue18)
+		for i := 0; i < vAlue18; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
-		this.Field6 = make([]uint64, v19)
-		for i := 0; i < v19; i++ {
+		vAlue19 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue19)
+		for i := 0; i < vAlue19; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
-		this.Field7 = make([]int32, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -787,9 +787,9 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
-		this.Field8 = make([]int64, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -797,16 +797,16 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
-		this.Field9 = make([]uint32, v22)
-		for i := 0; i < v22; i++ {
+		vAlue22 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue22)
+		for i := 0; i < vAlue22; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
-		this.Field10 = make([]int32, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -814,16 +814,16 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
-		this.Field11 = make([]uint64, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
-		this.Field12 = make([]int64, v25)
-		for i := 0; i < v25; i++ {
+		vAlue25 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue25)
+		for i := 0; i < vAlue25; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -831,9 +831,9 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
-		this.Field13 = make([]bool, v26)
-		for i := 0; i < v26; i++ {
+		vAlue26 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue26)
+		for i := 0; i < vAlue26; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -846,9 +846,9 @@ func NewPopulatedNinRepPackedNative(r randyPacked, easy bool) *NinRepPackedNativ
 func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsafe {
 	this := &NinRepNativeUnsafe{}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
-		this.Field1 = make([]float64, v27)
-		for i := 0; i < v27; i++ {
+		vAlue27 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue27)
+		for i := 0; i < vAlue27; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -856,9 +856,9 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
-		this.Field2 = make([]float32, v28)
-		for i := 0; i < v28; i++ {
+		vAlue28 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue28)
+		for i := 0; i < vAlue28; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -866,9 +866,9 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
-		this.Field3 = make([]int32, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -876,9 +876,9 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
-		this.Field4 = make([]int64, v30)
-		for i := 0; i < v30; i++ {
+		vAlue30 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue30)
+		for i := 0; i < vAlue30; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -886,23 +886,23 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
-		this.Field5 = make([]uint32, v31)
-		for i := 0; i < v31; i++ {
+		vAlue31 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue31)
+		for i := 0; i < vAlue31; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
-		this.Field6 = make([]uint64, v32)
-		for i := 0; i < v32; i++ {
+		vAlue32 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue32)
+		for i := 0; i < vAlue32; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
-		this.Field7 = make([]int32, v33)
-		for i := 0; i < v33; i++ {
+		vAlue33 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue33)
+		for i := 0; i < vAlue33; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -910,9 +910,9 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v34 := r.Intn(10)
-		this.Field8 = make([]int64, v34)
-		for i := 0; i < v34; i++ {
+		vAlue34 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue34)
+		for i := 0; i < vAlue34; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -920,16 +920,16 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
-		this.Field9 = make([]uint32, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
-		this.Field10 = make([]int32, v36)
-		for i := 0; i < v36; i++ {
+		vAlue36 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue36)
+		for i := 0; i < vAlue36; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -937,16 +937,16 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
-		this.Field11 = make([]uint64, v37)
-		for i := 0; i < v37; i++ {
+		vAlue37 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue37)
+		for i := 0; i < vAlue37; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
-		this.Field12 = make([]int64, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -954,9 +954,9 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
-		this.Field13 = make([]bool, v39)
-		for i := 0; i < v39; i++ {
+		vAlue39 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue39)
+		for i := 0; i < vAlue39; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -969,9 +969,9 @@ func NewPopulatedNinRepNativeUnsafe(r randyPacked, easy bool) *NinRepNativeUnsaf
 func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPackedNativeUnsafe {
 	this := &NinRepPackedNativeUnsafe{}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
-		this.Field1 = make([]float64, v40)
-		for i := 0; i < v40; i++ {
+		vAlue40 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue40)
+		for i := 0; i < vAlue40; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -979,9 +979,9 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
-		this.Field2 = make([]float32, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -989,9 +989,9 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
-		this.Field3 = make([]int32, v42)
-		for i := 0; i < v42; i++ {
+		vAlue42 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue42)
+		for i := 0; i < vAlue42; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -999,9 +999,9 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
-		this.Field4 = make([]int64, v43)
-		for i := 0; i < v43; i++ {
+		vAlue43 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue43)
+		for i := 0; i < vAlue43; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -1009,23 +1009,23 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
-		this.Field5 = make([]uint32, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
-		this.Field6 = make([]uint64, v45)
-		for i := 0; i < v45; i++ {
+		vAlue45 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue45)
+		for i := 0; i < vAlue45; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
-		this.Field7 = make([]int32, v46)
-		for i := 0; i < v46; i++ {
+		vAlue46 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue46)
+		for i := 0; i < vAlue46; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -1033,9 +1033,9 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
-		this.Field8 = make([]int64, v47)
-		for i := 0; i < v47; i++ {
+		vAlue47 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue47)
+		for i := 0; i < vAlue47; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -1043,16 +1043,16 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(10)
-		this.Field9 = make([]uint32, v48)
-		for i := 0; i < v48; i++ {
+		vAlue48 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue48)
+		for i := 0; i < vAlue48; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
-		this.Field10 = make([]int32, v49)
-		for i := 0; i < v49; i++ {
+		vAlue49 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue49)
+		for i := 0; i < vAlue49; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -1060,16 +1060,16 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
-		this.Field11 = make([]uint64, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
-		this.Field12 = make([]int64, v51)
-		for i := 0; i < v51; i++ {
+		vAlue51 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue51)
+		for i := 0; i < vAlue51; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -1077,9 +1077,9 @@ func NewPopulatedNinRepPackedNativeUnsafe(r randyPacked, easy bool) *NinRepPacke
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
-		this.Field13 = make([]bool, v52)
-		for i := 0; i < v52; i++ {
+		vAlue52 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue52)
+		for i := 0; i < vAlue52; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -1108,9 +1108,9 @@ func randUTF8RunePacked(r randyPacked) rune {
 	return rune(ru + 61)
 }
 func randStringPacked(r randyPacked) string {
-	v53 := r.Intn(100)
-	tmps := make([]rune, v53)
-	for i := 0; i < v53; i++ {
+	vAlue53 := r.Intn(100)
+	tmps := make([]rune, vAlue53)
+	for i := 0; i < vAlue53; i++ {
 		tmps[i] = randUTF8RunePacked(r)
 	}
 	return string(tmps)
@@ -1132,11 +1132,11 @@ func randFieldPacked(dAtA []byte, r randyPacked, fieldNumber int, wire int) []by
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulatePacked(dAtA, uint64(key))
-		v54 := r.Int63()
+		vAlue54 := r.Int63()
 		if r.Intn(2) == 0 {
-			v54 *= -1
+			vAlue54 *= -1
 		}
-		dAtA = encodeVarintPopulatePacked(dAtA, uint64(v54))
+		dAtA = encodeVarintPopulatePacked(dAtA, uint64(vAlue54))
 	case 1:
 		dAtA = encodeVarintPopulatePacked(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/protosize/protosize.pb.go
+++ b/test/protosize/protosize.pb.go
@@ -245,26 +245,26 @@ func encodeVarintProtosize(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedSizeMessage(r randyProtosize, easy bool) *SizeMessage {
 	this := &SizeMessage{}
 	if r.Intn(5) != 0 {
-		v1 := int64(r.Int63())
+		vAlue1 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Size = &v1
+		this.Size = &vAlue1
 	}
 	if r.Intn(5) != 0 {
-		v2 := int64(r.Int63())
+		vAlue2 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.ProtoSize_ = &v2
+		this.ProtoSize_ = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := bool(bool(r.Intn(2) == 0))
-		this.Equal_ = &v3
+		vAlue3 := bool(bool(r.Intn(2) == 0))
+		this.Equal_ = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := string(randStringProtosize(r))
-		this.String_ = &v4
+		vAlue4 := string(randStringProtosize(r))
+		this.String_ = &vAlue4
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedProtosize(r, 5)
@@ -291,9 +291,9 @@ func randUTF8RuneProtosize(r randyProtosize) rune {
 	return rune(ru + 61)
 }
 func randStringProtosize(r randyProtosize) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneProtosize(r)
 	}
 	return string(tmps)
@@ -315,11 +315,11 @@ func randFieldProtosize(dAtA []byte, r randyProtosize, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateProtosize(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateProtosize(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateProtosize(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateProtosize(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/required/requiredexample.pb.go
+++ b/test/required/requiredexample.pb.go
@@ -838,16 +838,16 @@ func encodeVarintRequiredexample(dAtA []byte, offset int, v uint64) int {
 }
 func NewPopulatedRequiredExample(r randyRequiredexample, easy bool) *RequiredExample {
 	this := &RequiredExample{}
-	v1 := string(randStringRequiredexample(r))
-	this.TheRequiredString = &v1
+	vAlue1 := string(randStringRequiredexample(r))
+	this.TheRequiredString = &vAlue1
 	if r.Intn(5) != 0 {
-		v2 := string(randStringRequiredexample(r))
-		this.TheOptionalString = &v2
+		vAlue2 := string(randStringRequiredexample(r))
+		this.TheOptionalString = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
-		this.TheRepeatedStrings = make([]string, v3)
-		for i := 0; i < v3; i++ {
+		vAlue3 := r.Intn(10)
+		this.TheRepeatedStrings = make([]string, vAlue3)
+		for i := 0; i < vAlue3; i++ {
 			this.TheRepeatedStrings[i] = string(randStringRequiredexample(r))
 		}
 	}
@@ -897,9 +897,9 @@ func NewPopulatedNidOptNative(r randyRequiredexample, easy bool) *NidOptNative {
 	}
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringRequiredexample(r))
-	v4 := r.Intn(100)
-	this.Field15 = make([]byte, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -910,61 +910,61 @@ func NewPopulatedNidOptNative(r randyRequiredexample, easy bool) *NidOptNative {
 
 func NewPopulatedNinOptNative(r randyRequiredexample, easy bool) *NinOptNative {
 	this := &NinOptNative{}
-	v5 := float64(r.Float64())
+	vAlue5 := float64(r.Float64())
 	if r.Intn(2) == 0 {
-		v5 *= -1
+		vAlue5 *= -1
 	}
-	this.Field1 = &v5
-	v6 := float32(r.Float32())
+	this.Field1 = &vAlue5
+	vAlue6 := float32(r.Float32())
 	if r.Intn(2) == 0 {
-		v6 *= -1
+		vAlue6 *= -1
 	}
-	this.Field2 = &v6
-	v7 := int32(r.Int31())
+	this.Field2 = &vAlue6
+	vAlue7 := int32(r.Int31())
 	if r.Intn(2) == 0 {
-		v7 *= -1
+		vAlue7 *= -1
 	}
-	this.Field3 = &v7
-	v8 := int64(r.Int63())
+	this.Field3 = &vAlue7
+	vAlue8 := int64(r.Int63())
 	if r.Intn(2) == 0 {
-		v8 *= -1
+		vAlue8 *= -1
 	}
-	this.Field4 = &v8
-	v9 := uint32(r.Uint32())
-	this.Field5 = &v9
-	v10 := uint64(uint64(r.Uint32()))
-	this.Field6 = &v10
-	v11 := int32(r.Int31())
+	this.Field4 = &vAlue8
+	vAlue9 := uint32(r.Uint32())
+	this.Field5 = &vAlue9
+	vAlue10 := uint64(uint64(r.Uint32()))
+	this.Field6 = &vAlue10
+	vAlue11 := int32(r.Int31())
 	if r.Intn(2) == 0 {
-		v11 *= -1
+		vAlue11 *= -1
 	}
-	this.Field7 = &v11
-	v12 := int64(r.Int63())
+	this.Field7 = &vAlue11
+	vAlue12 := int64(r.Int63())
 	if r.Intn(2) == 0 {
-		v12 *= -1
+		vAlue12 *= -1
 	}
-	this.Field8 = &v12
-	v13 := uint32(r.Uint32())
-	this.Field9 = &v13
-	v14 := int32(r.Int31())
+	this.Field8 = &vAlue12
+	vAlue13 := uint32(r.Uint32())
+	this.Field9 = &vAlue13
+	vAlue14 := int32(r.Int31())
 	if r.Intn(2) == 0 {
-		v14 *= -1
+		vAlue14 *= -1
 	}
-	this.Field10 = &v14
-	v15 := uint64(uint64(r.Uint32()))
-	this.Field11 = &v15
-	v16 := int64(r.Int63())
+	this.Field10 = &vAlue14
+	vAlue15 := uint64(uint64(r.Uint32()))
+	this.Field11 = &vAlue15
+	vAlue16 := int64(r.Int63())
 	if r.Intn(2) == 0 {
-		v16 *= -1
+		vAlue16 *= -1
 	}
-	this.Field12 = &v16
-	v17 := bool(bool(r.Intn(2) == 0))
-	this.Field13 = &v17
-	v18 := string(randStringRequiredexample(r))
-	this.Field14 = &v18
-	v19 := r.Intn(100)
-	this.Field15 = make([]byte, v19)
-	for i := 0; i < v19; i++ {
+	this.Field12 = &vAlue16
+	vAlue17 := bool(bool(r.Intn(2) == 0))
+	this.Field13 = &vAlue17
+	vAlue18 := string(randStringRequiredexample(r))
+	this.Field14 = &vAlue18
+	vAlue19 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue19)
+	for i := 0; i < vAlue19; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -976,9 +976,9 @@ func NewPopulatedNinOptNative(r randyRequiredexample, easy bool) *NinOptNative {
 func NewPopulatedNestedNinOptNative(r randyRequiredexample, easy bool) *NestedNinOptNative {
 	this := &NestedNinOptNative{}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(5)
-		this.NestedNinOpts = make([]*NinOptNative, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(5)
+		this.NestedNinOpts = make([]*NinOptNative, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.NestedNinOpts[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
@@ -1007,9 +1007,9 @@ func randUTF8RuneRequiredexample(r randyRequiredexample) rune {
 	return rune(ru + 61)
 }
 func randStringRequiredexample(r randyRequiredexample) string {
-	v21 := r.Intn(100)
-	tmps := make([]rune, v21)
-	for i := 0; i < v21; i++ {
+	vAlue21 := r.Intn(100)
+	tmps := make([]rune, vAlue21)
+	for i := 0; i < vAlue21; i++ {
 		tmps[i] = randUTF8RuneRequiredexample(r)
 	}
 	return string(tmps)
@@ -1031,11 +1031,11 @@ func randFieldRequiredexample(dAtA []byte, r randyRequiredexample, fieldNumber i
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateRequiredexample(dAtA, uint64(key))
-		v22 := r.Int63()
+		vAlue22 := r.Int63()
 		if r.Intn(2) == 0 {
-			v22 *= -1
+			vAlue22 *= -1
 		}
-		dAtA = encodeVarintPopulateRequiredexample(dAtA, uint64(v22))
+		dAtA = encodeVarintPopulateRequiredexample(dAtA, uint64(vAlue22))
 	case 1:
 		dAtA = encodeVarintPopulateRequiredexample(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/sizeunderscore/sizeunderscore.pb.go
+++ b/test/sizeunderscore/sizeunderscore.pb.go
@@ -222,19 +222,19 @@ func encodeVarintSizeunderscore(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedSizeMessage(r randySizeunderscore, easy bool) *SizeMessage {
 	this := &SizeMessage{}
 	if r.Intn(5) != 0 {
-		v1 := int64(r.Int63())
+		vAlue1 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Size_ = &v1
+		this.Size_ = &vAlue1
 	}
 	if r.Intn(5) != 0 {
-		v2 := bool(bool(r.Intn(2) == 0))
-		this.Equal_ = &v2
+		vAlue2 := bool(bool(r.Intn(2) == 0))
+		this.Equal_ = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := string(randStringSizeunderscore(r))
-		this.String_ = &v3
+		vAlue3 := string(randStringSizeunderscore(r))
+		this.String_ = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedSizeunderscore(r, 4)
@@ -261,9 +261,9 @@ func randUTF8RuneSizeunderscore(r randySizeunderscore) rune {
 	return rune(ru + 61)
 }
 func randStringSizeunderscore(r randySizeunderscore) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneSizeunderscore(r)
 	}
 	return string(tmps)
@@ -285,11 +285,11 @@ func randFieldSizeunderscore(dAtA []byte, r randySizeunderscore, fieldNumber int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateSizeunderscore(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateSizeunderscore(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateSizeunderscore(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateSizeunderscore(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/stdtypes/stdtypes.pb.go
+++ b/test/stdtypes/stdtypes.pb.go
@@ -3435,55 +3435,55 @@ func NewPopulatedStdTypes(r randyStdtypes, easy bool) *StdTypes {
 	if r.Intn(5) != 0 {
 		this.NullableDuration = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 	}
-	v1 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-	this.Timestamp = *v1
-	v2 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-	this.Duration = *v2
+	vAlue1 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+	this.Timestamp = *vAlue1
+	vAlue2 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+	this.Duration = *vAlue2
 	if r.Intn(5) != 0 {
 		this.NullableDouble = github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
 	}
-	v3 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-	this.NonnullDouble = *v3
+	vAlue3 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+	this.NonnullDouble = *vAlue3
 	if r.Intn(5) != 0 {
 		this.NullableFloat = github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
 	}
-	v4 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-	this.NonnullFloat = *v4
+	vAlue4 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+	this.NonnullFloat = *vAlue4
 	if r.Intn(5) != 0 {
 		this.NullableInt64 = github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
 	}
-	v5 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-	this.NonnullInt64 = *v5
+	vAlue5 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+	this.NonnullInt64 = *vAlue5
 	if r.Intn(5) != 0 {
 		this.NullableUInt64 = github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
 	}
-	v6 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-	this.NonnullUInt64 = *v6
+	vAlue6 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+	this.NonnullUInt64 = *vAlue6
 	if r.Intn(5) != 0 {
 		this.NullableInt32 = github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
 	}
-	v7 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-	this.NonnullInt32 = *v7
+	vAlue7 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+	this.NonnullInt32 = *vAlue7
 	if r.Intn(5) != 0 {
 		this.NullableUInt32 = github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
 	}
-	v8 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-	this.NonnullUInt32 = *v8
+	vAlue8 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+	this.NonnullUInt32 = *vAlue8
 	if r.Intn(5) != 0 {
 		this.NullableBool = github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
 	}
-	v9 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-	this.NonnullBool = *v9
+	vAlue9 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+	this.NonnullBool = *vAlue9
 	if r.Intn(5) != 0 {
 		this.NullableString = github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
 	}
-	v10 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-	this.NonnullString = *v10
+	vAlue10 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+	this.NonnullString = *vAlue10
 	if r.Intn(5) != 0 {
 		this.NullableBytes = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 	}
-	v11 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-	this.NonnullBytes = *v11
+	vAlue11 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+	this.NonnullBytes = *vAlue11
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedStdtypes(r, 23)
 	}
@@ -3493,168 +3493,168 @@ func NewPopulatedStdTypes(r randyStdtypes, easy bool) *StdTypes {
 func NewPopulatedRepStdTypes(r randyStdtypes, easy bool) *RepStdTypes {
 	this := &RepStdTypes{}
 	if r.Intn(5) != 0 {
-		v12 := r.Intn(5)
-		this.NullableTimestamps = make([]*time.Time, v12)
-		for i := 0; i < v12; i++ {
+		vAlue12 := r.Intn(5)
+		this.NullableTimestamps = make([]*time.Time, vAlue12)
+		for i := 0; i < vAlue12; i++ {
 			this.NullableTimestamps[i] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(5)
-		this.NullableDurations = make([]*time.Duration, v13)
-		for i := 0; i < v13; i++ {
+		vAlue13 := r.Intn(5)
+		this.NullableDurations = make([]*time.Duration, vAlue13)
+		for i := 0; i < vAlue13; i++ {
 			this.NullableDurations[i] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := r.Intn(5)
-		this.Timestamps = make([]time.Time, v14)
-		for i := 0; i < v14; i++ {
-			v15 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-			this.Timestamps[i] = *v15
+		vAlue14 := r.Intn(5)
+		this.Timestamps = make([]time.Time, vAlue14)
+		for i := 0; i < vAlue14; i++ {
+			vAlue15 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+			this.Timestamps[i] = *vAlue15
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(5)
-		this.Durations = make([]time.Duration, v16)
-		for i := 0; i < v16; i++ {
-			v17 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-			this.Durations[i] = *v17
+		vAlue16 := r.Intn(5)
+		this.Durations = make([]time.Duration, vAlue16)
+		for i := 0; i < vAlue16; i++ {
+			vAlue17 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+			this.Durations[i] = *vAlue17
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(5)
-		this.NullableDouble = make([]*float64, v18)
-		for i := 0; i < v18; i++ {
+		vAlue18 := r.Intn(5)
+		this.NullableDouble = make([]*float64, vAlue18)
+		for i := 0; i < vAlue18; i++ {
 			this.NullableDouble[i] = github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(5)
-		this.NonnullDouble = make([]float64, v19)
-		for i := 0; i < v19; i++ {
-			v20 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-			this.NonnullDouble[i] = *v20
+		vAlue19 := r.Intn(5)
+		this.NonnullDouble = make([]float64, vAlue19)
+		for i := 0; i < vAlue19; i++ {
+			vAlue20 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+			this.NonnullDouble[i] = *vAlue20
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(5)
-		this.NullableFloat = make([]*float32, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(5)
+		this.NullableFloat = make([]*float32, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.NullableFloat[i] = github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(5)
-		this.NonnullFloat = make([]float32, v22)
-		for i := 0; i < v22; i++ {
-			v23 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-			this.NonnullFloat[i] = *v23
+		vAlue22 := r.Intn(5)
+		this.NonnullFloat = make([]float32, vAlue22)
+		for i := 0; i < vAlue22; i++ {
+			vAlue23 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+			this.NonnullFloat[i] = *vAlue23
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(5)
-		this.NullableInt64 = make([]*int64, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(5)
+		this.NullableInt64 = make([]*int64, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.NullableInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(5)
-		this.NonnullInt64 = make([]int64, v25)
-		for i := 0; i < v25; i++ {
-			v26 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-			this.NonnullInt64[i] = *v26
+		vAlue25 := r.Intn(5)
+		this.NonnullInt64 = make([]int64, vAlue25)
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+			this.NonnullInt64[i] = *vAlue26
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(5)
-		this.NullableUInt64 = make([]*uint64, v27)
-		for i := 0; i < v27; i++ {
+		vAlue27 := r.Intn(5)
+		this.NullableUInt64 = make([]*uint64, vAlue27)
+		for i := 0; i < vAlue27; i++ {
 			this.NullableUInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(5)
-		this.NonnullUInt64 = make([]uint64, v28)
-		for i := 0; i < v28; i++ {
-			v29 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-			this.NonnullUInt64[i] = *v29
+		vAlue28 := r.Intn(5)
+		this.NonnullUInt64 = make([]uint64, vAlue28)
+		for i := 0; i < vAlue28; i++ {
+			vAlue29 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+			this.NonnullUInt64[i] = *vAlue29
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(5)
-		this.NullableInt32 = make([]*int32, v30)
-		for i := 0; i < v30; i++ {
+		vAlue30 := r.Intn(5)
+		this.NullableInt32 = make([]*int32, vAlue30)
+		for i := 0; i < vAlue30; i++ {
 			this.NullableInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(5)
-		this.NonnullInt32 = make([]int32, v31)
-		for i := 0; i < v31; i++ {
-			v32 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-			this.NonnullInt32[i] = *v32
+		vAlue31 := r.Intn(5)
+		this.NonnullInt32 = make([]int32, vAlue31)
+		for i := 0; i < vAlue31; i++ {
+			vAlue32 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+			this.NonnullInt32[i] = *vAlue32
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(5)
-		this.NullableUInt32 = make([]*uint32, v33)
-		for i := 0; i < v33; i++ {
+		vAlue33 := r.Intn(5)
+		this.NullableUInt32 = make([]*uint32, vAlue33)
+		for i := 0; i < vAlue33; i++ {
 			this.NullableUInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v34 := r.Intn(5)
-		this.NonnullUInt32 = make([]uint32, v34)
-		for i := 0; i < v34; i++ {
-			v35 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-			this.NonnullUInt32[i] = *v35
+		vAlue34 := r.Intn(5)
+		this.NonnullUInt32 = make([]uint32, vAlue34)
+		for i := 0; i < vAlue34; i++ {
+			vAlue35 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+			this.NonnullUInt32[i] = *vAlue35
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(5)
-		this.NullableBool = make([]*bool, v36)
-		for i := 0; i < v36; i++ {
+		vAlue36 := r.Intn(5)
+		this.NullableBool = make([]*bool, vAlue36)
+		for i := 0; i < vAlue36; i++ {
 			this.NullableBool[i] = github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(5)
-		this.NonnullBool = make([]bool, v37)
-		for i := 0; i < v37; i++ {
-			v38 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-			this.NonnullBool[i] = *v38
+		vAlue37 := r.Intn(5)
+		this.NonnullBool = make([]bool, vAlue37)
+		for i := 0; i < vAlue37; i++ {
+			vAlue38 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+			this.NonnullBool[i] = *vAlue38
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(5)
-		this.NullableString = make([]*string, v39)
-		for i := 0; i < v39; i++ {
+		vAlue39 := r.Intn(5)
+		this.NullableString = make([]*string, vAlue39)
+		for i := 0; i < vAlue39; i++ {
 			this.NullableString[i] = github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(5)
-		this.NonnullString = make([]string, v40)
-		for i := 0; i < v40; i++ {
-			v41 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-			this.NonnullString[i] = *v41
+		vAlue40 := r.Intn(5)
+		this.NonnullString = make([]string, vAlue40)
+		for i := 0; i < vAlue40; i++ {
+			vAlue41 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+			this.NonnullString[i] = *vAlue41
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(5)
-		this.NullableBytes = make([]*[]byte, v42)
-		for i := 0; i < v42; i++ {
+		vAlue42 := r.Intn(5)
+		this.NullableBytes = make([]*[]byte, vAlue42)
+		for i := 0; i < vAlue42; i++ {
 			this.NullableBytes[i] = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(5)
-		this.NonnullBytes = make([][]byte, v43)
-		for i := 0; i < v43; i++ {
-			v44 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-			this.NonnullBytes[i] = *v44
+		vAlue43 := r.Intn(5)
+		this.NonnullBytes = make([][]byte, vAlue43)
+		for i := 0; i < vAlue43; i++ {
+			vAlue44 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+			this.NonnullBytes[i] = *vAlue44
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -3666,156 +3666,156 @@ func NewPopulatedRepStdTypes(r randyStdtypes, easy bool) *RepStdTypes {
 func NewPopulatedMapStdTypes(r randyStdtypes, easy bool) *MapStdTypes {
 	this := &MapStdTypes{}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
+		vAlue45 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*time.Time)
-		for i := 0; i < v45; i++ {
+		for i := 0; i < vAlue45; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
+		vAlue46 := r.Intn(10)
 		this.Timestamp = make(map[int32]time.Time)
-		for i := 0; i < v46; i++ {
+		for i := 0; i < vAlue46; i++ {
 			this.Timestamp[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
+		vAlue47 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*time.Duration)
-		for i := 0; i < v47; i++ {
+		for i := 0; i < vAlue47; i++ {
 			this.NullableDuration[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(10)
+		vAlue48 := r.Intn(10)
 		this.Duration = make(map[int32]time.Duration)
-		for i := 0; i < v48; i++ {
+		for i := 0; i < vAlue48; i++ {
 			this.Duration[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
+		vAlue49 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*float64)
-		for i := 0; i < v49; i++ {
+		for i := 0; i < vAlue49; i++ {
 			this.NullableDouble[int32(r.Int31())] = (*float64)(github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
+		vAlue50 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]float64)
-		for i := 0; i < v50; i++ {
+		for i := 0; i < vAlue50; i++ {
 			this.NonnullDouble[int32(r.Int31())] = (float64)(*github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
+		vAlue51 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*float32)
-		for i := 0; i < v51; i++ {
+		for i := 0; i < vAlue51; i++ {
 			this.NullableFloat[int32(r.Int31())] = (*float32)(github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
+		vAlue52 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]float32)
-		for i := 0; i < v52; i++ {
+		for i := 0; i < vAlue52; i++ {
 			this.NonnullFloat[int32(r.Int31())] = (float32)(*github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
+		vAlue53 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*int64)
-		for i := 0; i < v53; i++ {
+		for i := 0; i < vAlue53; i++ {
 			this.NullableInt64[int32(r.Int31())] = (*int64)(github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
+		vAlue54 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]int64)
-		for i := 0; i < v54; i++ {
+		for i := 0; i < vAlue54; i++ {
 			this.NonnullInt64[int32(r.Int31())] = (int64)(*github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
+		vAlue55 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*uint64)
-		for i := 0; i < v55; i++ {
+		for i := 0; i < vAlue55; i++ {
 			this.NullableUInt64[int32(r.Int31())] = (*uint64)(github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
+		vAlue56 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]uint64)
-		for i := 0; i < v56; i++ {
+		for i := 0; i < vAlue56; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = (uint64)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
+		vAlue57 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*int32)
-		for i := 0; i < v57; i++ {
+		for i := 0; i < vAlue57; i++ {
 			this.NullableInt32[int32(r.Int31())] = (*int32)(github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
+		vAlue58 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]int32)
-		for i := 0; i < v58; i++ {
+		for i := 0; i < vAlue58; i++ {
 			this.NonnullInt32[int32(r.Int31())] = (int32)(*github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
+		vAlue59 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*uint32)
-		for i := 0; i < v59; i++ {
+		for i := 0; i < vAlue59; i++ {
 			this.NullableUInt32[int32(r.Int31())] = (*uint32)(github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
+		vAlue60 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]uint32)
-		for i := 0; i < v60; i++ {
+		for i := 0; i < vAlue60; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = (uint32)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
+		vAlue61 := r.Intn(10)
 		this.NullableBool = make(map[int32]*bool)
-		for i := 0; i < v61; i++ {
+		for i := 0; i < vAlue61; i++ {
 			this.NullableBool[int32(r.Int31())] = (*bool)(github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
+		vAlue62 := r.Intn(10)
 		this.NonnullBool = make(map[int32]bool)
-		for i := 0; i < v62; i++ {
+		for i := 0; i < vAlue62; i++ {
 			this.NonnullBool[int32(r.Int31())] = (bool)(*github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
+		vAlue63 := r.Intn(10)
 		this.NullableString = make(map[int32]*string)
-		for i := 0; i < v63; i++ {
+		for i := 0; i < vAlue63; i++ {
 			this.NullableString[int32(r.Int31())] = (*string)(github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.NonnullString = make(map[int32]string)
-		for i := 0; i < v64; i++ {
+		for i := 0; i < vAlue64; i++ {
 			this.NonnullString[int32(r.Int31())] = (string)(*github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
+		vAlue65 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*[]byte)
-		for i := 0; i < v65; i++ {
+		for i := 0; i < vAlue65; i++ {
 			this.NullableBytes[int32(r.Int31())] = (*[]byte)(github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(10)
+		vAlue66 := r.Intn(10)
 		this.NonnullBytes = make(map[int32][]byte)
-		for i := 0; i < v66; i++ {
+		for i := 0; i < vAlue66; i++ {
 			this.NonnullBytes[int32(r.Int31())] = ([]byte)(*github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
@@ -3933,9 +3933,9 @@ func randUTF8RuneStdtypes(r randyStdtypes) rune {
 	return rune(ru + 61)
 }
 func randStringStdtypes(r randyStdtypes) string {
-	v67 := r.Intn(100)
-	tmps := make([]rune, v67)
-	for i := 0; i < v67; i++ {
+	vAlue67 := r.Intn(100)
+	tmps := make([]rune, vAlue67)
+	for i := 0; i < vAlue67; i++ {
 		tmps[i] = randUTF8RuneStdtypes(r)
 	}
 	return string(tmps)
@@ -3957,11 +3957,11 @@ func randFieldStdtypes(dAtA []byte, r randyStdtypes, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateStdtypes(dAtA, uint64(key))
-		v68 := r.Int63()
+		vAlue68 := r.Int63()
 		if r.Intn(2) == 0 {
-			v68 *= -1
+			vAlue68 *= -1
 		}
-		dAtA = encodeVarintPopulateStdtypes(dAtA, uint64(v68))
+		dAtA = encodeVarintPopulateStdtypes(dAtA, uint64(vAlue68))
 	case 1:
 		dAtA = encodeVarintPopulateStdtypes(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/tags/tags.pb.go
+++ b/test/tags/tags.pb.go
@@ -164,8 +164,8 @@ func NewPopulatedOutside(r randyTags, easy bool) *Outside {
 		this.Inside = NewPopulatedInside(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v1 := string(randStringTags(r))
-		this.Field2 = &v1
+		vAlue1 := string(randStringTags(r))
+		this.Field2 = &vAlue1
 	}
 	oneofNumber_Filed := []int32{3}[r.Intn(1)]
 	switch oneofNumber_Filed {
@@ -186,8 +186,8 @@ func NewPopulatedOutside_Field3(r randyTags, easy bool) *Outside_Field3 {
 func NewPopulatedInside(r randyTags, easy bool) *Inside {
 	this := &Inside{}
 	if r.Intn(5) != 0 {
-		v2 := string(randStringTags(r))
-		this.Field1 = &v2
+		vAlue2 := string(randStringTags(r))
+		this.Field1 = &vAlue2
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTags(r, 2)
@@ -214,9 +214,9 @@ func randUTF8RuneTags(r randyTags) rune {
 	return rune(ru + 61)
 }
 func randStringTags(r randyTags) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneTags(r)
 	}
 	return string(tmps)
@@ -238,11 +238,11 @@ func randFieldTags(dAtA []byte, r randyTags, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTags(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateTags(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateTags(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateTags(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -4957,14 +4957,14 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 	this.Name = string(randStringTheproto3(r))
 	this.Hilarity = Message_Humour([]int32{0, 1, 2, 3}[r.Intn(4)])
 	this.HeightInCm = uint32(r.Uint32())
-	v1 := r.Intn(100)
-	this.Data = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Data = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
-	v2 := r.Intn(10)
-	this.Key = make([]uint64, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(10)
+	this.Key = make([]uint64, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if r.Intn(5) != 0 {
@@ -4980,9 +4980,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 		this.Score *= -1
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Terrain = make(map[int64]*Nested)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Terrain[int64(r.Int63())] = NewPopulatedNested(r, easy)
 		}
 	}
@@ -4990,9 +4990,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 		this.Proto2Field = both.NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.Proto2Value = make(map[int64]*both.NinOptEnum)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.Proto2Value[int64(r.Int63())] = both.NewPopulatedNinOptEnum(r, easy)
 		}
 	}
@@ -5014,163 +5014,163 @@ func NewPopulatedNested(r randyTheproto3, easy bool) *Nested {
 func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v5; i++ {
-			v6 := randStringTheproto3(r)
-			this.StringToDoubleMap[v6] = float64(r.Float64())
+		for i := 0; i < vAlue5; i++ {
+			vAlue6 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue6] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v6] *= -1
+				this.StringToDoubleMap[vAlue6] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
+		vAlue7 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v7; i++ {
-			v8 := randStringTheproto3(r)
-			this.StringToFloatMap[v8] = float32(r.Float32())
+		for i := 0; i < vAlue7; i++ {
+			vAlue8 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue8] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v8] *= -1
+				this.StringToFloatMap[vAlue8] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := r.Intn(10)
+		vAlue9 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v9; i++ {
-			v10 := int32(r.Int31())
-			this.Int32Map[v10] = int32(r.Int31())
+		for i := 0; i < vAlue9; i++ {
+			vAlue10 := int32(r.Int31())
+			this.Int32Map[vAlue10] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v10] *= -1
+				this.Int32Map[vAlue10] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
+		vAlue11 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v11; i++ {
-			v12 := int64(r.Int63())
-			this.Int64Map[v12] = int64(r.Int63())
+		for i := 0; i < vAlue11; i++ {
+			vAlue12 := int64(r.Int63())
+			this.Int64Map[vAlue12] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v12] *= -1
+				this.Int64Map[vAlue12] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v13; i++ {
-			v14 := uint32(r.Uint32())
-			this.Uint32Map[v14] = uint32(r.Uint32())
+		for i := 0; i < vAlue13; i++ {
+			vAlue14 := uint32(r.Uint32())
+			this.Uint32Map[vAlue14] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v15 := r.Intn(10)
+		vAlue15 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v15; i++ {
-			v16 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v16] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue15; i++ {
+			vAlue16 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue16] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
+		vAlue17 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v17; i++ {
-			v18 := int32(r.Int31())
-			this.Sint32Map[v18] = int32(r.Int31())
+		for i := 0; i < vAlue17; i++ {
+			vAlue18 := int32(r.Int31())
+			this.Sint32Map[vAlue18] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v18] *= -1
+				this.Sint32Map[vAlue18] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
+		vAlue19 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v19; i++ {
-			v20 := int64(r.Int63())
-			this.Sint64Map[v20] = int64(r.Int63())
+		for i := 0; i < vAlue19; i++ {
+			vAlue20 := int64(r.Int63())
+			this.Sint64Map[vAlue20] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v20] *= -1
+				this.Sint64Map[vAlue20] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
+		vAlue21 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v21; i++ {
-			v22 := uint32(r.Uint32())
-			this.Fixed32Map[v22] = uint32(r.Uint32())
+		for i := 0; i < vAlue21; i++ {
+			vAlue22 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue22] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
+		vAlue23 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v23; i++ {
-			v24 := int32(r.Int31())
-			this.Sfixed32Map[v24] = int32(r.Int31())
+		for i := 0; i < vAlue23; i++ {
+			vAlue24 := int32(r.Int31())
+			this.Sfixed32Map[vAlue24] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v24] *= -1
+				this.Sfixed32Map[vAlue24] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
+		vAlue25 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v25; i++ {
-			v26 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v26] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue26] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
+		vAlue27 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v27; i++ {
-			v28 := int64(r.Int63())
-			this.Sfixed64Map[v28] = int64(r.Int63())
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := int64(r.Int63())
+			this.Sfixed64Map[vAlue28] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v28] *= -1
+				this.Sfixed64Map[vAlue28] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
+		vAlue29 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v29; i++ {
-			v30 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v30] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue29; i++ {
+			vAlue30 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue30] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
+		vAlue31 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v31; i++ {
+		for i := 0; i < vAlue31; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v32; i++ {
-			v33 := r.Intn(100)
-			v34 := randStringTheproto3(r)
-			this.StringToBytesMap[v34] = make([]byte, v33)
-			for i := 0; i < v33; i++ {
-				this.StringToBytesMap[v34][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue32; i++ {
+			vAlue33 := r.Intn(100)
+			vAlue34 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue34] = make([]byte, vAlue33)
+			for i := 0; i < vAlue33; i++ {
+				this.StringToBytesMap[vAlue34][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
+		vAlue35 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v35; i++ {
+		for i := 0; i < vAlue35; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -5183,163 +5183,163 @@ func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v37; i++ {
-			v38 := randStringTheproto3(r)
-			this.StringToDoubleMap[v38] = float64(r.Float64())
+		for i := 0; i < vAlue37; i++ {
+			vAlue38 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue38] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v38] *= -1
+				this.StringToDoubleMap[vAlue38] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
+		vAlue39 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v39; i++ {
-			v40 := randStringTheproto3(r)
-			this.StringToFloatMap[v40] = float32(r.Float32())
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue40] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v40] *= -1
+				this.StringToFloatMap[vAlue40] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
+		vAlue41 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v41; i++ {
-			v42 := int32(r.Int31())
-			this.Int32Map[v42] = int32(r.Int31())
+		for i := 0; i < vAlue41; i++ {
+			vAlue42 := int32(r.Int31())
+			this.Int32Map[vAlue42] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v42] *= -1
+				this.Int32Map[vAlue42] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
+		vAlue43 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v43; i++ {
-			v44 := int64(r.Int63())
-			this.Int64Map[v44] = int64(r.Int63())
+		for i := 0; i < vAlue43; i++ {
+			vAlue44 := int64(r.Int63())
+			this.Int64Map[vAlue44] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v44] *= -1
+				this.Int64Map[vAlue44] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
+		vAlue45 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v45; i++ {
-			v46 := uint32(r.Uint32())
-			this.Uint32Map[v46] = uint32(r.Uint32())
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := uint32(r.Uint32())
+			this.Uint32Map[vAlue46] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
+		vAlue47 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v47; i++ {
-			v48 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v48] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue48] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
+		vAlue49 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v49; i++ {
-			v50 := int32(r.Int31())
-			this.Sint32Map[v50] = int32(r.Int31())
+		for i := 0; i < vAlue49; i++ {
+			vAlue50 := int32(r.Int31())
+			this.Sint32Map[vAlue50] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v50] *= -1
+				this.Sint32Map[vAlue50] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
+		vAlue51 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v51; i++ {
-			v52 := int64(r.Int63())
-			this.Sint64Map[v52] = int64(r.Int63())
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := int64(r.Int63())
+			this.Sint64Map[vAlue52] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v52] *= -1
+				this.Sint64Map[vAlue52] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
+		vAlue53 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v53; i++ {
-			v54 := uint32(r.Uint32())
-			this.Fixed32Map[v54] = uint32(r.Uint32())
+		for i := 0; i < vAlue53; i++ {
+			vAlue54 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue54] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
+		vAlue55 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v55; i++ {
-			v56 := int32(r.Int31())
-			this.Sfixed32Map[v56] = int32(r.Int31())
+		for i := 0; i < vAlue55; i++ {
+			vAlue56 := int32(r.Int31())
+			this.Sfixed32Map[vAlue56] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v56] *= -1
+				this.Sfixed32Map[vAlue56] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
+		vAlue57 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v57; i++ {
-			v58 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v58] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue57; i++ {
+			vAlue58 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue58] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
+		vAlue59 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v59; i++ {
-			v60 := int64(r.Int63())
-			this.Sfixed64Map[v60] = int64(r.Int63())
+		for i := 0; i < vAlue59; i++ {
+			vAlue60 := int64(r.Int63())
+			this.Sfixed64Map[vAlue60] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v60] *= -1
+				this.Sfixed64Map[vAlue60] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
+		vAlue61 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v61; i++ {
-			v62 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v62] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue61; i++ {
+			vAlue62 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue62] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
+		vAlue63 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v63; i++ {
+		for i := 0; i < vAlue63; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v64; i++ {
-			v65 := r.Intn(100)
-			v66 := randStringTheproto3(r)
-			this.StringToBytesMap[v66] = make([]byte, v65)
-			for i := 0; i < v65; i++ {
-				this.StringToBytesMap[v66][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue64; i++ {
+			vAlue65 := r.Intn(100)
+			vAlue66 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue66] = make([]byte, vAlue65)
+			for i := 0; i < vAlue65; i++ {
+				this.StringToBytesMap[vAlue66][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
+		vAlue67 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v67; i++ {
+		for i := 0; i < vAlue67; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -5352,28 +5352,28 @@ func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 func NewPopulatedMessageWithMap(r randyTheproto3, easy bool) *MessageWithMap {
 	this := &MessageWithMap{}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.NameMapping = make(map[int32]string)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.NameMapping[int32(r.Int31())] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
+		vAlue70 := r.Intn(10)
 		this.MsgMapping = make(map[int64]*FloatingPoint)
-		for i := 0; i < v70; i++ {
+		for i := 0; i < vAlue70; i++ {
 			this.MsgMapping[int64(r.Int63())] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
+		vAlue71 := r.Intn(10)
 		this.ByteMapping = make(map[bool][]byte)
-		for i := 0; i < v71; i++ {
-			v72 := r.Intn(100)
-			v73 := bool(bool(r.Intn(2) == 0))
-			this.ByteMapping[v73] = make([]byte, v72)
-			for i := 0; i < v72; i++ {
-				this.ByteMapping[v73][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue71; i++ {
+			vAlue72 := r.Intn(100)
+			vAlue73 := bool(bool(r.Intn(2) == 0))
+			this.ByteMapping[vAlue73] = make([]byte, vAlue72)
+			for i := 0; i < vAlue72; i++ {
+				this.ByteMapping[vAlue73][i] = byte(r.Intn(256))
 			}
 		}
 	}
@@ -5397,8 +5397,8 @@ func NewPopulatedFloatingPoint(r randyTheproto3, easy bool) *FloatingPoint {
 
 func NewPopulatedUint128Pair(r randyTheproto3, easy bool) *Uint128Pair {
 	this := &Uint128Pair{}
-	v74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Left = *v74
+	vAlue74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Left = *vAlue74
 	this.Right = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTheproto3(r, 3)
@@ -5417,13 +5417,13 @@ func NewPopulatedContainsNestedMap(r randyTheproto3, easy bool) *ContainsNestedM
 func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *ContainsNestedMap_NestedMap {
 	this := &ContainsNestedMap_NestedMap{}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(10)
+		vAlue75 := r.Intn(10)
 		this.NestedMapField = make(map[string]float64)
-		for i := 0; i < v75; i++ {
-			v76 := randStringTheproto3(r)
-			this.NestedMapField[v76] = float64(r.Float64())
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := randStringTheproto3(r)
+			this.NestedMapField[vAlue76] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.NestedMapField[v76] *= -1
+				this.NestedMapField[vAlue76] *= -1
 			}
 		}
 	}
@@ -5435,9 +5435,9 @@ func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *Conta
 
 func NewPopulatedNotPacked(r randyTheproto3, easy bool) *NotPacked {
 	this := &NotPacked{}
-	v77 := r.Intn(10)
-	this.Key = make([]uint64, v77)
-	for i := 0; i < v77; i++ {
+	vAlue77 := r.Intn(10)
+	this.Key = make([]uint64, vAlue77)
+	for i := 0; i < vAlue77; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -5465,9 +5465,9 @@ func randUTF8RuneTheproto3(r randyTheproto3) rune {
 	return rune(ru + 61)
 }
 func randStringTheproto3(r randyTheproto3) string {
-	v78 := r.Intn(100)
-	tmps := make([]rune, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	tmps := make([]rune, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		tmps[i] = randUTF8RuneTheproto3(r)
 	}
 	return string(tmps)
@@ -5489,11 +5489,11 @@ func randFieldTheproto3(dAtA []byte, r randyTheproto3, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
-		v79 := r.Int63()
+		vAlue79 := r.Int63()
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(v79))
+		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(vAlue79))
 	case 1:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/theproto3/combos/marshaler/theproto3.pb.go
+++ b/test/theproto3/combos/marshaler/theproto3.pb.go
@@ -4957,14 +4957,14 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 	this.Name = string(randStringTheproto3(r))
 	this.Hilarity = Message_Humour([]int32{0, 1, 2, 3}[r.Intn(4)])
 	this.HeightInCm = uint32(r.Uint32())
-	v1 := r.Intn(100)
-	this.Data = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Data = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
-	v2 := r.Intn(10)
-	this.Key = make([]uint64, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(10)
+	this.Key = make([]uint64, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if r.Intn(5) != 0 {
@@ -4980,9 +4980,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 		this.Score *= -1
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Terrain = make(map[int64]*Nested)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Terrain[int64(r.Int63())] = NewPopulatedNested(r, easy)
 		}
 	}
@@ -4990,9 +4990,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 		this.Proto2Field = both.NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.Proto2Value = make(map[int64]*both.NinOptEnum)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.Proto2Value[int64(r.Int63())] = both.NewPopulatedNinOptEnum(r, easy)
 		}
 	}
@@ -5014,163 +5014,163 @@ func NewPopulatedNested(r randyTheproto3, easy bool) *Nested {
 func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v5; i++ {
-			v6 := randStringTheproto3(r)
-			this.StringToDoubleMap[v6] = float64(r.Float64())
+		for i := 0; i < vAlue5; i++ {
+			vAlue6 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue6] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v6] *= -1
+				this.StringToDoubleMap[vAlue6] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
+		vAlue7 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v7; i++ {
-			v8 := randStringTheproto3(r)
-			this.StringToFloatMap[v8] = float32(r.Float32())
+		for i := 0; i < vAlue7; i++ {
+			vAlue8 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue8] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v8] *= -1
+				this.StringToFloatMap[vAlue8] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := r.Intn(10)
+		vAlue9 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v9; i++ {
-			v10 := int32(r.Int31())
-			this.Int32Map[v10] = int32(r.Int31())
+		for i := 0; i < vAlue9; i++ {
+			vAlue10 := int32(r.Int31())
+			this.Int32Map[vAlue10] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v10] *= -1
+				this.Int32Map[vAlue10] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
+		vAlue11 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v11; i++ {
-			v12 := int64(r.Int63())
-			this.Int64Map[v12] = int64(r.Int63())
+		for i := 0; i < vAlue11; i++ {
+			vAlue12 := int64(r.Int63())
+			this.Int64Map[vAlue12] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v12] *= -1
+				this.Int64Map[vAlue12] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v13; i++ {
-			v14 := uint32(r.Uint32())
-			this.Uint32Map[v14] = uint32(r.Uint32())
+		for i := 0; i < vAlue13; i++ {
+			vAlue14 := uint32(r.Uint32())
+			this.Uint32Map[vAlue14] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v15 := r.Intn(10)
+		vAlue15 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v15; i++ {
-			v16 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v16] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue15; i++ {
+			vAlue16 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue16] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
+		vAlue17 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v17; i++ {
-			v18 := int32(r.Int31())
-			this.Sint32Map[v18] = int32(r.Int31())
+		for i := 0; i < vAlue17; i++ {
+			vAlue18 := int32(r.Int31())
+			this.Sint32Map[vAlue18] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v18] *= -1
+				this.Sint32Map[vAlue18] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
+		vAlue19 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v19; i++ {
-			v20 := int64(r.Int63())
-			this.Sint64Map[v20] = int64(r.Int63())
+		for i := 0; i < vAlue19; i++ {
+			vAlue20 := int64(r.Int63())
+			this.Sint64Map[vAlue20] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v20] *= -1
+				this.Sint64Map[vAlue20] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
+		vAlue21 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v21; i++ {
-			v22 := uint32(r.Uint32())
-			this.Fixed32Map[v22] = uint32(r.Uint32())
+		for i := 0; i < vAlue21; i++ {
+			vAlue22 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue22] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
+		vAlue23 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v23; i++ {
-			v24 := int32(r.Int31())
-			this.Sfixed32Map[v24] = int32(r.Int31())
+		for i := 0; i < vAlue23; i++ {
+			vAlue24 := int32(r.Int31())
+			this.Sfixed32Map[vAlue24] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v24] *= -1
+				this.Sfixed32Map[vAlue24] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
+		vAlue25 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v25; i++ {
-			v26 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v26] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue26] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
+		vAlue27 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v27; i++ {
-			v28 := int64(r.Int63())
-			this.Sfixed64Map[v28] = int64(r.Int63())
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := int64(r.Int63())
+			this.Sfixed64Map[vAlue28] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v28] *= -1
+				this.Sfixed64Map[vAlue28] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
+		vAlue29 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v29; i++ {
-			v30 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v30] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue29; i++ {
+			vAlue30 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue30] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
+		vAlue31 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v31; i++ {
+		for i := 0; i < vAlue31; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v32; i++ {
-			v33 := r.Intn(100)
-			v34 := randStringTheproto3(r)
-			this.StringToBytesMap[v34] = make([]byte, v33)
-			for i := 0; i < v33; i++ {
-				this.StringToBytesMap[v34][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue32; i++ {
+			vAlue33 := r.Intn(100)
+			vAlue34 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue34] = make([]byte, vAlue33)
+			for i := 0; i < vAlue33; i++ {
+				this.StringToBytesMap[vAlue34][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
+		vAlue35 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v35; i++ {
+		for i := 0; i < vAlue35; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -5183,163 +5183,163 @@ func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v37; i++ {
-			v38 := randStringTheproto3(r)
-			this.StringToDoubleMap[v38] = float64(r.Float64())
+		for i := 0; i < vAlue37; i++ {
+			vAlue38 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue38] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v38] *= -1
+				this.StringToDoubleMap[vAlue38] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
+		vAlue39 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v39; i++ {
-			v40 := randStringTheproto3(r)
-			this.StringToFloatMap[v40] = float32(r.Float32())
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue40] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v40] *= -1
+				this.StringToFloatMap[vAlue40] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
+		vAlue41 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v41; i++ {
-			v42 := int32(r.Int31())
-			this.Int32Map[v42] = int32(r.Int31())
+		for i := 0; i < vAlue41; i++ {
+			vAlue42 := int32(r.Int31())
+			this.Int32Map[vAlue42] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v42] *= -1
+				this.Int32Map[vAlue42] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
+		vAlue43 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v43; i++ {
-			v44 := int64(r.Int63())
-			this.Int64Map[v44] = int64(r.Int63())
+		for i := 0; i < vAlue43; i++ {
+			vAlue44 := int64(r.Int63())
+			this.Int64Map[vAlue44] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v44] *= -1
+				this.Int64Map[vAlue44] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
+		vAlue45 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v45; i++ {
-			v46 := uint32(r.Uint32())
-			this.Uint32Map[v46] = uint32(r.Uint32())
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := uint32(r.Uint32())
+			this.Uint32Map[vAlue46] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
+		vAlue47 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v47; i++ {
-			v48 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v48] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue48] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
+		vAlue49 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v49; i++ {
-			v50 := int32(r.Int31())
-			this.Sint32Map[v50] = int32(r.Int31())
+		for i := 0; i < vAlue49; i++ {
+			vAlue50 := int32(r.Int31())
+			this.Sint32Map[vAlue50] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v50] *= -1
+				this.Sint32Map[vAlue50] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
+		vAlue51 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v51; i++ {
-			v52 := int64(r.Int63())
-			this.Sint64Map[v52] = int64(r.Int63())
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := int64(r.Int63())
+			this.Sint64Map[vAlue52] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v52] *= -1
+				this.Sint64Map[vAlue52] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
+		vAlue53 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v53; i++ {
-			v54 := uint32(r.Uint32())
-			this.Fixed32Map[v54] = uint32(r.Uint32())
+		for i := 0; i < vAlue53; i++ {
+			vAlue54 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue54] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
+		vAlue55 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v55; i++ {
-			v56 := int32(r.Int31())
-			this.Sfixed32Map[v56] = int32(r.Int31())
+		for i := 0; i < vAlue55; i++ {
+			vAlue56 := int32(r.Int31())
+			this.Sfixed32Map[vAlue56] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v56] *= -1
+				this.Sfixed32Map[vAlue56] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
+		vAlue57 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v57; i++ {
-			v58 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v58] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue57; i++ {
+			vAlue58 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue58] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
+		vAlue59 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v59; i++ {
-			v60 := int64(r.Int63())
-			this.Sfixed64Map[v60] = int64(r.Int63())
+		for i := 0; i < vAlue59; i++ {
+			vAlue60 := int64(r.Int63())
+			this.Sfixed64Map[vAlue60] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v60] *= -1
+				this.Sfixed64Map[vAlue60] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
+		vAlue61 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v61; i++ {
-			v62 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v62] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue61; i++ {
+			vAlue62 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue62] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
+		vAlue63 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v63; i++ {
+		for i := 0; i < vAlue63; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v64; i++ {
-			v65 := r.Intn(100)
-			v66 := randStringTheproto3(r)
-			this.StringToBytesMap[v66] = make([]byte, v65)
-			for i := 0; i < v65; i++ {
-				this.StringToBytesMap[v66][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue64; i++ {
+			vAlue65 := r.Intn(100)
+			vAlue66 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue66] = make([]byte, vAlue65)
+			for i := 0; i < vAlue65; i++ {
+				this.StringToBytesMap[vAlue66][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
+		vAlue67 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v67; i++ {
+		for i := 0; i < vAlue67; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -5352,28 +5352,28 @@ func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 func NewPopulatedMessageWithMap(r randyTheproto3, easy bool) *MessageWithMap {
 	this := &MessageWithMap{}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.NameMapping = make(map[int32]string)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.NameMapping[int32(r.Int31())] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
+		vAlue70 := r.Intn(10)
 		this.MsgMapping = make(map[int64]*FloatingPoint)
-		for i := 0; i < v70; i++ {
+		for i := 0; i < vAlue70; i++ {
 			this.MsgMapping[int64(r.Int63())] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
+		vAlue71 := r.Intn(10)
 		this.ByteMapping = make(map[bool][]byte)
-		for i := 0; i < v71; i++ {
-			v72 := r.Intn(100)
-			v73 := bool(bool(r.Intn(2) == 0))
-			this.ByteMapping[v73] = make([]byte, v72)
-			for i := 0; i < v72; i++ {
-				this.ByteMapping[v73][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue71; i++ {
+			vAlue72 := r.Intn(100)
+			vAlue73 := bool(bool(r.Intn(2) == 0))
+			this.ByteMapping[vAlue73] = make([]byte, vAlue72)
+			for i := 0; i < vAlue72; i++ {
+				this.ByteMapping[vAlue73][i] = byte(r.Intn(256))
 			}
 		}
 	}
@@ -5397,8 +5397,8 @@ func NewPopulatedFloatingPoint(r randyTheproto3, easy bool) *FloatingPoint {
 
 func NewPopulatedUint128Pair(r randyTheproto3, easy bool) *Uint128Pair {
 	this := &Uint128Pair{}
-	v74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Left = *v74
+	vAlue74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Left = *vAlue74
 	this.Right = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTheproto3(r, 3)
@@ -5417,13 +5417,13 @@ func NewPopulatedContainsNestedMap(r randyTheproto3, easy bool) *ContainsNestedM
 func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *ContainsNestedMap_NestedMap {
 	this := &ContainsNestedMap_NestedMap{}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(10)
+		vAlue75 := r.Intn(10)
 		this.NestedMapField = make(map[string]float64)
-		for i := 0; i < v75; i++ {
-			v76 := randStringTheproto3(r)
-			this.NestedMapField[v76] = float64(r.Float64())
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := randStringTheproto3(r)
+			this.NestedMapField[vAlue76] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.NestedMapField[v76] *= -1
+				this.NestedMapField[vAlue76] *= -1
 			}
 		}
 	}
@@ -5435,9 +5435,9 @@ func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *Conta
 
 func NewPopulatedNotPacked(r randyTheproto3, easy bool) *NotPacked {
 	this := &NotPacked{}
-	v77 := r.Intn(10)
-	this.Key = make([]uint64, v77)
-	for i := 0; i < v77; i++ {
+	vAlue77 := r.Intn(10)
+	this.Key = make([]uint64, vAlue77)
+	for i := 0; i < vAlue77; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -5465,9 +5465,9 @@ func randUTF8RuneTheproto3(r randyTheproto3) rune {
 	return rune(ru + 61)
 }
 func randStringTheproto3(r randyTheproto3) string {
-	v78 := r.Intn(100)
-	tmps := make([]rune, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	tmps := make([]rune, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		tmps[i] = randUTF8RuneTheproto3(r)
 	}
 	return string(tmps)
@@ -5489,11 +5489,11 @@ func randFieldTheproto3(dAtA []byte, r randyTheproto3, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
-		v79 := r.Int63()
+		vAlue79 := r.Int63()
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(v79))
+		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(vAlue79))
 	case 1:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/theproto3/combos/neither/theproto3.pb.go
+++ b/test/theproto3/combos/neither/theproto3.pb.go
@@ -3632,9 +3632,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 	this.Name = string(randStringTheproto3(r))
 	this.Hilarity = Message_Humour([]int32{0, 1, 2, 3}[r.Intn(4)])
 	this.HeightInCm = uint32(r.Uint32())
-	v1 := r.Intn(100)
-	this.Data = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Data = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
 	this.ResultCount = int64(r.Int63())
@@ -3646,18 +3646,18 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 	if r.Intn(2) == 0 {
 		this.Score *= -1
 	}
-	v2 := r.Intn(10)
-	this.Key = make([]uint64, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(10)
+	this.Key = make([]uint64, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if r.Intn(5) != 0 {
 		this.Nested = NewPopulatedNested(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Terrain = make(map[int64]*Nested)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Terrain[int64(r.Int63())] = NewPopulatedNested(r, easy)
 		}
 	}
@@ -3665,9 +3665,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 		this.Proto2Field = both.NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.Proto2Value = make(map[int64]*both.NinOptEnum)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.Proto2Value[int64(r.Int63())] = both.NewPopulatedNinOptEnum(r, easy)
 		}
 	}
@@ -3689,163 +3689,163 @@ func NewPopulatedNested(r randyTheproto3, easy bool) *Nested {
 func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v5; i++ {
-			v6 := randStringTheproto3(r)
-			this.StringToDoubleMap[v6] = float64(r.Float64())
+		for i := 0; i < vAlue5; i++ {
+			vAlue6 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue6] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v6] *= -1
+				this.StringToDoubleMap[vAlue6] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
+		vAlue7 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v7; i++ {
-			v8 := randStringTheproto3(r)
-			this.StringToFloatMap[v8] = float32(r.Float32())
+		for i := 0; i < vAlue7; i++ {
+			vAlue8 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue8] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v8] *= -1
+				this.StringToFloatMap[vAlue8] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := r.Intn(10)
+		vAlue9 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v9; i++ {
-			v10 := int32(r.Int31())
-			this.Int32Map[v10] = int32(r.Int31())
+		for i := 0; i < vAlue9; i++ {
+			vAlue10 := int32(r.Int31())
+			this.Int32Map[vAlue10] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v10] *= -1
+				this.Int32Map[vAlue10] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
+		vAlue11 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v11; i++ {
-			v12 := int64(r.Int63())
-			this.Int64Map[v12] = int64(r.Int63())
+		for i := 0; i < vAlue11; i++ {
+			vAlue12 := int64(r.Int63())
+			this.Int64Map[vAlue12] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v12] *= -1
+				this.Int64Map[vAlue12] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v13; i++ {
-			v14 := uint32(r.Uint32())
-			this.Uint32Map[v14] = uint32(r.Uint32())
+		for i := 0; i < vAlue13; i++ {
+			vAlue14 := uint32(r.Uint32())
+			this.Uint32Map[vAlue14] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v15 := r.Intn(10)
+		vAlue15 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v15; i++ {
-			v16 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v16] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue15; i++ {
+			vAlue16 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue16] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
+		vAlue17 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v17; i++ {
-			v18 := int32(r.Int31())
-			this.Sint32Map[v18] = int32(r.Int31())
+		for i := 0; i < vAlue17; i++ {
+			vAlue18 := int32(r.Int31())
+			this.Sint32Map[vAlue18] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v18] *= -1
+				this.Sint32Map[vAlue18] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
+		vAlue19 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v19; i++ {
-			v20 := int64(r.Int63())
-			this.Sint64Map[v20] = int64(r.Int63())
+		for i := 0; i < vAlue19; i++ {
+			vAlue20 := int64(r.Int63())
+			this.Sint64Map[vAlue20] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v20] *= -1
+				this.Sint64Map[vAlue20] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
+		vAlue21 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v21; i++ {
-			v22 := uint32(r.Uint32())
-			this.Fixed32Map[v22] = uint32(r.Uint32())
+		for i := 0; i < vAlue21; i++ {
+			vAlue22 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue22] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
+		vAlue23 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v23; i++ {
-			v24 := int32(r.Int31())
-			this.Sfixed32Map[v24] = int32(r.Int31())
+		for i := 0; i < vAlue23; i++ {
+			vAlue24 := int32(r.Int31())
+			this.Sfixed32Map[vAlue24] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v24] *= -1
+				this.Sfixed32Map[vAlue24] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
+		vAlue25 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v25; i++ {
-			v26 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v26] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue26] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
+		vAlue27 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v27; i++ {
-			v28 := int64(r.Int63())
-			this.Sfixed64Map[v28] = int64(r.Int63())
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := int64(r.Int63())
+			this.Sfixed64Map[vAlue28] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v28] *= -1
+				this.Sfixed64Map[vAlue28] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
+		vAlue29 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v29; i++ {
-			v30 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v30] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue29; i++ {
+			vAlue30 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue30] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
+		vAlue31 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v31; i++ {
+		for i := 0; i < vAlue31; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v32; i++ {
-			v33 := r.Intn(100)
-			v34 := randStringTheproto3(r)
-			this.StringToBytesMap[v34] = make([]byte, v33)
-			for i := 0; i < v33; i++ {
-				this.StringToBytesMap[v34][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue32; i++ {
+			vAlue33 := r.Intn(100)
+			vAlue34 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue34] = make([]byte, vAlue33)
+			for i := 0; i < vAlue33; i++ {
+				this.StringToBytesMap[vAlue34][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
+		vAlue35 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v35; i++ {
+		for i := 0; i < vAlue35; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -3858,163 +3858,163 @@ func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v37; i++ {
-			v38 := randStringTheproto3(r)
-			this.StringToDoubleMap[v38] = float64(r.Float64())
+		for i := 0; i < vAlue37; i++ {
+			vAlue38 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue38] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v38] *= -1
+				this.StringToDoubleMap[vAlue38] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
+		vAlue39 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v39; i++ {
-			v40 := randStringTheproto3(r)
-			this.StringToFloatMap[v40] = float32(r.Float32())
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue40] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v40] *= -1
+				this.StringToFloatMap[vAlue40] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
+		vAlue41 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v41; i++ {
-			v42 := int32(r.Int31())
-			this.Int32Map[v42] = int32(r.Int31())
+		for i := 0; i < vAlue41; i++ {
+			vAlue42 := int32(r.Int31())
+			this.Int32Map[vAlue42] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v42] *= -1
+				this.Int32Map[vAlue42] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
+		vAlue43 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v43; i++ {
-			v44 := int64(r.Int63())
-			this.Int64Map[v44] = int64(r.Int63())
+		for i := 0; i < vAlue43; i++ {
+			vAlue44 := int64(r.Int63())
+			this.Int64Map[vAlue44] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v44] *= -1
+				this.Int64Map[vAlue44] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
+		vAlue45 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v45; i++ {
-			v46 := uint32(r.Uint32())
-			this.Uint32Map[v46] = uint32(r.Uint32())
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := uint32(r.Uint32())
+			this.Uint32Map[vAlue46] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
+		vAlue47 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v47; i++ {
-			v48 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v48] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue48] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
+		vAlue49 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v49; i++ {
-			v50 := int32(r.Int31())
-			this.Sint32Map[v50] = int32(r.Int31())
+		for i := 0; i < vAlue49; i++ {
+			vAlue50 := int32(r.Int31())
+			this.Sint32Map[vAlue50] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v50] *= -1
+				this.Sint32Map[vAlue50] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
+		vAlue51 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v51; i++ {
-			v52 := int64(r.Int63())
-			this.Sint64Map[v52] = int64(r.Int63())
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := int64(r.Int63())
+			this.Sint64Map[vAlue52] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v52] *= -1
+				this.Sint64Map[vAlue52] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
+		vAlue53 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v53; i++ {
-			v54 := uint32(r.Uint32())
-			this.Fixed32Map[v54] = uint32(r.Uint32())
+		for i := 0; i < vAlue53; i++ {
+			vAlue54 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue54] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
+		vAlue55 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v55; i++ {
-			v56 := int32(r.Int31())
-			this.Sfixed32Map[v56] = int32(r.Int31())
+		for i := 0; i < vAlue55; i++ {
+			vAlue56 := int32(r.Int31())
+			this.Sfixed32Map[vAlue56] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v56] *= -1
+				this.Sfixed32Map[vAlue56] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
+		vAlue57 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v57; i++ {
-			v58 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v58] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue57; i++ {
+			vAlue58 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue58] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
+		vAlue59 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v59; i++ {
-			v60 := int64(r.Int63())
-			this.Sfixed64Map[v60] = int64(r.Int63())
+		for i := 0; i < vAlue59; i++ {
+			vAlue60 := int64(r.Int63())
+			this.Sfixed64Map[vAlue60] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v60] *= -1
+				this.Sfixed64Map[vAlue60] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
+		vAlue61 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v61; i++ {
-			v62 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v62] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue61; i++ {
+			vAlue62 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue62] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
+		vAlue63 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v63; i++ {
+		for i := 0; i < vAlue63; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v64; i++ {
-			v65 := r.Intn(100)
-			v66 := randStringTheproto3(r)
-			this.StringToBytesMap[v66] = make([]byte, v65)
-			for i := 0; i < v65; i++ {
-				this.StringToBytesMap[v66][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue64; i++ {
+			vAlue65 := r.Intn(100)
+			vAlue66 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue66] = make([]byte, vAlue65)
+			for i := 0; i < vAlue65; i++ {
+				this.StringToBytesMap[vAlue66][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
+		vAlue67 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v67; i++ {
+		for i := 0; i < vAlue67; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -4027,28 +4027,28 @@ func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 func NewPopulatedMessageWithMap(r randyTheproto3, easy bool) *MessageWithMap {
 	this := &MessageWithMap{}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.NameMapping = make(map[int32]string)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.NameMapping[int32(r.Int31())] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
+		vAlue70 := r.Intn(10)
 		this.MsgMapping = make(map[int64]*FloatingPoint)
-		for i := 0; i < v70; i++ {
+		for i := 0; i < vAlue70; i++ {
 			this.MsgMapping[int64(r.Int63())] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
+		vAlue71 := r.Intn(10)
 		this.ByteMapping = make(map[bool][]byte)
-		for i := 0; i < v71; i++ {
-			v72 := r.Intn(100)
-			v73 := bool(bool(r.Intn(2) == 0))
-			this.ByteMapping[v73] = make([]byte, v72)
-			for i := 0; i < v72; i++ {
-				this.ByteMapping[v73][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue71; i++ {
+			vAlue72 := r.Intn(100)
+			vAlue73 := bool(bool(r.Intn(2) == 0))
+			this.ByteMapping[vAlue73] = make([]byte, vAlue72)
+			for i := 0; i < vAlue72; i++ {
+				this.ByteMapping[vAlue73][i] = byte(r.Intn(256))
 			}
 		}
 	}
@@ -4072,8 +4072,8 @@ func NewPopulatedFloatingPoint(r randyTheproto3, easy bool) *FloatingPoint {
 
 func NewPopulatedUint128Pair(r randyTheproto3, easy bool) *Uint128Pair {
 	this := &Uint128Pair{}
-	v74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Left = *v74
+	vAlue74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Left = *vAlue74
 	this.Right = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTheproto3(r, 3)
@@ -4092,13 +4092,13 @@ func NewPopulatedContainsNestedMap(r randyTheproto3, easy bool) *ContainsNestedM
 func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *ContainsNestedMap_NestedMap {
 	this := &ContainsNestedMap_NestedMap{}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(10)
+		vAlue75 := r.Intn(10)
 		this.NestedMapField = make(map[string]float64)
-		for i := 0; i < v75; i++ {
-			v76 := randStringTheproto3(r)
-			this.NestedMapField[v76] = float64(r.Float64())
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := randStringTheproto3(r)
+			this.NestedMapField[vAlue76] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.NestedMapField[v76] *= -1
+				this.NestedMapField[vAlue76] *= -1
 			}
 		}
 	}
@@ -4110,9 +4110,9 @@ func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *Conta
 
 func NewPopulatedNotPacked(r randyTheproto3, easy bool) *NotPacked {
 	this := &NotPacked{}
-	v77 := r.Intn(10)
-	this.Key = make([]uint64, v77)
-	for i := 0; i < v77; i++ {
+	vAlue77 := r.Intn(10)
+	this.Key = make([]uint64, vAlue77)
+	for i := 0; i < vAlue77; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -4140,9 +4140,9 @@ func randUTF8RuneTheproto3(r randyTheproto3) rune {
 	return rune(ru + 61)
 }
 func randStringTheproto3(r randyTheproto3) string {
-	v78 := r.Intn(100)
-	tmps := make([]rune, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	tmps := make([]rune, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		tmps[i] = randUTF8RuneTheproto3(r)
 	}
 	return string(tmps)
@@ -4164,11 +4164,11 @@ func randFieldTheproto3(dAtA []byte, r randyTheproto3, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
-		v79 := r.Int63()
+		vAlue79 := r.Int63()
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(v79))
+		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(vAlue79))
 	case 1:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -3634,9 +3634,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 	this.Name = string(randStringTheproto3(r))
 	this.Hilarity = Message_Humour([]int32{0, 1, 2, 3}[r.Intn(4)])
 	this.HeightInCm = uint32(r.Uint32())
-	v1 := r.Intn(100)
-	this.Data = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Data = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
 	this.ResultCount = int64(r.Int63())
@@ -3648,18 +3648,18 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 	if r.Intn(2) == 0 {
 		this.Score *= -1
 	}
-	v2 := r.Intn(10)
-	this.Key = make([]uint64, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(10)
+	this.Key = make([]uint64, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if r.Intn(5) != 0 {
 		this.Nested = NewPopulatedNested(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(10)
+		vAlue3 := r.Intn(10)
 		this.Terrain = make(map[int64]*Nested)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < vAlue3; i++ {
 			this.Terrain[int64(r.Int63())] = NewPopulatedNested(r, easy)
 		}
 	}
@@ -3667,9 +3667,9 @@ func NewPopulatedMessage(r randyTheproto3, easy bool) *Message {
 		this.Proto2Field = both.NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(10)
+		vAlue4 := r.Intn(10)
 		this.Proto2Value = make(map[int64]*both.NinOptEnum)
-		for i := 0; i < v4; i++ {
+		for i := 0; i < vAlue4; i++ {
 			this.Proto2Value[int64(r.Int63())] = both.NewPopulatedNinOptEnum(r, easy)
 		}
 	}
@@ -3691,163 +3691,163 @@ func NewPopulatedNested(r randyTheproto3, easy bool) *Nested {
 func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 	this := &AllMaps{}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
+		vAlue5 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v5; i++ {
-			v6 := randStringTheproto3(r)
-			this.StringToDoubleMap[v6] = float64(r.Float64())
+		for i := 0; i < vAlue5; i++ {
+			vAlue6 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue6] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v6] *= -1
+				this.StringToDoubleMap[vAlue6] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
+		vAlue7 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v7; i++ {
-			v8 := randStringTheproto3(r)
-			this.StringToFloatMap[v8] = float32(r.Float32())
+		for i := 0; i < vAlue7; i++ {
+			vAlue8 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue8] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v8] *= -1
+				this.StringToFloatMap[vAlue8] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := r.Intn(10)
+		vAlue9 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v9; i++ {
-			v10 := int32(r.Int31())
-			this.Int32Map[v10] = int32(r.Int31())
+		for i := 0; i < vAlue9; i++ {
+			vAlue10 := int32(r.Int31())
+			this.Int32Map[vAlue10] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v10] *= -1
+				this.Int32Map[vAlue10] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
+		vAlue11 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v11; i++ {
-			v12 := int64(r.Int63())
-			this.Int64Map[v12] = int64(r.Int63())
+		for i := 0; i < vAlue11; i++ {
+			vAlue12 := int64(r.Int63())
+			this.Int64Map[vAlue12] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v12] *= -1
+				this.Int64Map[vAlue12] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
+		vAlue13 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v13; i++ {
-			v14 := uint32(r.Uint32())
-			this.Uint32Map[v14] = uint32(r.Uint32())
+		for i := 0; i < vAlue13; i++ {
+			vAlue14 := uint32(r.Uint32())
+			this.Uint32Map[vAlue14] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v15 := r.Intn(10)
+		vAlue15 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v15; i++ {
-			v16 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v16] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue15; i++ {
+			vAlue16 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue16] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
+		vAlue17 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v17; i++ {
-			v18 := int32(r.Int31())
-			this.Sint32Map[v18] = int32(r.Int31())
+		for i := 0; i < vAlue17; i++ {
+			vAlue18 := int32(r.Int31())
+			this.Sint32Map[vAlue18] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v18] *= -1
+				this.Sint32Map[vAlue18] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
+		vAlue19 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v19; i++ {
-			v20 := int64(r.Int63())
-			this.Sint64Map[v20] = int64(r.Int63())
+		for i := 0; i < vAlue19; i++ {
+			vAlue20 := int64(r.Int63())
+			this.Sint64Map[vAlue20] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v20] *= -1
+				this.Sint64Map[vAlue20] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
+		vAlue21 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v21; i++ {
-			v22 := uint32(r.Uint32())
-			this.Fixed32Map[v22] = uint32(r.Uint32())
+		for i := 0; i < vAlue21; i++ {
+			vAlue22 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue22] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
+		vAlue23 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v23; i++ {
-			v24 := int32(r.Int31())
-			this.Sfixed32Map[v24] = int32(r.Int31())
+		for i := 0; i < vAlue23; i++ {
+			vAlue24 := int32(r.Int31())
+			this.Sfixed32Map[vAlue24] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v24] *= -1
+				this.Sfixed32Map[vAlue24] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
+		vAlue25 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v25; i++ {
-			v26 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v26] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue26] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
+		vAlue27 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v27; i++ {
-			v28 := int64(r.Int63())
-			this.Sfixed64Map[v28] = int64(r.Int63())
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := int64(r.Int63())
+			this.Sfixed64Map[vAlue28] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v28] *= -1
+				this.Sfixed64Map[vAlue28] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
+		vAlue29 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v29; i++ {
-			v30 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v30] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue29; i++ {
+			vAlue30 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue30] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
+		vAlue31 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v31; i++ {
+		for i := 0; i < vAlue31; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(10)
+		vAlue32 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v32; i++ {
-			v33 := r.Intn(100)
-			v34 := randStringTheproto3(r)
-			this.StringToBytesMap[v34] = make([]byte, v33)
-			for i := 0; i < v33; i++ {
-				this.StringToBytesMap[v34][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue32; i++ {
+			vAlue33 := r.Intn(100)
+			vAlue34 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue34] = make([]byte, vAlue33)
+			for i := 0; i < vAlue33; i++ {
+				this.StringToBytesMap[vAlue34][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
+		vAlue35 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v35; i++ {
+		for i := 0; i < vAlue35; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
+		vAlue36 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v36; i++ {
+		for i := 0; i < vAlue36; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -3860,163 +3860,163 @@ func NewPopulatedAllMaps(r randyTheproto3, easy bool) *AllMaps {
 func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 	this := &AllMapsOrdered{}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
+		vAlue37 := r.Intn(10)
 		this.StringToDoubleMap = make(map[string]float64)
-		for i := 0; i < v37; i++ {
-			v38 := randStringTheproto3(r)
-			this.StringToDoubleMap[v38] = float64(r.Float64())
+		for i := 0; i < vAlue37; i++ {
+			vAlue38 := randStringTheproto3(r)
+			this.StringToDoubleMap[vAlue38] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.StringToDoubleMap[v38] *= -1
+				this.StringToDoubleMap[vAlue38] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
+		vAlue39 := r.Intn(10)
 		this.StringToFloatMap = make(map[string]float32)
-		for i := 0; i < v39; i++ {
-			v40 := randStringTheproto3(r)
-			this.StringToFloatMap[v40] = float32(r.Float32())
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := randStringTheproto3(r)
+			this.StringToFloatMap[vAlue40] = float32(r.Float32())
 			if r.Intn(2) == 0 {
-				this.StringToFloatMap[v40] *= -1
+				this.StringToFloatMap[vAlue40] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
+		vAlue41 := r.Intn(10)
 		this.Int32Map = make(map[int32]int32)
-		for i := 0; i < v41; i++ {
-			v42 := int32(r.Int31())
-			this.Int32Map[v42] = int32(r.Int31())
+		for i := 0; i < vAlue41; i++ {
+			vAlue42 := int32(r.Int31())
+			this.Int32Map[vAlue42] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Int32Map[v42] *= -1
+				this.Int32Map[vAlue42] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
+		vAlue43 := r.Intn(10)
 		this.Int64Map = make(map[int64]int64)
-		for i := 0; i < v43; i++ {
-			v44 := int64(r.Int63())
-			this.Int64Map[v44] = int64(r.Int63())
+		for i := 0; i < vAlue43; i++ {
+			vAlue44 := int64(r.Int63())
+			this.Int64Map[vAlue44] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Int64Map[v44] *= -1
+				this.Int64Map[vAlue44] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
+		vAlue45 := r.Intn(10)
 		this.Uint32Map = make(map[uint32]uint32)
-		for i := 0; i < v45; i++ {
-			v46 := uint32(r.Uint32())
-			this.Uint32Map[v46] = uint32(r.Uint32())
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := uint32(r.Uint32())
+			this.Uint32Map[vAlue46] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
+		vAlue47 := r.Intn(10)
 		this.Uint64Map = make(map[uint64]uint64)
-		for i := 0; i < v47; i++ {
-			v48 := uint64(uint64(r.Uint32()))
-			this.Uint64Map[v48] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := uint64(uint64(r.Uint32()))
+			this.Uint64Map[vAlue48] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
+		vAlue49 := r.Intn(10)
 		this.Sint32Map = make(map[int32]int32)
-		for i := 0; i < v49; i++ {
-			v50 := int32(r.Int31())
-			this.Sint32Map[v50] = int32(r.Int31())
+		for i := 0; i < vAlue49; i++ {
+			vAlue50 := int32(r.Int31())
+			this.Sint32Map[vAlue50] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sint32Map[v50] *= -1
+				this.Sint32Map[vAlue50] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
+		vAlue51 := r.Intn(10)
 		this.Sint64Map = make(map[int64]int64)
-		for i := 0; i < v51; i++ {
-			v52 := int64(r.Int63())
-			this.Sint64Map[v52] = int64(r.Int63())
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := int64(r.Int63())
+			this.Sint64Map[vAlue52] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sint64Map[v52] *= -1
+				this.Sint64Map[vAlue52] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
+		vAlue53 := r.Intn(10)
 		this.Fixed32Map = make(map[uint32]uint32)
-		for i := 0; i < v53; i++ {
-			v54 := uint32(r.Uint32())
-			this.Fixed32Map[v54] = uint32(r.Uint32())
+		for i := 0; i < vAlue53; i++ {
+			vAlue54 := uint32(r.Uint32())
+			this.Fixed32Map[vAlue54] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
+		vAlue55 := r.Intn(10)
 		this.Sfixed32Map = make(map[int32]int32)
-		for i := 0; i < v55; i++ {
-			v56 := int32(r.Int31())
-			this.Sfixed32Map[v56] = int32(r.Int31())
+		for i := 0; i < vAlue55; i++ {
+			vAlue56 := int32(r.Int31())
+			this.Sfixed32Map[vAlue56] = int32(r.Int31())
 			if r.Intn(2) == 0 {
-				this.Sfixed32Map[v56] *= -1
+				this.Sfixed32Map[vAlue56] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
+		vAlue57 := r.Intn(10)
 		this.Fixed64Map = make(map[uint64]uint64)
-		for i := 0; i < v57; i++ {
-			v58 := uint64(uint64(r.Uint32()))
-			this.Fixed64Map[v58] = uint64(uint64(r.Uint32()))
+		for i := 0; i < vAlue57; i++ {
+			vAlue58 := uint64(uint64(r.Uint32()))
+			this.Fixed64Map[vAlue58] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
+		vAlue59 := r.Intn(10)
 		this.Sfixed64Map = make(map[int64]int64)
-		for i := 0; i < v59; i++ {
-			v60 := int64(r.Int63())
-			this.Sfixed64Map[v60] = int64(r.Int63())
+		for i := 0; i < vAlue59; i++ {
+			vAlue60 := int64(r.Int63())
+			this.Sfixed64Map[vAlue60] = int64(r.Int63())
 			if r.Intn(2) == 0 {
-				this.Sfixed64Map[v60] *= -1
+				this.Sfixed64Map[vAlue60] *= -1
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
+		vAlue61 := r.Intn(10)
 		this.BoolMap = make(map[bool]bool)
-		for i := 0; i < v61; i++ {
-			v62 := bool(bool(r.Intn(2) == 0))
-			this.BoolMap[v62] = bool(bool(r.Intn(2) == 0))
+		for i := 0; i < vAlue61; i++ {
+			vAlue62 := bool(bool(r.Intn(2) == 0))
+			this.BoolMap[vAlue62] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
+		vAlue63 := r.Intn(10)
 		this.StringMap = make(map[string]string)
-		for i := 0; i < v63; i++ {
+		for i := 0; i < vAlue63; i++ {
 			this.StringMap[randStringTheproto3(r)] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
+		vAlue64 := r.Intn(10)
 		this.StringToBytesMap = make(map[string][]byte)
-		for i := 0; i < v64; i++ {
-			v65 := r.Intn(100)
-			v66 := randStringTheproto3(r)
-			this.StringToBytesMap[v66] = make([]byte, v65)
-			for i := 0; i < v65; i++ {
-				this.StringToBytesMap[v66][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue64; i++ {
+			vAlue65 := r.Intn(100)
+			vAlue66 := randStringTheproto3(r)
+			this.StringToBytesMap[vAlue66] = make([]byte, vAlue65)
+			for i := 0; i < vAlue65; i++ {
+				this.StringToBytesMap[vAlue66][i] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
+		vAlue67 := r.Intn(10)
 		this.StringToEnumMap = make(map[string]MapEnum)
-		for i := 0; i < v67; i++ {
+		for i := 0; i < vAlue67; i++ {
 			this.StringToEnumMap[randStringTheproto3(r)] = MapEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
+		vAlue68 := r.Intn(10)
 		this.StringToMsgMap = make(map[string]*FloatingPoint)
-		for i := 0; i < v68; i++ {
+		for i := 0; i < vAlue68; i++ {
 			this.StringToMsgMap[randStringTheproto3(r)] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
@@ -4029,28 +4029,28 @@ func NewPopulatedAllMapsOrdered(r randyTheproto3, easy bool) *AllMapsOrdered {
 func NewPopulatedMessageWithMap(r randyTheproto3, easy bool) *MessageWithMap {
 	this := &MessageWithMap{}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
+		vAlue69 := r.Intn(10)
 		this.NameMapping = make(map[int32]string)
-		for i := 0; i < v69; i++ {
+		for i := 0; i < vAlue69; i++ {
 			this.NameMapping[int32(r.Int31())] = randStringTheproto3(r)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
+		vAlue70 := r.Intn(10)
 		this.MsgMapping = make(map[int64]*FloatingPoint)
-		for i := 0; i < v70; i++ {
+		for i := 0; i < vAlue70; i++ {
 			this.MsgMapping[int64(r.Int63())] = NewPopulatedFloatingPoint(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
+		vAlue71 := r.Intn(10)
 		this.ByteMapping = make(map[bool][]byte)
-		for i := 0; i < v71; i++ {
-			v72 := r.Intn(100)
-			v73 := bool(bool(r.Intn(2) == 0))
-			this.ByteMapping[v73] = make([]byte, v72)
-			for i := 0; i < v72; i++ {
-				this.ByteMapping[v73][i] = byte(r.Intn(256))
+		for i := 0; i < vAlue71; i++ {
+			vAlue72 := r.Intn(100)
+			vAlue73 := bool(bool(r.Intn(2) == 0))
+			this.ByteMapping[vAlue73] = make([]byte, vAlue72)
+			for i := 0; i < vAlue72; i++ {
+				this.ByteMapping[vAlue73][i] = byte(r.Intn(256))
 			}
 		}
 	}
@@ -4074,8 +4074,8 @@ func NewPopulatedFloatingPoint(r randyTheproto3, easy bool) *FloatingPoint {
 
 func NewPopulatedUint128Pair(r randyTheproto3, easy bool) *Uint128Pair {
 	this := &Uint128Pair{}
-	v74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Left = *v74
+	vAlue74 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Left = *vAlue74
 	this.Right = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTheproto3(r, 3)
@@ -4094,13 +4094,13 @@ func NewPopulatedContainsNestedMap(r randyTheproto3, easy bool) *ContainsNestedM
 func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *ContainsNestedMap_NestedMap {
 	this := &ContainsNestedMap_NestedMap{}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(10)
+		vAlue75 := r.Intn(10)
 		this.NestedMapField = make(map[string]float64)
-		for i := 0; i < v75; i++ {
-			v76 := randStringTheproto3(r)
-			this.NestedMapField[v76] = float64(r.Float64())
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := randStringTheproto3(r)
+			this.NestedMapField[vAlue76] = float64(r.Float64())
 			if r.Intn(2) == 0 {
-				this.NestedMapField[v76] *= -1
+				this.NestedMapField[vAlue76] *= -1
 			}
 		}
 	}
@@ -4112,9 +4112,9 @@ func NewPopulatedContainsNestedMap_NestedMap(r randyTheproto3, easy bool) *Conta
 
 func NewPopulatedNotPacked(r randyTheproto3, easy bool) *NotPacked {
 	this := &NotPacked{}
-	v77 := r.Intn(10)
-	this.Key = make([]uint64, v77)
-	for i := 0; i < v77; i++ {
+	vAlue77 := r.Intn(10)
+	this.Key = make([]uint64, vAlue77)
+	for i := 0; i < vAlue77; i++ {
 		this.Key[i] = uint64(uint64(r.Uint32()))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -4142,9 +4142,9 @@ func randUTF8RuneTheproto3(r randyTheproto3) rune {
 	return rune(ru + 61)
 }
 func randStringTheproto3(r randyTheproto3) string {
-	v78 := r.Intn(100)
-	tmps := make([]rune, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	tmps := make([]rune, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		tmps[i] = randUTF8RuneTheproto3(r)
 	}
 	return string(tmps)
@@ -4166,11 +4166,11 @@ func randFieldTheproto3(dAtA []byte, r randyTheproto3, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
-		v79 := r.Int63()
+		vAlue79 := r.Int63()
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(v79))
+		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(vAlue79))
 	case 1:
 		dAtA = encodeVarintPopulateTheproto3(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/thetest.pb.go
+++ b/test/thetest.pb.go
@@ -21528,9 +21528,9 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 	}
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v1 := r.Intn(100)
-	this.Field15 = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -21542,89 +21542,89 @@ func NewPopulatedNidOptNative(r randyThetest, easy bool) *NidOptNative {
 func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 	this := &NinOptNative{}
 	if r.Intn(5) != 0 {
-		v2 := float64(r.Float64())
+		vAlue2 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := float32(r.Float32())
+		vAlue3 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field2 = &v3
+		this.Field2 = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := int32(r.Int31())
+		vAlue4 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field3 = &v4
+		this.Field3 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
-		v5 := int64(r.Int63())
+		vAlue5 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		this.Field4 = &v5
+		this.Field4 = &vAlue5
 	}
 	if r.Intn(5) != 0 {
-		v6 := uint32(r.Uint32())
-		this.Field5 = &v6
+		vAlue6 := uint32(r.Uint32())
+		this.Field5 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v7
+		vAlue7 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue7
 	}
 	if r.Intn(5) != 0 {
-		v8 := int32(r.Int31())
+		vAlue8 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v8 *= -1
+			vAlue8 *= -1
 		}
-		this.Field7 = &v8
+		this.Field7 = &vAlue8
 	}
 	if r.Intn(5) != 0 {
-		v9 := int64(r.Int63())
+		vAlue9 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		this.Field8 = &v9
+		this.Field8 = &vAlue9
 	}
 	if r.Intn(5) != 0 {
-		v10 := uint32(r.Uint32())
-		this.Field9 = &v10
+		vAlue10 := uint32(r.Uint32())
+		this.Field9 = &vAlue10
 	}
 	if r.Intn(5) != 0 {
-		v11 := int32(r.Int31())
+		vAlue11 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v11 *= -1
+			vAlue11 *= -1
 		}
-		this.Field10 = &v11
+		this.Field10 = &vAlue11
 	}
 	if r.Intn(5) != 0 {
-		v12 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v12
+		vAlue12 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue12
 	}
 	if r.Intn(5) != 0 {
-		v13 := int64(r.Int63())
+		vAlue13 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v13 *= -1
+			vAlue13 *= -1
 		}
-		this.Field12 = &v13
+		this.Field12 = &vAlue13
 	}
 	if r.Intn(5) != 0 {
-		v14 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v14
+		vAlue14 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue14
 	}
 	if r.Intn(5) != 0 {
-		v15 := string(randStringThetest(r))
-		this.Field14 = &v15
+		vAlue15 := string(randStringThetest(r))
+		this.Field14 = &vAlue15
 	}
 	if r.Intn(5) != 0 {
-		v16 := r.Intn(100)
-		this.Field15 = make([]byte, v16)
-		for i := 0; i < v16; i++ {
+		vAlue16 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue16)
+		for i := 0; i < vAlue16; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -21637,9 +21637,9 @@ func NewPopulatedNinOptNative(r randyThetest, easy bool) *NinOptNative {
 func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 	this := &NidRepNative{}
 	if r.Intn(5) != 0 {
-		v17 := r.Intn(10)
-		this.Field1 = make([]float64, v17)
-		for i := 0; i < v17; i++ {
+		vAlue17 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue17)
+		for i := 0; i < vAlue17; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -21647,9 +21647,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v18 := r.Intn(10)
-		this.Field2 = make([]float32, v18)
-		for i := 0; i < v18; i++ {
+		vAlue18 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue18)
+		for i := 0; i < vAlue18; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -21657,9 +21657,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v19 := r.Intn(10)
-		this.Field3 = make([]int32, v19)
-		for i := 0; i < v19; i++ {
+		vAlue19 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue19)
+		for i := 0; i < vAlue19; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -21667,9 +21667,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(10)
-		this.Field4 = make([]int64, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -21677,23 +21677,23 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
-		this.Field5 = make([]uint32, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v22 := r.Intn(10)
-		this.Field6 = make([]uint64, v22)
-		for i := 0; i < v22; i++ {
+		vAlue22 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue22)
+		for i := 0; i < vAlue22; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
-		this.Field7 = make([]int32, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -21701,9 +21701,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
-		this.Field8 = make([]int64, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -21711,16 +21711,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
-		this.Field9 = make([]uint32, v25)
-		for i := 0; i < v25; i++ {
+		vAlue25 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue25)
+		for i := 0; i < vAlue25; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v26 := r.Intn(10)
-		this.Field10 = make([]int32, v26)
-		for i := 0; i < v26; i++ {
+		vAlue26 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue26)
+		for i := 0; i < vAlue26; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -21728,16 +21728,16 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(10)
-		this.Field11 = make([]uint64, v27)
-		for i := 0; i < v27; i++ {
+		vAlue27 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue27)
+		for i := 0; i < vAlue27; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v28 := r.Intn(10)
-		this.Field12 = make([]int64, v28)
-		for i := 0; i < v28; i++ {
+		vAlue28 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue28)
+		for i := 0; i < vAlue28; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -21745,26 +21745,26 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(10)
-		this.Field13 = make([]bool, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(10)
-		this.Field14 = make([]string, v30)
-		for i := 0; i < v30; i++ {
+		vAlue30 := r.Intn(10)
+		this.Field14 = make([]string, vAlue30)
+		for i := 0; i < vAlue30; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v31 := r.Intn(10)
-		this.Field15 = make([][]byte, v31)
-		for i := 0; i < v31; i++ {
-			v32 := r.Intn(100)
-			this.Field15[i] = make([]byte, v32)
-			for j := 0; j < v32; j++ {
+		vAlue31 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue31)
+		for i := 0; i < vAlue31; i++ {
+			vAlue32 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue32)
+			for j := 0; j < vAlue32; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -21778,9 +21778,9 @@ func NewPopulatedNidRepNative(r randyThetest, easy bool) *NidRepNative {
 func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 	this := &NinRepNative{}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(10)
-		this.Field1 = make([]float64, v33)
-		for i := 0; i < v33; i++ {
+		vAlue33 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue33)
+		for i := 0; i < vAlue33; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -21788,9 +21788,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v34 := r.Intn(10)
-		this.Field2 = make([]float32, v34)
-		for i := 0; i < v34; i++ {
+		vAlue34 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue34)
+		for i := 0; i < vAlue34; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -21798,9 +21798,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(10)
-		this.Field3 = make([]int32, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -21808,9 +21808,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(10)
-		this.Field4 = make([]int64, v36)
-		for i := 0; i < v36; i++ {
+		vAlue36 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue36)
+		for i := 0; i < vAlue36; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -21818,23 +21818,23 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v37 := r.Intn(10)
-		this.Field5 = make([]uint32, v37)
-		for i := 0; i < v37; i++ {
+		vAlue37 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue37)
+		for i := 0; i < vAlue37; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(10)
-		this.Field6 = make([]uint64, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(10)
-		this.Field7 = make([]int32, v39)
-		for i := 0; i < v39; i++ {
+		vAlue39 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue39)
+		for i := 0; i < vAlue39; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -21842,9 +21842,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v40 := r.Intn(10)
-		this.Field8 = make([]int64, v40)
-		for i := 0; i < v40; i++ {
+		vAlue40 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue40)
+		for i := 0; i < vAlue40; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -21852,16 +21852,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(10)
-		this.Field9 = make([]uint32, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(10)
-		this.Field10 = make([]int32, v42)
-		for i := 0; i < v42; i++ {
+		vAlue42 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue42)
+		for i := 0; i < vAlue42; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -21869,16 +21869,16 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v43 := r.Intn(10)
-		this.Field11 = make([]uint64, v43)
-		for i := 0; i < v43; i++ {
+		vAlue43 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue43)
+		for i := 0; i < vAlue43; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(10)
-		this.Field12 = make([]int64, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -21886,26 +21886,26 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(10)
-		this.Field13 = make([]bool, v45)
-		for i := 0; i < v45; i++ {
+		vAlue45 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue45)
+		for i := 0; i < vAlue45; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v46 := r.Intn(10)
-		this.Field14 = make([]string, v46)
-		for i := 0; i < v46; i++ {
+		vAlue46 := r.Intn(10)
+		this.Field14 = make([]string, vAlue46)
+		for i := 0; i < vAlue46; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(10)
-		this.Field15 = make([][]byte, v47)
-		for i := 0; i < v47; i++ {
-			v48 := r.Intn(100)
-			this.Field15[i] = make([]byte, v48)
-			for j := 0; j < v48; j++ {
+		vAlue47 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue47)
+		for i := 0; i < vAlue47; i++ {
+			vAlue48 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue48)
+			for j := 0; j < vAlue48; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -21919,9 +21919,9 @@ func NewPopulatedNinRepNative(r randyThetest, easy bool) *NinRepNative {
 func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNative {
 	this := &NidRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v49 := r.Intn(10)
-		this.Field1 = make([]float64, v49)
-		for i := 0; i < v49; i++ {
+		vAlue49 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue49)
+		for i := 0; i < vAlue49; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -21929,9 +21929,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(10)
-		this.Field2 = make([]float32, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -21939,9 +21939,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(10)
-		this.Field3 = make([]int32, v51)
-		for i := 0; i < v51; i++ {
+		vAlue51 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue51)
+		for i := 0; i < vAlue51; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -21949,9 +21949,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v52 := r.Intn(10)
-		this.Field4 = make([]int64, v52)
-		for i := 0; i < v52; i++ {
+		vAlue52 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue52)
+		for i := 0; i < vAlue52; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -21959,23 +21959,23 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(10)
-		this.Field5 = make([]uint32, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(10)
-		this.Field6 = make([]uint64, v54)
-		for i := 0; i < v54; i++ {
+		vAlue54 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue54)
+		for i := 0; i < vAlue54; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v55 := r.Intn(10)
-		this.Field7 = make([]int32, v55)
-		for i := 0; i < v55; i++ {
+		vAlue55 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue55)
+		for i := 0; i < vAlue55; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -21983,9 +21983,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(10)
-		this.Field8 = make([]int64, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -21993,16 +21993,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(10)
-		this.Field9 = make([]uint32, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(10)
-		this.Field10 = make([]int32, v58)
-		for i := 0; i < v58; i++ {
+		vAlue58 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue58)
+		for i := 0; i < vAlue58; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -22010,16 +22010,16 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v59 := r.Intn(10)
-		this.Field11 = make([]uint64, v59)
-		for i := 0; i < v59; i++ {
+		vAlue59 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue59)
+		for i := 0; i < vAlue59; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(10)
-		this.Field12 = make([]int64, v60)
-		for i := 0; i < v60; i++ {
+		vAlue60 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue60)
+		for i := 0; i < vAlue60; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -22027,9 +22027,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v61 := r.Intn(10)
-		this.Field13 = make([]bool, v61)
-		for i := 0; i < v61; i++ {
+		vAlue61 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue61)
+		for i := 0; i < vAlue61; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -22042,9 +22042,9 @@ func NewPopulatedNidRepPackedNative(r randyThetest, easy bool) *NidRepPackedNati
 func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNative {
 	this := &NinRepPackedNative{}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(10)
-		this.Field1 = make([]float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -22052,9 +22052,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(10)
-		this.Field2 = make([]float32, v63)
-		for i := 0; i < v63; i++ {
+		vAlue63 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue63)
+		for i := 0; i < vAlue63; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -22062,9 +22062,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v64 := r.Intn(10)
-		this.Field3 = make([]int32, v64)
-		for i := 0; i < v64; i++ {
+		vAlue64 := r.Intn(10)
+		this.Field3 = make([]int32, vAlue64)
+		for i := 0; i < vAlue64; i++ {
 			this.Field3[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -22072,9 +22072,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(10)
-		this.Field4 = make([]int64, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(10)
+		this.Field4 = make([]int64, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.Field4[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field4[i] *= -1
@@ -22082,23 +22082,23 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(10)
-		this.Field5 = make([]uint32, v66)
-		for i := 0; i < v66; i++ {
+		vAlue66 := r.Intn(10)
+		this.Field5 = make([]uint32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
 			this.Field5[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v67 := r.Intn(10)
-		this.Field6 = make([]uint64, v67)
-		for i := 0; i < v67; i++ {
+		vAlue67 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue67)
+		for i := 0; i < vAlue67; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(10)
-		this.Field7 = make([]int32, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -22106,9 +22106,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(10)
-		this.Field8 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
+		vAlue69 := r.Intn(10)
+		this.Field8 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
 			this.Field8[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field8[i] *= -1
@@ -22116,16 +22116,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v70 := r.Intn(10)
-		this.Field9 = make([]uint32, v70)
-		for i := 0; i < v70; i++ {
+		vAlue70 := r.Intn(10)
+		this.Field9 = make([]uint32, vAlue70)
+		for i := 0; i < vAlue70; i++ {
 			this.Field9[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(10)
-		this.Field10 = make([]int32, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(10)
+		this.Field10 = make([]int32, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.Field10[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field10[i] *= -1
@@ -22133,16 +22133,16 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(10)
-		this.Field11 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
+		vAlue72 := r.Intn(10)
+		this.Field11 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
 			this.Field11[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v73 := r.Intn(10)
-		this.Field12 = make([]int64, v73)
-		for i := 0; i < v73; i++ {
+		vAlue73 := r.Intn(10)
+		this.Field12 = make([]int64, vAlue73)
+		for i := 0; i < vAlue73; i++ {
 			this.Field12[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.Field12[i] *= -1
@@ -22150,9 +22150,9 @@ func NewPopulatedNinRepPackedNative(r randyThetest, easy bool) *NinRepPackedNati
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(10)
-		this.Field13 = make([]bool, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
@@ -22172,22 +22172,22 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 	if r.Intn(2) == 0 {
 		this.Field2 *= -1
 	}
-	v75 := NewPopulatedNidOptNative(r, easy)
-	this.Field3 = *v75
-	v76 := NewPopulatedNinOptNative(r, easy)
-	this.Field4 = *v76
+	vAlue75 := NewPopulatedNidOptNative(r, easy)
+	this.Field3 = *vAlue75
+	vAlue76 := NewPopulatedNinOptNative(r, easy)
+	this.Field4 = *vAlue76
 	this.Field6 = uint64(uint64(r.Uint32()))
 	this.Field7 = int32(r.Int31())
 	if r.Intn(2) == 0 {
 		this.Field7 *= -1
 	}
-	v77 := NewPopulatedNidOptNative(r, easy)
-	this.Field8 = *v77
+	vAlue77 := NewPopulatedNidOptNative(r, easy)
+	this.Field8 = *vAlue77
 	this.Field13 = bool(bool(r.Intn(2) == 0))
 	this.Field14 = string(randStringThetest(r))
-	v78 := r.Intn(100)
-	this.Field15 = make([]byte, v78)
-	for i := 0; i < v78; i++ {
+	vAlue78 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue78)
+	for i := 0; i < vAlue78; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22199,18 +22199,18 @@ func NewPopulatedNidOptStruct(r randyThetest, easy bool) *NidOptStruct {
 func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 	this := &NinOptStruct{}
 	if r.Intn(5) != 0 {
-		v79 := float64(r.Float64())
+		vAlue79 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v79 *= -1
+			vAlue79 *= -1
 		}
-		this.Field1 = &v79
+		this.Field1 = &vAlue79
 	}
 	if r.Intn(5) != 0 {
-		v80 := float32(r.Float32())
+		vAlue80 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v80 *= -1
+			vAlue80 *= -1
 		}
-		this.Field2 = &v80
+		this.Field2 = &vAlue80
 	}
 	if r.Intn(5) != 0 {
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
@@ -22219,31 +22219,31 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v81 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v81
+		vAlue81 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue81
 	}
 	if r.Intn(5) != 0 {
-		v82 := int32(r.Int31())
+		vAlue82 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v82 *= -1
+			vAlue82 *= -1
 		}
-		this.Field7 = &v82
+		this.Field7 = &vAlue82
 	}
 	if r.Intn(5) != 0 {
 		this.Field8 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v83 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v83
+		vAlue83 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue83
 	}
 	if r.Intn(5) != 0 {
-		v84 := string(randStringThetest(r))
-		this.Field14 = &v84
+		vAlue84 := string(randStringThetest(r))
+		this.Field14 = &vAlue84
 	}
 	if r.Intn(5) != 0 {
-		v85 := r.Intn(100)
-		this.Field15 = make([]byte, v85)
-		for i := 0; i < v85; i++ {
+		vAlue85 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue85)
+		for i := 0; i < vAlue85; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -22256,9 +22256,9 @@ func NewPopulatedNinOptStruct(r randyThetest, easy bool) *NinOptStruct {
 func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 	this := &NidRepStruct{}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(10)
-		this.Field1 = make([]float64, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -22266,9 +22266,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(10)
-		this.Field2 = make([]float32, v87)
-		for i := 0; i < v87; i++ {
+		vAlue87 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue87)
+		for i := 0; i < vAlue87; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -22276,32 +22276,32 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v88 := r.Intn(5)
-		this.Field3 = make([]NidOptNative, v88)
-		for i := 0; i < v88; i++ {
-			v89 := NewPopulatedNidOptNative(r, easy)
-			this.Field3[i] = *v89
+		vAlue88 := r.Intn(5)
+		this.Field3 = make([]NidOptNative, vAlue88)
+		for i := 0; i < vAlue88; i++ {
+			vAlue89 := NewPopulatedNidOptNative(r, easy)
+			this.Field3[i] = *vAlue89
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(5)
-		this.Field4 = make([]NinOptNative, v90)
-		for i := 0; i < v90; i++ {
-			v91 := NewPopulatedNinOptNative(r, easy)
-			this.Field4[i] = *v91
+		vAlue90 := r.Intn(5)
+		this.Field4 = make([]NinOptNative, vAlue90)
+		for i := 0; i < vAlue90; i++ {
+			vAlue91 := NewPopulatedNinOptNative(r, easy)
+			this.Field4[i] = *vAlue91
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
-		this.Field6 = make([]uint64, v92)
-		for i := 0; i < v92; i++ {
+		vAlue92 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue92)
+		for i := 0; i < vAlue92; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
-		this.Field7 = make([]int32, v93)
-		for i := 0; i < v93; i++ {
+		vAlue93 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue93)
+		for i := 0; i < vAlue93; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -22309,34 +22309,34 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(5)
-		this.Field8 = make([]NidOptNative, v94)
-		for i := 0; i < v94; i++ {
-			v95 := NewPopulatedNidOptNative(r, easy)
-			this.Field8[i] = *v95
+		vAlue94 := r.Intn(5)
+		this.Field8 = make([]NidOptNative, vAlue94)
+		for i := 0; i < vAlue94; i++ {
+			vAlue95 := NewPopulatedNidOptNative(r, easy)
+			this.Field8[i] = *vAlue95
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
-		this.Field13 = make([]bool, v96)
-		for i := 0; i < v96; i++ {
+		vAlue96 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue96)
+		for i := 0; i < vAlue96; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
-		this.Field14 = make([]string, v97)
-		for i := 0; i < v97; i++ {
+		vAlue97 := r.Intn(10)
+		this.Field14 = make([]string, vAlue97)
+		for i := 0; i < vAlue97; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
-		this.Field15 = make([][]byte, v98)
-		for i := 0; i < v98; i++ {
-			v99 := r.Intn(100)
-			this.Field15[i] = make([]byte, v99)
-			for j := 0; j < v99; j++ {
+		vAlue98 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue98)
+		for i := 0; i < vAlue98; i++ {
+			vAlue99 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue99)
+			for j := 0; j < vAlue99; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -22350,9 +22350,9 @@ func NewPopulatedNidRepStruct(r randyThetest, easy bool) *NidRepStruct {
 func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 	this := &NinRepStruct{}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
-		this.Field1 = make([]float64, v100)
-		for i := 0; i < v100; i++ {
+		vAlue100 := r.Intn(10)
+		this.Field1 = make([]float64, vAlue100)
+		for i := 0; i < vAlue100; i++ {
 			this.Field1[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field1[i] *= -1
@@ -22360,9 +22360,9 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
-		this.Field2 = make([]float32, v101)
-		for i := 0; i < v101; i++ {
+		vAlue101 := r.Intn(10)
+		this.Field2 = make([]float32, vAlue101)
+		for i := 0; i < vAlue101; i++ {
 			this.Field2[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -22370,30 +22370,30 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(5)
-		this.Field3 = make([]*NidOptNative, v102)
-		for i := 0; i < v102; i++ {
+		vAlue102 := r.Intn(5)
+		this.Field3 = make([]*NidOptNative, vAlue102)
+		for i := 0; i < vAlue102; i++ {
 			this.Field3[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(5)
-		this.Field4 = make([]*NinOptNative, v103)
-		for i := 0; i < v103; i++ {
+		vAlue103 := r.Intn(5)
+		this.Field4 = make([]*NinOptNative, vAlue103)
+		for i := 0; i < vAlue103; i++ {
 			this.Field4[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
-		this.Field6 = make([]uint64, v104)
-		for i := 0; i < v104; i++ {
+		vAlue104 := r.Intn(10)
+		this.Field6 = make([]uint64, vAlue104)
+		for i := 0; i < vAlue104; i++ {
 			this.Field6[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
-		this.Field7 = make([]int32, v105)
-		for i := 0; i < v105; i++ {
+		vAlue105 := r.Intn(10)
+		this.Field7 = make([]int32, vAlue105)
+		for i := 0; i < vAlue105; i++ {
 			this.Field7[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -22401,33 +22401,33 @@ func NewPopulatedNinRepStruct(r randyThetest, easy bool) *NinRepStruct {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(5)
-		this.Field8 = make([]*NidOptNative, v106)
-		for i := 0; i < v106; i++ {
+		vAlue106 := r.Intn(5)
+		this.Field8 = make([]*NidOptNative, vAlue106)
+		for i := 0; i < vAlue106; i++ {
 			this.Field8[i] = NewPopulatedNidOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
-		this.Field13 = make([]bool, v107)
-		for i := 0; i < v107; i++ {
+		vAlue107 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue107)
+		for i := 0; i < vAlue107; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
-		this.Field14 = make([]string, v108)
-		for i := 0; i < v108; i++ {
+		vAlue108 := r.Intn(10)
+		this.Field14 = make([]string, vAlue108)
+		for i := 0; i < vAlue108; i++ {
 			this.Field14[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
-		this.Field15 = make([][]byte, v109)
-		for i := 0; i < v109; i++ {
-			v110 := r.Intn(100)
-			this.Field15[i] = make([]byte, v110)
-			for j := 0; j < v110; j++ {
+		vAlue109 := r.Intn(10)
+		this.Field15 = make([][]byte, vAlue109)
+		for i := 0; i < vAlue109; i++ {
+			vAlue110 := r.Intn(100)
+			this.Field15[i] = make([]byte, vAlue110)
+			for j := 0; j < vAlue110; j++ {
 				this.Field15[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -22443,8 +22443,8 @@ func NewPopulatedNidEmbeddedStruct(r randyThetest, easy bool) *NidEmbeddedStruct
 	if r.Intn(5) != 0 {
 		this.NidOptNative = NewPopulatedNidOptNative(r, easy)
 	}
-	v111 := NewPopulatedNidOptNative(r, easy)
-	this.Field200 = *v111
+	vAlue111 := NewPopulatedNidOptNative(r, easy)
+	this.Field200 = *vAlue111
 	this.Field210 = bool(bool(r.Intn(2) == 0))
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -22461,8 +22461,8 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 		this.Field200 = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v112 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v112
+		vAlue112 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue112
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 211)
@@ -22472,14 +22472,14 @@ func NewPopulatedNinEmbeddedStruct(r randyThetest, easy bool) *NinEmbeddedStruct
 
 func NewPopulatedNidNestedStruct(r randyThetest, easy bool) *NidNestedStruct {
 	this := &NidNestedStruct{}
-	v113 := NewPopulatedNidOptStruct(r, easy)
-	this.Field1 = *v113
+	vAlue113 := NewPopulatedNidOptStruct(r, easy)
+	this.Field1 = *vAlue113
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(5)
-		this.Field2 = make([]NidRepStruct, v114)
-		for i := 0; i < v114; i++ {
-			v115 := NewPopulatedNidRepStruct(r, easy)
-			this.Field2[i] = *v115
+		vAlue114 := r.Intn(5)
+		this.Field2 = make([]NidRepStruct, vAlue114)
+		for i := 0; i < vAlue114; i++ {
+			vAlue115 := NewPopulatedNidRepStruct(r, easy)
+			this.Field2[i] = *vAlue115
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22494,9 +22494,9 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 		this.Field1 = NewPopulatedNinOptStruct(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(5)
-		this.Field2 = make([]*NinRepStruct, v116)
-		for i := 0; i < v116; i++ {
+		vAlue116 := r.Intn(5)
+		this.Field2 = make([]*NinRepStruct, vAlue116)
+		for i := 0; i < vAlue116; i++ {
 			this.Field2[i] = NewPopulatedNinRepStruct(r, easy)
 		}
 	}
@@ -22508,10 +22508,10 @@ func NewPopulatedNinNestedStruct(r randyThetest, easy bool) *NinNestedStruct {
 
 func NewPopulatedNidOptCustom(r randyThetest, easy bool) *NidOptCustom {
 	this := &NidOptCustom{}
-	v117 := NewPopulatedUuid(r)
-	this.Id = *v117
-	v118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-	this.Value = *v118
+	vAlue117 := NewPopulatedUuid(r)
+	this.Id = *vAlue117
+	vAlue118 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+	this.Value = *vAlue118
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22546,19 +22546,19 @@ func NewPopulatedNinOptCustom(r randyThetest, easy bool) *NinOptCustom {
 func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 	this := &NidRepCustom{}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
-		this.Id = make([]Uuid, v119)
-		for i := 0; i < v119; i++ {
-			v120 := NewPopulatedUuid(r)
-			this.Id[i] = *v120
+		vAlue119 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue119)
+		for i := 0; i < vAlue119; i++ {
+			vAlue120 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue120
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v121)
-		for i := 0; i < v121; i++ {
-			v122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v122
+		vAlue121 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue121)
+		for i := 0; i < vAlue121; i++ {
+			vAlue122 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue122
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22570,19 +22570,19 @@ func NewPopulatedNidRepCustom(r randyThetest, easy bool) *NidRepCustom {
 func NewPopulatedNinRepCustom(r randyThetest, easy bool) *NinRepCustom {
 	this := &NinRepCustom{}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
-		this.Id = make([]Uuid, v123)
-		for i := 0; i < v123; i++ {
-			v124 := NewPopulatedUuid(r)
-			this.Id[i] = *v124
+		vAlue123 := r.Intn(10)
+		this.Id = make([]Uuid, vAlue123)
+		for i := 0; i < vAlue123; i++ {
+			vAlue124 := NewPopulatedUuid(r)
+			this.Id[i] = *vAlue124
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
-		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, v125)
-		for i := 0; i < v125; i++ {
-			v126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.Value[i] = *v126
+		vAlue125 := r.Intn(10)
+		this.Value = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue125)
+		for i := 0; i < vAlue125; i++ {
+			vAlue126 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.Value[i] = *vAlue126
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22596,45 +22596,45 @@ func NewPopulatedNinOptNativeUnion(r randyThetest, easy bool) *NinOptNativeUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v127 := float64(r.Float64())
+		vAlue127 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v127 *= -1
+			vAlue127 *= -1
 		}
-		this.Field1 = &v127
+		this.Field1 = &vAlue127
 	case 1:
-		v128 := float32(r.Float32())
+		vAlue128 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v128 *= -1
+			vAlue128 *= -1
 		}
-		this.Field2 = &v128
+		this.Field2 = &vAlue128
 	case 2:
-		v129 := int32(r.Int31())
+		vAlue129 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v129 *= -1
+			vAlue129 *= -1
 		}
-		this.Field3 = &v129
+		this.Field3 = &vAlue129
 	case 3:
-		v130 := int64(r.Int63())
+		vAlue130 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v130 *= -1
+			vAlue130 *= -1
 		}
-		this.Field4 = &v130
+		this.Field4 = &vAlue130
 	case 4:
-		v131 := uint32(r.Uint32())
-		this.Field5 = &v131
+		vAlue131 := uint32(r.Uint32())
+		this.Field5 = &vAlue131
 	case 5:
-		v132 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v132
+		vAlue132 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue132
 	case 6:
-		v133 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v133
+		vAlue133 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue133
 	case 7:
-		v134 := string(randStringThetest(r))
-		this.Field14 = &v134
+		vAlue134 := string(randStringThetest(r))
+		this.Field14 = &vAlue134
 	case 8:
-		v135 := r.Intn(100)
-		this.Field15 = make([]byte, v135)
-		for i := 0; i < v135; i++ {
+		vAlue135 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue135)
+		for i := 0; i < vAlue135; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -22646,40 +22646,40 @@ func NewPopulatedNinOptStructUnion(r randyThetest, easy bool) *NinOptStructUnion
 	fieldNum := r.Intn(9)
 	switch fieldNum {
 	case 0:
-		v136 := float64(r.Float64())
+		vAlue136 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v136 *= -1
+			vAlue136 *= -1
 		}
-		this.Field1 = &v136
+		this.Field1 = &vAlue136
 	case 1:
-		v137 := float32(r.Float32())
+		vAlue137 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v137 *= -1
+			vAlue137 *= -1
 		}
-		this.Field2 = &v137
+		this.Field2 = &vAlue137
 	case 2:
 		this.Field3 = NewPopulatedNidOptNative(r, easy)
 	case 3:
 		this.Field4 = NewPopulatedNinOptNative(r, easy)
 	case 4:
-		v138 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v138
+		vAlue138 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue138
 	case 5:
-		v139 := int32(r.Int31())
+		vAlue139 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v139 *= -1
+			vAlue139 *= -1
 		}
-		this.Field7 = &v139
+		this.Field7 = &vAlue139
 	case 6:
-		v140 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v140
+		vAlue140 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue140
 	case 7:
-		v141 := string(randStringThetest(r))
-		this.Field14 = &v141
+		vAlue141 := string(randStringThetest(r))
+		this.Field14 = &vAlue141
 	case 8:
-		v142 := r.Intn(100)
-		this.Field15 = make([]byte, v142)
-		for i := 0; i < v142; i++ {
+		vAlue142 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue142)
+		for i := 0; i < vAlue142; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -22695,8 +22695,8 @@ func NewPopulatedNinEmbeddedStructUnion(r randyThetest, easy bool) *NinEmbeddedS
 	case 1:
 		this.Field200 = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v143 := bool(bool(r.Intn(2) == 0))
-		this.Field210 = &v143
+		vAlue143 := bool(bool(r.Intn(2) == 0))
+		this.Field210 = &vAlue143
 	}
 	return this
 }
@@ -22731,10 +22731,10 @@ func NewPopulatedTree(r randyThetest, easy bool) *Tree {
 
 func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 	this := &OrBranch{}
-	v144 := NewPopulatedTree(r, easy)
-	this.Left = *v144
-	v145 := NewPopulatedTree(r, easy)
-	this.Right = *v145
+	vAlue144 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue144
+	vAlue145 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue145
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22743,10 +22743,10 @@ func NewPopulatedOrBranch(r randyThetest, easy bool) *OrBranch {
 
 func NewPopulatedAndBranch(r randyThetest, easy bool) *AndBranch {
 	this := &AndBranch{}
-	v146 := NewPopulatedTree(r, easy)
-	this.Left = *v146
-	v147 := NewPopulatedTree(r, easy)
-	this.Right = *v147
+	vAlue146 := NewPopulatedTree(r, easy)
+	this.Left = *vAlue146
+	vAlue147 := NewPopulatedTree(r, easy)
+	this.Right = *vAlue147
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22782,8 +22782,8 @@ func NewPopulatedDeepTree(r randyThetest, easy bool) *DeepTree {
 
 func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 	this := &ADeepBranch{}
-	v148 := NewPopulatedDeepTree(r, easy)
-	this.Down = *v148
+	vAlue148 := NewPopulatedDeepTree(r, easy)
+	this.Down = *vAlue148
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22792,10 +22792,10 @@ func NewPopulatedADeepBranch(r randyThetest, easy bool) *ADeepBranch {
 
 func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 	this := &AndDeepBranch{}
-	v149 := NewPopulatedDeepTree(r, easy)
-	this.Left = *v149
-	v150 := NewPopulatedDeepTree(r, easy)
-	this.Right = *v150
+	vAlue149 := NewPopulatedDeepTree(r, easy)
+	this.Left = *vAlue149
+	vAlue150 := NewPopulatedDeepTree(r, easy)
+	this.Right = *vAlue150
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
 	}
@@ -22804,8 +22804,8 @@ func NewPopulatedAndDeepBranch(r randyThetest, easy bool) *AndDeepBranch {
 
 func NewPopulatedDeepLeaf(r randyThetest, easy bool) *DeepLeaf {
 	this := &DeepLeaf{}
-	v151 := NewPopulatedTree(r, easy)
-	this.Tree = *v151
+	vAlue151 := NewPopulatedTree(r, easy)
+	this.Tree = *vAlue151
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -22832,16 +22832,16 @@ func NewPopulatedNidOptEnum(r randyThetest, easy bool) *NidOptEnum {
 func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 	this := &NinOptEnum{}
 	if r.Intn(5) != 0 {
-		v152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v152
+		vAlue152 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue152
 	}
 	if r.Intn(5) != 0 {
-		v153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v153
+		vAlue153 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue153
 	}
 	if r.Intn(5) != 0 {
-		v154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v154
+		vAlue154 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue154
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22852,23 +22852,23 @@ func NewPopulatedNinOptEnum(r randyThetest, easy bool) *NinOptEnum {
 func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 	this := &NidRepEnum{}
 	if r.Intn(5) != 0 {
-		v155 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v155)
-		for i := 0; i < v155; i++ {
+		vAlue155 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue155)
+		for i := 0; i < vAlue155; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v156 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v156)
-		for i := 0; i < v156; i++ {
+		vAlue156 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue156)
+		for i := 0; i < vAlue156; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v157 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v157)
-		for i := 0; i < v157; i++ {
+		vAlue157 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue157)
+		for i := 0; i < vAlue157; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -22881,23 +22881,23 @@ func NewPopulatedNidRepEnum(r randyThetest, easy bool) *NidRepEnum {
 func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 	this := &NinRepEnum{}
 	if r.Intn(5) != 0 {
-		v158 := r.Intn(10)
-		this.Field1 = make([]TheTestEnum, v158)
-		for i := 0; i < v158; i++ {
+		vAlue158 := r.Intn(10)
+		this.Field1 = make([]TheTestEnum, vAlue158)
+		for i := 0; i < vAlue158; i++ {
 			this.Field1[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v159 := r.Intn(10)
-		this.Field2 = make([]YetAnotherTestEnum, v159)
-		for i := 0; i < v159; i++ {
+		vAlue159 := r.Intn(10)
+		this.Field2 = make([]YetAnotherTestEnum, vAlue159)
+		for i := 0; i < vAlue159; i++ {
 			this.Field2[i] = YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
 	if r.Intn(5) != 0 {
-		v160 := r.Intn(10)
-		this.Field3 = make([]YetYetAnotherTestEnum, v160)
-		for i := 0; i < v160; i++ {
+		vAlue160 := r.Intn(10)
+		this.Field3 = make([]YetYetAnotherTestEnum, vAlue160)
+		for i := 0; i < vAlue160; i++ {
 			this.Field3[i] = YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
 		}
 	}
@@ -22910,16 +22910,16 @@ func NewPopulatedNinRepEnum(r randyThetest, easy bool) *NinRepEnum {
 func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault {
 	this := &NinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.Field1 = &v161
+		vAlue161 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.Field1 = &vAlue161
 	}
 	if r.Intn(5) != 0 {
-		v162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v162
+		vAlue162 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue162
 	}
 	if r.Intn(5) != 0 {
-		v163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v163
+		vAlue163 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue163
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22930,16 +22930,16 @@ func NewPopulatedNinOptEnumDefault(r randyThetest, easy bool) *NinOptEnumDefault
 func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum {
 	this := &AnotherNinOptEnum{}
 	if r.Intn(5) != 0 {
-		v164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v164
+		vAlue164 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue164
 	}
 	if r.Intn(5) != 0 {
-		v165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v165
+		vAlue165 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue165
 	}
 	if r.Intn(5) != 0 {
-		v166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v166
+		vAlue166 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue166
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22950,16 +22950,16 @@ func NewPopulatedAnotherNinOptEnum(r randyThetest, easy bool) *AnotherNinOptEnum
 func NewPopulatedAnotherNinOptEnumDefault(r randyThetest, easy bool) *AnotherNinOptEnumDefault {
 	this := &AnotherNinOptEnumDefault{}
 	if r.Intn(5) != 0 {
-		v167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
-		this.Field1 = &v167
+		vAlue167 := AnotherTestEnum([]int32{10, 11}[r.Intn(2)])
+		this.Field1 = &vAlue167
 	}
 	if r.Intn(5) != 0 {
-		v168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field2 = &v168
+		vAlue168 := YetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field2 = &vAlue168
 	}
 	if r.Intn(5) != 0 {
-		v169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
-		this.Field3 = &v169
+		vAlue169 := YetYetAnotherTestEnum([]int32{0, 1}[r.Intn(2)])
+		this.Field3 = &vAlue169
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 4)
@@ -22977,9 +22977,9 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 	if r.Intn(2) == 0 {
 		this.Time2 *= -1
 	}
-	v170 := r.Intn(100)
-	this.Data = make([]byte, v170)
-	for i := 0; i < v170; i++ {
+	vAlue170 := r.Intn(100)
+	this.Data = make([]byte, vAlue170)
+	for i := 0; i < vAlue170; i++ {
 		this.Data[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -22991,11 +22991,11 @@ func NewPopulatedTimer(r randyThetest, easy bool) *Timer {
 func NewPopulatedMyExtendable(r randyThetest, easy bool) *MyExtendable {
 	this := &MyExtendable{}
 	if r.Intn(5) != 0 {
-		v171 := int64(r.Int63())
+		vAlue171 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v171 *= -1
+			vAlue171 *= -1
 		}
-		this.Field1 = &v171
+		this.Field1 = &vAlue171
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -23018,18 +23018,18 @@ func NewPopulatedMyExtendable(r randyThetest, easy bool) *MyExtendable {
 func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 	this := &OtherExtenable{}
 	if r.Intn(5) != 0 {
-		v172 := int64(r.Int63())
+		vAlue172 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v172 *= -1
+			vAlue172 *= -1
 		}
-		this.Field2 = &v172
+		this.Field2 = &vAlue172
 	}
 	if r.Intn(5) != 0 {
-		v173 := int64(r.Int63())
+		vAlue173 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v173 *= -1
+			vAlue173 *= -1
 		}
-		this.Field13 = &v173
+		this.Field13 = &vAlue173
 	}
 	if r.Intn(5) != 0 {
 		this.M = NewPopulatedMyExtendable(r, easy)
@@ -23062,15 +23062,15 @@ func NewPopulatedOtherExtenable(r randyThetest, easy bool) *OtherExtenable {
 func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 	this := &NestedDefinition{}
 	if r.Intn(5) != 0 {
-		v174 := int64(r.Int63())
+		vAlue174 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v174 *= -1
+			vAlue174 *= -1
 		}
-		this.Field1 = &v174
+		this.Field1 = &vAlue174
 	}
 	if r.Intn(5) != 0 {
-		v175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.EnumField = &v175
+		vAlue175 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.EnumField = &vAlue175
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -23087,8 +23087,8 @@ func NewPopulatedNestedDefinition(r randyThetest, easy bool) *NestedDefinition {
 func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *NestedDefinition_NestedMessage {
 	this := &NestedDefinition_NestedMessage{}
 	if r.Intn(5) != 0 {
-		v176 := uint64(uint64(r.Uint32()))
-		this.NestedField1 = &v176
+		vAlue176 := uint64(uint64(r.Uint32()))
+		this.NestedField1 = &vAlue176
 	}
 	if r.Intn(5) != 0 {
 		this.NNM = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
@@ -23102,8 +23102,8 @@ func NewPopulatedNestedDefinition_NestedMessage(r randyThetest, easy bool) *Nest
 func NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r randyThetest, easy bool) *NestedDefinition_NestedMessage_NestedNestedMsg {
 	this := &NestedDefinition_NestedMessage_NestedNestedMsg{}
 	if r.Intn(5) != 0 {
-		v177 := string(randStringThetest(r))
-		this.NestedNestedField1 = &v177
+		vAlue177 := string(randStringThetest(r))
+		this.NestedNestedField1 = &vAlue177
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 11)
@@ -23117,8 +23117,8 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 		this.A = NewPopulatedNestedDefinition_NestedMessage_NestedNestedMsg(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
-		this.B = &v178
+		vAlue178 := NestedDefinition_NestedEnum([]int32{1}[r.Intn(1)])
+		this.B = &vAlue178
 	}
 	if r.Intn(5) != 0 {
 		this.C = NewPopulatedNestedDefinition_NestedMessage(r, easy)
@@ -23132,89 +23132,89 @@ func NewPopulatedNestedScope(r randyThetest, easy bool) *NestedScope {
 func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDefault {
 	this := &NinOptNativeDefault{}
 	if r.Intn(5) != 0 {
-		v179 := float64(r.Float64())
+		vAlue179 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v179 *= -1
+			vAlue179 *= -1
 		}
-		this.Field1 = &v179
+		this.Field1 = &vAlue179
 	}
 	if r.Intn(5) != 0 {
-		v180 := float32(r.Float32())
+		vAlue180 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v180 *= -1
+			vAlue180 *= -1
 		}
-		this.Field2 = &v180
+		this.Field2 = &vAlue180
 	}
 	if r.Intn(5) != 0 {
-		v181 := int32(r.Int31())
+		vAlue181 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v181 *= -1
+			vAlue181 *= -1
 		}
-		this.Field3 = &v181
+		this.Field3 = &vAlue181
 	}
 	if r.Intn(5) != 0 {
-		v182 := int64(r.Int63())
+		vAlue182 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v182 *= -1
+			vAlue182 *= -1
 		}
-		this.Field4 = &v182
+		this.Field4 = &vAlue182
 	}
 	if r.Intn(5) != 0 {
-		v183 := uint32(r.Uint32())
-		this.Field5 = &v183
+		vAlue183 := uint32(r.Uint32())
+		this.Field5 = &vAlue183
 	}
 	if r.Intn(5) != 0 {
-		v184 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v184
+		vAlue184 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue184
 	}
 	if r.Intn(5) != 0 {
-		v185 := int32(r.Int31())
+		vAlue185 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v185 *= -1
+			vAlue185 *= -1
 		}
-		this.Field7 = &v185
+		this.Field7 = &vAlue185
 	}
 	if r.Intn(5) != 0 {
-		v186 := int64(r.Int63())
+		vAlue186 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v186 *= -1
+			vAlue186 *= -1
 		}
-		this.Field8 = &v186
+		this.Field8 = &vAlue186
 	}
 	if r.Intn(5) != 0 {
-		v187 := uint32(r.Uint32())
-		this.Field9 = &v187
+		vAlue187 := uint32(r.Uint32())
+		this.Field9 = &vAlue187
 	}
 	if r.Intn(5) != 0 {
-		v188 := int32(r.Int31())
+		vAlue188 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v188 *= -1
+			vAlue188 *= -1
 		}
-		this.Field10 = &v188
+		this.Field10 = &vAlue188
 	}
 	if r.Intn(5) != 0 {
-		v189 := uint64(uint64(r.Uint32()))
-		this.Field11 = &v189
+		vAlue189 := uint64(uint64(r.Uint32()))
+		this.Field11 = &vAlue189
 	}
 	if r.Intn(5) != 0 {
-		v190 := int64(r.Int63())
+		vAlue190 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v190 *= -1
+			vAlue190 *= -1
 		}
-		this.Field12 = &v190
+		this.Field12 = &vAlue190
 	}
 	if r.Intn(5) != 0 {
-		v191 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v191
+		vAlue191 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue191
 	}
 	if r.Intn(5) != 0 {
-		v192 := string(randStringThetest(r))
-		this.Field14 = &v192
+		vAlue192 := string(randStringThetest(r))
+		this.Field14 = &vAlue192
 	}
 	if r.Intn(5) != 0 {
-		v193 := r.Intn(100)
-		this.Field15 = make([]byte, v193)
-		for i := 0; i < v193; i++ {
+		vAlue193 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue193)
+		for i := 0; i < vAlue193; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -23226,8 +23226,8 @@ func NewPopulatedNinOptNativeDefault(r randyThetest, easy bool) *NinOptNativeDef
 
 func NewPopulatedCustomContainer(r randyThetest, easy bool) *CustomContainer {
 	this := &CustomContainer{}
-	v194 := NewPopulatedNidOptCustom(r, easy)
-	this.CustomStruct = *v194
+	vAlue194 := NewPopulatedNidOptCustom(r, easy)
+	this.CustomStruct = *vAlue194
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -23274,9 +23274,9 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 	}
 	this.FieldM = bool(bool(r.Intn(2) == 0))
 	this.FieldN = string(randStringThetest(r))
-	v195 := r.Intn(100)
-	this.FieldO = make([]byte, v195)
-	for i := 0; i < v195; i++ {
+	vAlue195 := r.Intn(100)
+	this.FieldO = make([]byte, vAlue195)
+	for i := 0; i < vAlue195; i++ {
 		this.FieldO[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23288,89 +23288,89 @@ func NewPopulatedCustomNameNidOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNinOptNative {
 	this := &CustomNameNinOptNative{}
 	if r.Intn(5) != 0 {
-		v196 := float64(r.Float64())
+		vAlue196 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v196 *= -1
+			vAlue196 *= -1
 		}
-		this.FieldA = &v196
+		this.FieldA = &vAlue196
 	}
 	if r.Intn(5) != 0 {
-		v197 := float32(r.Float32())
+		vAlue197 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v197 *= -1
+			vAlue197 *= -1
 		}
-		this.FieldB = &v197
+		this.FieldB = &vAlue197
 	}
 	if r.Intn(5) != 0 {
-		v198 := int32(r.Int31())
+		vAlue198 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v198 *= -1
+			vAlue198 *= -1
 		}
-		this.FieldC = &v198
+		this.FieldC = &vAlue198
 	}
 	if r.Intn(5) != 0 {
-		v199 := int64(r.Int63())
+		vAlue199 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v199 *= -1
+			vAlue199 *= -1
 		}
-		this.FieldD = &v199
+		this.FieldD = &vAlue199
 	}
 	if r.Intn(5) != 0 {
-		v200 := uint32(r.Uint32())
-		this.FieldE = &v200
+		vAlue200 := uint32(r.Uint32())
+		this.FieldE = &vAlue200
 	}
 	if r.Intn(5) != 0 {
-		v201 := uint64(uint64(r.Uint32()))
-		this.FieldF = &v201
+		vAlue201 := uint64(uint64(r.Uint32()))
+		this.FieldF = &vAlue201
 	}
 	if r.Intn(5) != 0 {
-		v202 := int32(r.Int31())
+		vAlue202 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v202 *= -1
+			vAlue202 *= -1
 		}
-		this.FieldG = &v202
+		this.FieldG = &vAlue202
 	}
 	if r.Intn(5) != 0 {
-		v203 := int64(r.Int63())
+		vAlue203 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v203 *= -1
+			vAlue203 *= -1
 		}
-		this.FieldH = &v203
+		this.FieldH = &vAlue203
 	}
 	if r.Intn(5) != 0 {
-		v204 := uint32(r.Uint32())
-		this.FieldI = &v204
+		vAlue204 := uint32(r.Uint32())
+		this.FieldI = &vAlue204
 	}
 	if r.Intn(5) != 0 {
-		v205 := int32(r.Int31())
+		vAlue205 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v205 *= -1
+			vAlue205 *= -1
 		}
-		this.FieldJ = &v205
+		this.FieldJ = &vAlue205
 	}
 	if r.Intn(5) != 0 {
-		v206 := uint64(uint64(r.Uint32()))
-		this.FieldK = &v206
+		vAlue206 := uint64(uint64(r.Uint32()))
+		this.FieldK = &vAlue206
 	}
 	if r.Intn(5) != 0 {
-		v207 := int64(r.Int63())
+		vAlue207 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v207 *= -1
+			vAlue207 *= -1
 		}
-		this.FielL = &v207
+		this.FielL = &vAlue207
 	}
 	if r.Intn(5) != 0 {
-		v208 := bool(bool(r.Intn(2) == 0))
-		this.FieldM = &v208
+		vAlue208 := bool(bool(r.Intn(2) == 0))
+		this.FieldM = &vAlue208
 	}
 	if r.Intn(5) != 0 {
-		v209 := string(randStringThetest(r))
-		this.FieldN = &v209
+		vAlue209 := string(randStringThetest(r))
+		this.FieldN = &vAlue209
 	}
 	if r.Intn(5) != 0 {
-		v210 := r.Intn(100)
-		this.FieldO = make([]byte, v210)
-		for i := 0; i < v210; i++ {
+		vAlue210 := r.Intn(100)
+		this.FieldO = make([]byte, vAlue210)
+		for i := 0; i < vAlue210; i++ {
 			this.FieldO[i] = byte(r.Intn(256))
 		}
 	}
@@ -23383,9 +23383,9 @@ func NewPopulatedCustomNameNinOptNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNinRepNative {
 	this := &CustomNameNinRepNative{}
 	if r.Intn(5) != 0 {
-		v211 := r.Intn(10)
-		this.FieldA = make([]float64, v211)
-		for i := 0; i < v211; i++ {
+		vAlue211 := r.Intn(10)
+		this.FieldA = make([]float64, vAlue211)
+		for i := 0; i < vAlue211; i++ {
 			this.FieldA[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.FieldA[i] *= -1
@@ -23393,9 +23393,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v212 := r.Intn(10)
-		this.FieldB = make([]float32, v212)
-		for i := 0; i < v212; i++ {
+		vAlue212 := r.Intn(10)
+		this.FieldB = make([]float32, vAlue212)
+		for i := 0; i < vAlue212; i++ {
 			this.FieldB[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.FieldB[i] *= -1
@@ -23403,9 +23403,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v213 := r.Intn(10)
-		this.FieldC = make([]int32, v213)
-		for i := 0; i < v213; i++ {
+		vAlue213 := r.Intn(10)
+		this.FieldC = make([]int32, vAlue213)
+		for i := 0; i < vAlue213; i++ {
 			this.FieldC[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldC[i] *= -1
@@ -23413,9 +23413,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v214 := r.Intn(10)
-		this.FieldD = make([]int64, v214)
-		for i := 0; i < v214; i++ {
+		vAlue214 := r.Intn(10)
+		this.FieldD = make([]int64, vAlue214)
+		for i := 0; i < vAlue214; i++ {
 			this.FieldD[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldD[i] *= -1
@@ -23423,23 +23423,23 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v215 := r.Intn(10)
-		this.FieldE = make([]uint32, v215)
-		for i := 0; i < v215; i++ {
+		vAlue215 := r.Intn(10)
+		this.FieldE = make([]uint32, vAlue215)
+		for i := 0; i < vAlue215; i++ {
 			this.FieldE[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v216 := r.Intn(10)
-		this.FieldF = make([]uint64, v216)
-		for i := 0; i < v216; i++ {
+		vAlue216 := r.Intn(10)
+		this.FieldF = make([]uint64, vAlue216)
+		for i := 0; i < vAlue216; i++ {
 			this.FieldF[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v217 := r.Intn(10)
-		this.FieldG = make([]int32, v217)
-		for i := 0; i < v217; i++ {
+		vAlue217 := r.Intn(10)
+		this.FieldG = make([]int32, vAlue217)
+		for i := 0; i < vAlue217; i++ {
 			this.FieldG[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldG[i] *= -1
@@ -23447,9 +23447,9 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v218 := r.Intn(10)
-		this.FieldH = make([]int64, v218)
-		for i := 0; i < v218; i++ {
+		vAlue218 := r.Intn(10)
+		this.FieldH = make([]int64, vAlue218)
+		for i := 0; i < vAlue218; i++ {
 			this.FieldH[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldH[i] *= -1
@@ -23457,16 +23457,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v219 := r.Intn(10)
-		this.FieldI = make([]uint32, v219)
-		for i := 0; i < v219; i++ {
+		vAlue219 := r.Intn(10)
+		this.FieldI = make([]uint32, vAlue219)
+		for i := 0; i < vAlue219; i++ {
 			this.FieldI[i] = uint32(r.Uint32())
 		}
 	}
 	if r.Intn(5) != 0 {
-		v220 := r.Intn(10)
-		this.FieldJ = make([]int32, v220)
-		for i := 0; i < v220; i++ {
+		vAlue220 := r.Intn(10)
+		this.FieldJ = make([]int32, vAlue220)
+		for i := 0; i < vAlue220; i++ {
 			this.FieldJ[i] = int32(r.Int31())
 			if r.Intn(2) == 0 {
 				this.FieldJ[i] *= -1
@@ -23474,16 +23474,16 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v221 := r.Intn(10)
-		this.FieldK = make([]uint64, v221)
-		for i := 0; i < v221; i++ {
+		vAlue221 := r.Intn(10)
+		this.FieldK = make([]uint64, vAlue221)
+		for i := 0; i < vAlue221; i++ {
 			this.FieldK[i] = uint64(uint64(r.Uint32()))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v222 := r.Intn(10)
-		this.FieldL = make([]int64, v222)
-		for i := 0; i < v222; i++ {
+		vAlue222 := r.Intn(10)
+		this.FieldL = make([]int64, vAlue222)
+		for i := 0; i < vAlue222; i++ {
 			this.FieldL[i] = int64(r.Int63())
 			if r.Intn(2) == 0 {
 				this.FieldL[i] *= -1
@@ -23491,26 +23491,26 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 		}
 	}
 	if r.Intn(5) != 0 {
-		v223 := r.Intn(10)
-		this.FieldM = make([]bool, v223)
-		for i := 0; i < v223; i++ {
+		vAlue223 := r.Intn(10)
+		this.FieldM = make([]bool, vAlue223)
+		for i := 0; i < vAlue223; i++ {
 			this.FieldM[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v224 := r.Intn(10)
-		this.FieldN = make([]string, v224)
-		for i := 0; i < v224; i++ {
+		vAlue224 := r.Intn(10)
+		this.FieldN = make([]string, vAlue224)
+		for i := 0; i < vAlue224; i++ {
 			this.FieldN[i] = string(randStringThetest(r))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v225 := r.Intn(10)
-		this.FieldO = make([][]byte, v225)
-		for i := 0; i < v225; i++ {
-			v226 := r.Intn(100)
-			this.FieldO[i] = make([]byte, v226)
-			for j := 0; j < v226; j++ {
+		vAlue225 := r.Intn(10)
+		this.FieldO = make([][]byte, vAlue225)
+		for i := 0; i < vAlue225; i++ {
+			vAlue226 := r.Intn(100)
+			this.FieldO[i] = make([]byte, vAlue226)
+			for j := 0; j < vAlue226; j++ {
 				this.FieldO[i][j] = byte(r.Intn(256))
 			}
 		}
@@ -23524,55 +23524,55 @@ func NewPopulatedCustomNameNinRepNative(r randyThetest, easy bool) *CustomNameNi
 func NewPopulatedCustomNameNinStruct(r randyThetest, easy bool) *CustomNameNinStruct {
 	this := &CustomNameNinStruct{}
 	if r.Intn(5) != 0 {
-		v227 := float64(r.Float64())
+		vAlue227 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v227 *= -1
+			vAlue227 *= -1
 		}
-		this.FieldA = &v227
+		this.FieldA = &vAlue227
 	}
 	if r.Intn(5) != 0 {
-		v228 := float32(r.Float32())
+		vAlue228 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v228 *= -1
+			vAlue228 *= -1
 		}
-		this.FieldB = &v228
+		this.FieldB = &vAlue228
 	}
 	if r.Intn(5) != 0 {
 		this.FieldC = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v229 := r.Intn(5)
-		this.FieldD = make([]*NinOptNative, v229)
-		for i := 0; i < v229; i++ {
+		vAlue229 := r.Intn(5)
+		this.FieldD = make([]*NinOptNative, vAlue229)
+		for i := 0; i < vAlue229; i++ {
 			this.FieldD[i] = NewPopulatedNinOptNative(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v230 := uint64(uint64(r.Uint32()))
-		this.FieldE = &v230
+		vAlue230 := uint64(uint64(r.Uint32()))
+		this.FieldE = &vAlue230
 	}
 	if r.Intn(5) != 0 {
-		v231 := int32(r.Int31())
+		vAlue231 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v231 *= -1
+			vAlue231 *= -1
 		}
-		this.FieldF = &v231
+		this.FieldF = &vAlue231
 	}
 	if r.Intn(5) != 0 {
 		this.FieldG = NewPopulatedNidOptNative(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v232 := bool(bool(r.Intn(2) == 0))
-		this.FieldH = &v232
+		vAlue232 := bool(bool(r.Intn(2) == 0))
+		this.FieldH = &vAlue232
 	}
 	if r.Intn(5) != 0 {
-		v233 := string(randStringThetest(r))
-		this.FieldI = &v233
+		vAlue233 := string(randStringThetest(r))
+		this.FieldI = &vAlue233
 	}
 	if r.Intn(5) != 0 {
-		v234 := r.Intn(100)
-		this.FieldJ = make([]byte, v234)
-		for i := 0; i < v234; i++ {
+		vAlue234 := r.Intn(100)
+		this.FieldJ = make([]byte, vAlue234)
+		for i := 0; i < vAlue234; i++ {
 			this.FieldJ[i] = byte(r.Intn(256))
 		}
 	}
@@ -23591,19 +23591,19 @@ func NewPopulatedCustomNameCustomType(r randyThetest, easy bool) *CustomNameCust
 		this.FieldB = github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
 	}
 	if r.Intn(5) != 0 {
-		v235 := r.Intn(10)
-		this.FieldC = make([]Uuid, v235)
-		for i := 0; i < v235; i++ {
-			v236 := NewPopulatedUuid(r)
-			this.FieldC[i] = *v236
+		vAlue235 := r.Intn(10)
+		this.FieldC = make([]Uuid, vAlue235)
+		for i := 0; i < vAlue235; i++ {
+			vAlue236 := NewPopulatedUuid(r)
+			this.FieldC[i] = *vAlue236
 		}
 	}
 	if r.Intn(5) != 0 {
-		v237 := r.Intn(10)
-		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, v237)
-		for i := 0; i < v237; i++ {
-			v238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
-			this.FieldD[i] = *v238
+		vAlue237 := r.Intn(10)
+		this.FieldD = make([]github_com_gogo_protobuf_test_custom.Uint128, vAlue237)
+		for i := 0; i < vAlue237; i++ {
+			vAlue238 := github_com_gogo_protobuf_test_custom.NewPopulatedUint128(r)
+			this.FieldD[i] = *vAlue238
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23621,8 +23621,8 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 	case 1:
 		this.FieldA = NewPopulatedNinOptNative(r, easy)
 	case 2:
-		v239 := bool(bool(r.Intn(2) == 0))
-		this.FieldB = &v239
+		vAlue239 := bool(bool(r.Intn(2) == 0))
+		this.FieldB = &vAlue239
 	}
 	return this
 }
@@ -23630,13 +23630,13 @@ func NewPopulatedCustomNameNinEmbeddedStructUnion(r randyThetest, easy bool) *Cu
 func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 	this := &CustomNameEnum{}
 	if r.Intn(5) != 0 {
-		v240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
-		this.FieldA = &v240
+		vAlue240 := TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
+		this.FieldA = &vAlue240
 	}
 	if r.Intn(5) != 0 {
-		v241 := r.Intn(10)
-		this.FieldB = make([]TheTestEnum, v241)
-		for i := 0; i < v241; i++ {
+		vAlue241 := r.Intn(10)
+		this.FieldB = make([]TheTestEnum, vAlue241)
+		for i := 0; i < vAlue241; i++ {
 			this.FieldB[i] = TheTestEnum([]int32{0, 1, 2}[r.Intn(3)])
 		}
 	}
@@ -23649,11 +23649,11 @@ func NewPopulatedCustomNameEnum(r randyThetest, easy bool) *CustomNameEnum {
 func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 	this := &NoExtensionsMap{}
 	if r.Intn(5) != 0 {
-		v242 := int64(r.Int63())
+		vAlue242 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v242 *= -1
+			vAlue242 *= -1
 		}
-		this.Field1 = &v242
+		this.Field1 = &vAlue242
 	}
 	if !easy && r.Intn(10) != 0 {
 		l := r.Intn(5)
@@ -23676,8 +23676,8 @@ func NewPopulatedNoExtensionsMap(r randyThetest, easy bool) *NoExtensionsMap {
 func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 	this := &Unrecognized{}
 	if r.Intn(5) != 0 {
-		v243 := string(randStringThetest(r))
-		this.Field1 = &v243
+		vAlue243 := string(randStringThetest(r))
+		this.Field1 = &vAlue243
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -23687,15 +23687,15 @@ func NewPopulatedUnrecognized(r randyThetest, easy bool) *Unrecognized {
 func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedWithInner {
 	this := &UnrecognizedWithInner{}
 	if r.Intn(5) != 0 {
-		v244 := r.Intn(5)
-		this.Embedded = make([]*UnrecognizedWithInner_Inner, v244)
-		for i := 0; i < v244; i++ {
+		vAlue244 := r.Intn(5)
+		this.Embedded = make([]*UnrecognizedWithInner_Inner, vAlue244)
+		for i := 0; i < vAlue244; i++ {
 			this.Embedded[i] = NewPopulatedUnrecognizedWithInner_Inner(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v245 := string(randStringThetest(r))
-		this.Field2 = &v245
+		vAlue245 := string(randStringThetest(r))
+		this.Field2 = &vAlue245
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -23706,8 +23706,8 @@ func NewPopulatedUnrecognizedWithInner(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *UnrecognizedWithInner_Inner {
 	this := &UnrecognizedWithInner_Inner{}
 	if r.Intn(5) != 0 {
-		v246 := uint32(r.Uint32())
-		this.Field1 = &v246
+		vAlue246 := uint32(r.Uint32())
+		this.Field1 = &vAlue246
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -23716,11 +23716,11 @@ func NewPopulatedUnrecognizedWithInner_Inner(r randyThetest, easy bool) *Unrecog
 
 func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedWithEmbed {
 	this := &UnrecognizedWithEmbed{}
-	v247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
-	this.UnrecognizedWithEmbed_Embedded = *v247
+	vAlue247 := NewPopulatedUnrecognizedWithEmbed_Embedded(r, easy)
+	this.UnrecognizedWithEmbed_Embedded = *vAlue247
 	if r.Intn(5) != 0 {
-		v248 := string(randStringThetest(r))
-		this.Field2 = &v248
+		vAlue248 := string(randStringThetest(r))
+		this.Field2 = &vAlue248
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 3)
@@ -23731,8 +23731,8 @@ func NewPopulatedUnrecognizedWithEmbed(r randyThetest, easy bool) *UnrecognizedW
 func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *UnrecognizedWithEmbed_Embedded {
 	this := &UnrecognizedWithEmbed_Embedded{}
 	if r.Intn(5) != 0 {
-		v249 := uint32(r.Uint32())
-		this.Field1 = &v249
+		vAlue249 := uint32(r.Uint32())
+		this.Field1 = &vAlue249
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -23742,13 +23742,13 @@ func NewPopulatedUnrecognizedWithEmbed_Embedded(r randyThetest, easy bool) *Unre
 func NewPopulatedNode(r randyThetest, easy bool) *Node {
 	this := &Node{}
 	if r.Intn(5) != 0 {
-		v250 := string(randStringThetest(r))
-		this.Label = &v250
+		vAlue250 := string(randStringThetest(r))
+		this.Label = &vAlue250
 	}
 	if r.Intn(5) == 0 {
-		v251 := r.Intn(5)
-		this.Children = make([]*Node, v251)
-		for i := 0; i < v251; i++ {
+		vAlue251 := r.Intn(5)
+		this.Children = make([]*Node, vAlue251)
+		for i := 0; i < vAlue251; i++ {
 			this.Children[i] = NewPopulatedNode(r, easy)
 		}
 	}
@@ -23771,8 +23771,8 @@ func NewPopulatedNonByteCustomType(r randyThetest, easy bool) *NonByteCustomType
 
 func NewPopulatedNidOptNonByteCustomType(r randyThetest, easy bool) *NidOptNonByteCustomType {
 	this := &NidOptNonByteCustomType{}
-	v252 := NewPopulatedT(r)
-	this.Field1 = *v252
+	vAlue252 := NewPopulatedT(r)
+	this.Field1 = *vAlue252
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
 	}
@@ -23793,11 +23793,11 @@ func NewPopulatedNinOptNonByteCustomType(r randyThetest, easy bool) *NinOptNonBy
 func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonByteCustomType {
 	this := &NidRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v253 := r.Intn(10)
-		this.Field1 = make([]T, v253)
-		for i := 0; i < v253; i++ {
-			v254 := NewPopulatedT(r)
-			this.Field1[i] = *v254
+		vAlue253 := r.Intn(10)
+		this.Field1 = make([]T, vAlue253)
+		for i := 0; i < vAlue253; i++ {
+			vAlue254 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue254
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23809,11 +23809,11 @@ func NewPopulatedNidRepNonByteCustomType(r randyThetest, easy bool) *NidRepNonBy
 func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonByteCustomType {
 	this := &NinRepNonByteCustomType{}
 	if r.Intn(5) != 0 {
-		v255 := r.Intn(10)
-		this.Field1 = make([]T, v255)
-		for i := 0; i < v255; i++ {
-			v256 := NewPopulatedT(r)
-			this.Field1[i] = *v256
+		vAlue255 := r.Intn(10)
+		this.Field1 = make([]T, vAlue255)
+		for i := 0; i < vAlue255; i++ {
+			vAlue256 := NewPopulatedT(r)
+			this.Field1[i] = *vAlue256
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -23825,8 +23825,8 @@ func NewPopulatedNinRepNonByteCustomType(r randyThetest, easy bool) *NinRepNonBy
 func NewPopulatedProtoType(r randyThetest, easy bool) *ProtoType {
 	this := &ProtoType{}
 	if r.Intn(5) != 0 {
-		v257 := string(randStringThetest(r))
-		this.Field2 = &v257
+		vAlue257 := string(randStringThetest(r))
+		this.Field2 = &vAlue257
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedThetest(r, 2)
@@ -23853,9 +23853,9 @@ func randUTF8RuneThetest(r randyThetest) rune {
 	return rune(ru + 61)
 }
 func randStringThetest(r randyThetest) string {
-	v258 := r.Intn(100)
-	tmps := make([]rune, v258)
-	for i := 0; i < v258; i++ {
+	vAlue258 := r.Intn(100)
+	tmps := make([]rune, vAlue258)
+	for i := 0; i < vAlue258; i++ {
 		tmps[i] = randUTF8RuneThetest(r)
 	}
 	return string(tmps)
@@ -23877,11 +23877,11 @@ func randFieldThetest(dAtA []byte, r randyThetest, fieldNumber int, wire int) []
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
-		v259 := r.Int63()
+		vAlue259 := r.Int63()
 		if r.Intn(2) == 0 {
-			v259 *= -1
+			vAlue259 *= -1
 		}
-		dAtA = encodeVarintPopulateThetest(dAtA, uint64(v259))
+		dAtA = encodeVarintPopulateThetest(dAtA, uint64(vAlue259))
 	case 1:
 		dAtA = encodeVarintPopulateThetest(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/typedecl/typedecl.pb.go
+++ b/test/typedecl/typedecl.pb.go
@@ -537,9 +537,9 @@ func randUTF8RuneTypedecl(r randyTypedecl) rune {
 	return rune(ru + 61)
 }
 func randStringTypedecl(r randyTypedecl) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneTypedecl(r)
 	}
 	return string(tmps)
@@ -561,11 +561,11 @@ func randFieldTypedecl(dAtA []byte, r randyTypedecl, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTypedecl(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateTypedecl(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateTypedecl(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateTypedecl(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/typedecl_all/typedeclall.pb.go
+++ b/test/typedecl_all/typedeclall.pb.go
@@ -537,9 +537,9 @@ func randUTF8RuneTypedeclall(r randyTypedeclall) rune {
 	return rune(ru + 61)
 }
 func randStringTypedeclall(r randyTypedeclall) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneTypedeclall(r)
 	}
 	return string(tmps)
@@ -561,11 +561,11 @@ func randFieldTypedeclall(dAtA []byte, r randyTypedeclall, fieldNumber int, wire
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTypedeclall(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateTypedeclall(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateTypedeclall(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateTypedeclall(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/types/combos/both/types.pb.go
+++ b/test/types/combos/both/types.pb.go
@@ -9327,28 +9327,28 @@ func NewPopulatedProtoTypes(r randyTypes, easy bool) *ProtoTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = types.NewPopulatedBytesValue(r, easy)
 	}
-	v1 := types.NewPopulatedTimestamp(r, easy)
-	this.Timestamp = *v1
-	v2 := types.NewPopulatedDuration(r, easy)
-	this.Duration = *v2
-	v3 := types.NewPopulatedDoubleValue(r, easy)
-	this.NonnullDouble = *v3
-	v4 := types.NewPopulatedFloatValue(r, easy)
-	this.NonnullFloat = *v4
-	v5 := types.NewPopulatedInt64Value(r, easy)
-	this.NonnullInt64 = *v5
-	v6 := types.NewPopulatedUInt64Value(r, easy)
-	this.NonnullUInt64 = *v6
-	v7 := types.NewPopulatedInt32Value(r, easy)
-	this.NonnullInt32 = *v7
-	v8 := types.NewPopulatedUInt32Value(r, easy)
-	this.NonnullUInt32 = *v8
-	v9 := types.NewPopulatedBoolValue(r, easy)
-	this.NonnullBool = *v9
-	v10 := types.NewPopulatedStringValue(r, easy)
-	this.NonnullString = *v10
-	v11 := types.NewPopulatedBytesValue(r, easy)
-	this.NonnullBytes = *v11
+	vAlue1 := types.NewPopulatedTimestamp(r, easy)
+	this.Timestamp = *vAlue1
+	vAlue2 := types.NewPopulatedDuration(r, easy)
+	this.Duration = *vAlue2
+	vAlue3 := types.NewPopulatedDoubleValue(r, easy)
+	this.NonnullDouble = *vAlue3
+	vAlue4 := types.NewPopulatedFloatValue(r, easy)
+	this.NonnullFloat = *vAlue4
+	vAlue5 := types.NewPopulatedInt64Value(r, easy)
+	this.NonnullInt64 = *vAlue5
+	vAlue6 := types.NewPopulatedUInt64Value(r, easy)
+	this.NonnullUInt64 = *vAlue6
+	vAlue7 := types.NewPopulatedInt32Value(r, easy)
+	this.NonnullInt32 = *vAlue7
+	vAlue8 := types.NewPopulatedUInt32Value(r, easy)
+	this.NonnullUInt32 = *vAlue8
+	vAlue9 := types.NewPopulatedBoolValue(r, easy)
+	this.NonnullBool = *vAlue9
+	vAlue10 := types.NewPopulatedStringValue(r, easy)
+	this.NonnullString = *vAlue10
+	vAlue11 := types.NewPopulatedBytesValue(r, easy)
+	this.NonnullBytes = *vAlue11
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -9390,28 +9390,28 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 	}
-	v12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-	this.Timestamp = *v12
-	v13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-	this.Duration = *v13
-	v14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-	this.NonnullDouble = *v14
-	v15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-	this.NonnullFloat = *v15
-	v16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-	this.NonnullInt64 = *v16
-	v17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-	this.NonnullUInt64 = *v17
-	v18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-	this.NonnullInt32 = *v18
-	v19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-	this.NonnullUInt32 = *v19
-	v20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-	this.NonnullBool = *v20
-	v21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-	this.NonnullString = *v21
-	v22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-	this.NonnullBytes = *v22
+	vAlue12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+	this.Timestamp = *vAlue12
+	vAlue13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+	this.Duration = *vAlue13
+	vAlue14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+	this.NonnullDouble = *vAlue14
+	vAlue15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+	this.NonnullFloat = *vAlue15
+	vAlue16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+	this.NonnullInt64 = *vAlue16
+	vAlue17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+	this.NonnullUInt64 = *vAlue17
+	vAlue18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+	this.NonnullInt32 = *vAlue18
+	vAlue19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+	this.NonnullUInt32 = *vAlue19
+	vAlue20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+	this.NonnullBool = *vAlue20
+	vAlue21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+	this.NonnullString = *vAlue21
+	vAlue22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+	this.NonnullBytes = *vAlue22
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -9421,168 +9421,168 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 	this := &RepProtoTypes{}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(5)
-		this.NullableTimestamps = make([]*types.Timestamp, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(5)
+		this.NullableTimestamps = make([]*types.Timestamp, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.NullableTimestamps[i] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(5)
-		this.NullableDurations = make([]*types.Duration, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(5)
+		this.NullableDurations = make([]*types.Duration, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.NullableDurations[i] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(5)
-		this.Timestamps = make([]types.Timestamp, v25)
-		for i := 0; i < v25; i++ {
-			v26 := types.NewPopulatedTimestamp(r, easy)
-			this.Timestamps[i] = *v26
+		vAlue25 := r.Intn(5)
+		this.Timestamps = make([]types.Timestamp, vAlue25)
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := types.NewPopulatedTimestamp(r, easy)
+			this.Timestamps[i] = *vAlue26
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(5)
-		this.Durations = make([]types.Duration, v27)
-		for i := 0; i < v27; i++ {
-			v28 := types.NewPopulatedDuration(r, easy)
-			this.Durations[i] = *v28
+		vAlue27 := r.Intn(5)
+		this.Durations = make([]types.Duration, vAlue27)
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := types.NewPopulatedDuration(r, easy)
+			this.Durations[i] = *vAlue28
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(5)
-		this.NullableDouble = make([]*types.DoubleValue, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(5)
+		this.NullableDouble = make([]*types.DoubleValue, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.NullableDouble[i] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(5)
-		this.NonnullDouble = make([]types.DoubleValue, v30)
-		for i := 0; i < v30; i++ {
-			v31 := types.NewPopulatedDoubleValue(r, easy)
-			this.NonnullDouble[i] = *v31
+		vAlue30 := r.Intn(5)
+		this.NonnullDouble = make([]types.DoubleValue, vAlue30)
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := types.NewPopulatedDoubleValue(r, easy)
+			this.NonnullDouble[i] = *vAlue31
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(5)
-		this.NullableFloat = make([]*types.FloatValue, v32)
-		for i := 0; i < v32; i++ {
+		vAlue32 := r.Intn(5)
+		this.NullableFloat = make([]*types.FloatValue, vAlue32)
+		for i := 0; i < vAlue32; i++ {
 			this.NullableFloat[i] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(5)
-		this.NonnullFloat = make([]types.FloatValue, v33)
-		for i := 0; i < v33; i++ {
-			v34 := types.NewPopulatedFloatValue(r, easy)
-			this.NonnullFloat[i] = *v34
+		vAlue33 := r.Intn(5)
+		this.NonnullFloat = make([]types.FloatValue, vAlue33)
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := types.NewPopulatedFloatValue(r, easy)
+			this.NonnullFloat[i] = *vAlue34
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(5)
-		this.NullableInt64 = make([]*types.Int64Value, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(5)
+		this.NullableInt64 = make([]*types.Int64Value, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.NullableInt64[i] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(5)
-		this.NonnullInt64 = make([]types.Int64Value, v36)
-		for i := 0; i < v36; i++ {
-			v37 := types.NewPopulatedInt64Value(r, easy)
-			this.NonnullInt64[i] = *v37
+		vAlue36 := r.Intn(5)
+		this.NonnullInt64 = make([]types.Int64Value, vAlue36)
+		for i := 0; i < vAlue36; i++ {
+			vAlue37 := types.NewPopulatedInt64Value(r, easy)
+			this.NonnullInt64[i] = *vAlue37
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(5)
-		this.NullableUInt64 = make([]*types.UInt64Value, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(5)
+		this.NullableUInt64 = make([]*types.UInt64Value, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.NullableUInt64[i] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(5)
-		this.NonnullUInt64 = make([]types.UInt64Value, v39)
-		for i := 0; i < v39; i++ {
-			v40 := types.NewPopulatedUInt64Value(r, easy)
-			this.NonnullUInt64[i] = *v40
+		vAlue39 := r.Intn(5)
+		this.NonnullUInt64 = make([]types.UInt64Value, vAlue39)
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := types.NewPopulatedUInt64Value(r, easy)
+			this.NonnullUInt64[i] = *vAlue40
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(5)
-		this.NullableInt32 = make([]*types.Int32Value, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(5)
+		this.NullableInt32 = make([]*types.Int32Value, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.NullableInt32[i] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(5)
-		this.NonnullInt32 = make([]types.Int32Value, v42)
-		for i := 0; i < v42; i++ {
-			v43 := types.NewPopulatedInt32Value(r, easy)
-			this.NonnullInt32[i] = *v43
+		vAlue42 := r.Intn(5)
+		this.NonnullInt32 = make([]types.Int32Value, vAlue42)
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := types.NewPopulatedInt32Value(r, easy)
+			this.NonnullInt32[i] = *vAlue43
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(5)
-		this.NullableUInt32 = make([]*types.UInt32Value, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(5)
+		this.NullableUInt32 = make([]*types.UInt32Value, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.NullableUInt32[i] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(5)
-		this.NonnullUInt32 = make([]types.UInt32Value, v45)
-		for i := 0; i < v45; i++ {
-			v46 := types.NewPopulatedUInt32Value(r, easy)
-			this.NonnullUInt32[i] = *v46
+		vAlue45 := r.Intn(5)
+		this.NonnullUInt32 = make([]types.UInt32Value, vAlue45)
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := types.NewPopulatedUInt32Value(r, easy)
+			this.NonnullUInt32[i] = *vAlue46
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(5)
-		this.NullableBool = make([]*types.BoolValue, v47)
-		for i := 0; i < v47; i++ {
+		vAlue47 := r.Intn(5)
+		this.NullableBool = make([]*types.BoolValue, vAlue47)
+		for i := 0; i < vAlue47; i++ {
 			this.NullableBool[i] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(5)
-		this.NonnullBool = make([]types.BoolValue, v48)
-		for i := 0; i < v48; i++ {
-			v49 := types.NewPopulatedBoolValue(r, easy)
-			this.NonnullBool[i] = *v49
+		vAlue48 := r.Intn(5)
+		this.NonnullBool = make([]types.BoolValue, vAlue48)
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := types.NewPopulatedBoolValue(r, easy)
+			this.NonnullBool[i] = *vAlue49
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(5)
-		this.NullableString = make([]*types.StringValue, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(5)
+		this.NullableString = make([]*types.StringValue, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.NullableString[i] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(5)
-		this.NonnullString = make([]types.StringValue, v51)
-		for i := 0; i < v51; i++ {
-			v52 := types.NewPopulatedStringValue(r, easy)
-			this.NonnullString[i] = *v52
+		vAlue51 := r.Intn(5)
+		this.NonnullString = make([]types.StringValue, vAlue51)
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := types.NewPopulatedStringValue(r, easy)
+			this.NonnullString[i] = *vAlue52
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(5)
-		this.NullableBytes = make([]*types.BytesValue, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(5)
+		this.NullableBytes = make([]*types.BytesValue, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.NullableBytes[i] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(5)
-		this.NonnullBytes = make([]types.BytesValue, v54)
-		for i := 0; i < v54; i++ {
-			v55 := types.NewPopulatedBytesValue(r, easy)
-			this.NonnullBytes[i] = *v55
+		vAlue54 := r.Intn(5)
+		this.NonnullBytes = make([]types.BytesValue, vAlue54)
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := types.NewPopulatedBytesValue(r, easy)
+			this.NonnullBytes[i] = *vAlue55
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -9594,168 +9594,168 @@ func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 	this := &RepStdTypes{}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(5)
-		this.NullableTimestamps = make([]*time.Time, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(5)
+		this.NullableTimestamps = make([]*time.Time, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.NullableTimestamps[i] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(5)
-		this.NullableDurations = make([]*time.Duration, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(5)
+		this.NullableDurations = make([]*time.Duration, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.NullableDurations[i] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(5)
-		this.Timestamps = make([]time.Time, v58)
-		for i := 0; i < v58; i++ {
-			v59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-			this.Timestamps[i] = *v59
+		vAlue58 := r.Intn(5)
+		this.Timestamps = make([]time.Time, vAlue58)
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+			this.Timestamps[i] = *vAlue59
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(5)
-		this.Durations = make([]time.Duration, v60)
-		for i := 0; i < v60; i++ {
-			v61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-			this.Durations[i] = *v61
+		vAlue60 := r.Intn(5)
+		this.Durations = make([]time.Duration, vAlue60)
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+			this.Durations[i] = *vAlue61
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(5)
-		this.NullableDouble = make([]*float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(5)
+		this.NullableDouble = make([]*float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.NullableDouble[i] = github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(5)
-		this.NonnullDouble = make([]float64, v63)
-		for i := 0; i < v63; i++ {
-			v64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-			this.NonnullDouble[i] = *v64
+		vAlue63 := r.Intn(5)
+		this.NonnullDouble = make([]float64, vAlue63)
+		for i := 0; i < vAlue63; i++ {
+			vAlue64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+			this.NonnullDouble[i] = *vAlue64
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(5)
-		this.NullableFloat = make([]*float32, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(5)
+		this.NullableFloat = make([]*float32, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.NullableFloat[i] = github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(5)
-		this.NonnullFloat = make([]float32, v66)
-		for i := 0; i < v66; i++ {
-			v67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-			this.NonnullFloat[i] = *v67
+		vAlue66 := r.Intn(5)
+		this.NonnullFloat = make([]float32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
+			vAlue67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+			this.NonnullFloat[i] = *vAlue67
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(5)
-		this.NullableInt64 = make([]*int64, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(5)
+		this.NullableInt64 = make([]*int64, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.NullableInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(5)
-		this.NonnullInt64 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
-			v70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-			this.NonnullInt64[i] = *v70
+		vAlue69 := r.Intn(5)
+		this.NonnullInt64 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
+			vAlue70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+			this.NonnullInt64[i] = *vAlue70
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(5)
-		this.NullableUInt64 = make([]*uint64, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(5)
+		this.NullableUInt64 = make([]*uint64, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.NullableUInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(5)
-		this.NonnullUInt64 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
-			v73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-			this.NonnullUInt64[i] = *v73
+		vAlue72 := r.Intn(5)
+		this.NonnullUInt64 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
+			vAlue73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+			this.NonnullUInt64[i] = *vAlue73
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(5)
-		this.NullableInt32 = make([]*int32, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(5)
+		this.NullableInt32 = make([]*int32, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.NullableInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(5)
-		this.NonnullInt32 = make([]int32, v75)
-		for i := 0; i < v75; i++ {
-			v76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-			this.NonnullInt32[i] = *v76
+		vAlue75 := r.Intn(5)
+		this.NonnullInt32 = make([]int32, vAlue75)
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+			this.NonnullInt32[i] = *vAlue76
 		}
 	}
 	if r.Intn(5) != 0 {
-		v77 := r.Intn(5)
-		this.NullableUInt32 = make([]*uint32, v77)
-		for i := 0; i < v77; i++ {
+		vAlue77 := r.Intn(5)
+		this.NullableUInt32 = make([]*uint32, vAlue77)
+		for i := 0; i < vAlue77; i++ {
 			this.NullableUInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v78 := r.Intn(5)
-		this.NonnullUInt32 = make([]uint32, v78)
-		for i := 0; i < v78; i++ {
-			v79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-			this.NonnullUInt32[i] = *v79
+		vAlue78 := r.Intn(5)
+		this.NonnullUInt32 = make([]uint32, vAlue78)
+		for i := 0; i < vAlue78; i++ {
+			vAlue79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+			this.NonnullUInt32[i] = *vAlue79
 		}
 	}
 	if r.Intn(5) != 0 {
-		v80 := r.Intn(5)
-		this.NullableBool = make([]*bool, v80)
-		for i := 0; i < v80; i++ {
+		vAlue80 := r.Intn(5)
+		this.NullableBool = make([]*bool, vAlue80)
+		for i := 0; i < vAlue80; i++ {
 			this.NullableBool[i] = github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v81 := r.Intn(5)
-		this.NonnullBool = make([]bool, v81)
-		for i := 0; i < v81; i++ {
-			v82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-			this.NonnullBool[i] = *v82
+		vAlue81 := r.Intn(5)
+		this.NonnullBool = make([]bool, vAlue81)
+		for i := 0; i < vAlue81; i++ {
+			vAlue82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+			this.NonnullBool[i] = *vAlue82
 		}
 	}
 	if r.Intn(5) != 0 {
-		v83 := r.Intn(5)
-		this.NullableString = make([]*string, v83)
-		for i := 0; i < v83; i++ {
+		vAlue83 := r.Intn(5)
+		this.NullableString = make([]*string, vAlue83)
+		for i := 0; i < vAlue83; i++ {
 			this.NullableString[i] = github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v84 := r.Intn(5)
-		this.NonnullString = make([]string, v84)
-		for i := 0; i < v84; i++ {
-			v85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-			this.NonnullString[i] = *v85
+		vAlue84 := r.Intn(5)
+		this.NonnullString = make([]string, vAlue84)
+		for i := 0; i < vAlue84; i++ {
+			vAlue85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+			this.NonnullString[i] = *vAlue85
 		}
 	}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(5)
-		this.NullableBytes = make([]*[]byte, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(5)
+		this.NullableBytes = make([]*[]byte, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.NullableBytes[i] = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(5)
-		this.NonnullBytes = make([][]byte, v87)
-		for i := 0; i < v87; i++ {
-			v88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-			this.NonnullBytes[i] = *v88
+		vAlue87 := r.Intn(5)
+		this.NonnullBytes = make([][]byte, vAlue87)
+		for i := 0; i < vAlue87; i++ {
+			vAlue88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+			this.NonnullBytes[i] = *vAlue88
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -9767,156 +9767,156 @@ func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 	this := &MapProtoTypes{}
 	if r.Intn(5) != 0 {
-		v89 := r.Intn(10)
+		vAlue89 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*types.Timestamp)
-		for i := 0; i < v89; i++ {
+		for i := 0; i < vAlue89; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(10)
+		vAlue90 := r.Intn(10)
 		this.Timestamp = make(map[int32]types.Timestamp)
-		for i := 0; i < v90; i++ {
+		for i := 0; i < vAlue90; i++ {
 			this.Timestamp[int32(r.Int31())] = *types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v91 := r.Intn(10)
+		vAlue91 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*types.Duration)
-		for i := 0; i < v91; i++ {
+		for i := 0; i < vAlue91; i++ {
 			this.NullableDuration[int32(r.Int31())] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
+		vAlue92 := r.Intn(10)
 		this.Duration = make(map[int32]types.Duration)
-		for i := 0; i < v92; i++ {
+		for i := 0; i < vAlue92; i++ {
 			this.Duration[int32(r.Int31())] = *types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
+		vAlue93 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*types.DoubleValue)
-		for i := 0; i < v93; i++ {
+		for i := 0; i < vAlue93; i++ {
 			this.NullableDouble[int32(r.Int31())] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(10)
+		vAlue94 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]types.DoubleValue)
-		for i := 0; i < v94; i++ {
+		for i := 0; i < vAlue94; i++ {
 			this.NonnullDouble[int32(r.Int31())] = *types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v95 := r.Intn(10)
+		vAlue95 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*types.FloatValue)
-		for i := 0; i < v95; i++ {
+		for i := 0; i < vAlue95; i++ {
 			this.NullableFloat[int32(r.Int31())] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
+		vAlue96 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]types.FloatValue)
-		for i := 0; i < v96; i++ {
+		for i := 0; i < vAlue96; i++ {
 			this.NonnullFloat[int32(r.Int31())] = *types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
+		vAlue97 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*types.Int64Value)
-		for i := 0; i < v97; i++ {
+		for i := 0; i < vAlue97; i++ {
 			this.NullableInt64[int32(r.Int31())] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
+		vAlue98 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]types.Int64Value)
-		for i := 0; i < v98; i++ {
+		for i := 0; i < vAlue98; i++ {
 			this.NonnullInt64[int32(r.Int31())] = *types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v99 := r.Intn(10)
+		vAlue99 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*types.UInt64Value)
-		for i := 0; i < v99; i++ {
+		for i := 0; i < vAlue99; i++ {
 			this.NullableUInt64[int32(r.Int31())] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
+		vAlue100 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]types.UInt64Value)
-		for i := 0; i < v100; i++ {
+		for i := 0; i < vAlue100; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = *types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
+		vAlue101 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*types.Int32Value)
-		for i := 0; i < v101; i++ {
+		for i := 0; i < vAlue101; i++ {
 			this.NullableInt32[int32(r.Int31())] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(10)
+		vAlue102 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]types.Int32Value)
-		for i := 0; i < v102; i++ {
+		for i := 0; i < vAlue102; i++ {
 			this.NonnullInt32[int32(r.Int31())] = *types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(10)
+		vAlue103 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*types.UInt32Value)
-		for i := 0; i < v103; i++ {
+		for i := 0; i < vAlue103; i++ {
 			this.NullableUInt32[int32(r.Int31())] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
+		vAlue104 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]types.UInt32Value)
-		for i := 0; i < v104; i++ {
+		for i := 0; i < vAlue104; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = *types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
+		vAlue105 := r.Intn(10)
 		this.NullableBool = make(map[int32]*types.BoolValue)
-		for i := 0; i < v105; i++ {
+		for i := 0; i < vAlue105; i++ {
 			this.NullableBool[int32(r.Int31())] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(10)
+		vAlue106 := r.Intn(10)
 		this.NonnullBool = make(map[int32]types.BoolValue)
-		for i := 0; i < v106; i++ {
+		for i := 0; i < vAlue106; i++ {
 			this.NonnullBool[int32(r.Int31())] = *types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
+		vAlue107 := r.Intn(10)
 		this.NullableString = make(map[int32]*types.StringValue)
-		for i := 0; i < v107; i++ {
+		for i := 0; i < vAlue107; i++ {
 			this.NullableString[int32(r.Int31())] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
+		vAlue108 := r.Intn(10)
 		this.NonnullString = make(map[int32]types.StringValue)
-		for i := 0; i < v108; i++ {
+		for i := 0; i < vAlue108; i++ {
 			this.NonnullString[int32(r.Int31())] = *types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
+		vAlue109 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*types.BytesValue)
-		for i := 0; i < v109; i++ {
+		for i := 0; i < vAlue109; i++ {
 			this.NullableBytes[int32(r.Int31())] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v110 := r.Intn(10)
+		vAlue110 := r.Intn(10)
 		this.NonnullBytes = make(map[int32]types.BytesValue)
-		for i := 0; i < v110; i++ {
+		for i := 0; i < vAlue110; i++ {
 			this.NonnullBytes[int32(r.Int31())] = *types.NewPopulatedBytesValue(r, easy)
 		}
 	}
@@ -9929,156 +9929,156 @@ func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 func NewPopulatedMapStdTypes(r randyTypes, easy bool) *MapStdTypes {
 	this := &MapStdTypes{}
 	if r.Intn(5) != 0 {
-		v111 := r.Intn(10)
+		vAlue111 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*time.Time)
-		for i := 0; i < v111; i++ {
+		for i := 0; i < vAlue111; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v112 := r.Intn(10)
+		vAlue112 := r.Intn(10)
 		this.Timestamp = make(map[int32]time.Time)
-		for i := 0; i < v112; i++ {
+		for i := 0; i < vAlue112; i++ {
 			this.Timestamp[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v113 := r.Intn(10)
+		vAlue113 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*time.Duration)
-		for i := 0; i < v113; i++ {
+		for i := 0; i < vAlue113; i++ {
 			this.NullableDuration[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(10)
+		vAlue114 := r.Intn(10)
 		this.Duration = make(map[int32]time.Duration)
-		for i := 0; i < v114; i++ {
+		for i := 0; i < vAlue114; i++ {
 			this.Duration[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v115 := r.Intn(10)
+		vAlue115 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*float64)
-		for i := 0; i < v115; i++ {
+		for i := 0; i < vAlue115; i++ {
 			this.NullableDouble[int32(r.Int31())] = (*float64)(github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(10)
+		vAlue116 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]float64)
-		for i := 0; i < v116; i++ {
+		for i := 0; i < vAlue116; i++ {
 			this.NonnullDouble[int32(r.Int31())] = (float64)(*github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v117 := r.Intn(10)
+		vAlue117 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*float32)
-		for i := 0; i < v117; i++ {
+		for i := 0; i < vAlue117; i++ {
 			this.NullableFloat[int32(r.Int31())] = (*float32)(github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v118 := r.Intn(10)
+		vAlue118 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]float32)
-		for i := 0; i < v118; i++ {
+		for i := 0; i < vAlue118; i++ {
 			this.NonnullFloat[int32(r.Int31())] = (float32)(*github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
+		vAlue119 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*int64)
-		for i := 0; i < v119; i++ {
+		for i := 0; i < vAlue119; i++ {
 			this.NullableInt64[int32(r.Int31())] = (*int64)(github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v120 := r.Intn(10)
+		vAlue120 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]int64)
-		for i := 0; i < v120; i++ {
+		for i := 0; i < vAlue120; i++ {
 			this.NonnullInt64[int32(r.Int31())] = (int64)(*github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
+		vAlue121 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*uint64)
-		for i := 0; i < v121; i++ {
+		for i := 0; i < vAlue121; i++ {
 			this.NullableUInt64[int32(r.Int31())] = (*uint64)(github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v122 := r.Intn(10)
+		vAlue122 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]uint64)
-		for i := 0; i < v122; i++ {
+		for i := 0; i < vAlue122; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = (uint64)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
+		vAlue123 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*int32)
-		for i := 0; i < v123; i++ {
+		for i := 0; i < vAlue123; i++ {
 			this.NullableInt32[int32(r.Int31())] = (*int32)(github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v124 := r.Intn(10)
+		vAlue124 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]int32)
-		for i := 0; i < v124; i++ {
+		for i := 0; i < vAlue124; i++ {
 			this.NonnullInt32[int32(r.Int31())] = (int32)(*github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
+		vAlue125 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*uint32)
-		for i := 0; i < v125; i++ {
+		for i := 0; i < vAlue125; i++ {
 			this.NullableUInt32[int32(r.Int31())] = (*uint32)(github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v126 := r.Intn(10)
+		vAlue126 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]uint32)
-		for i := 0; i < v126; i++ {
+		for i := 0; i < vAlue126; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = (uint32)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v127 := r.Intn(10)
+		vAlue127 := r.Intn(10)
 		this.NullableBool = make(map[int32]*bool)
-		for i := 0; i < v127; i++ {
+		for i := 0; i < vAlue127; i++ {
 			this.NullableBool[int32(r.Int31())] = (*bool)(github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v128 := r.Intn(10)
+		vAlue128 := r.Intn(10)
 		this.NonnullBool = make(map[int32]bool)
-		for i := 0; i < v128; i++ {
+		for i := 0; i < vAlue128; i++ {
 			this.NonnullBool[int32(r.Int31())] = (bool)(*github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v129 := r.Intn(10)
+		vAlue129 := r.Intn(10)
 		this.NullableString = make(map[int32]*string)
-		for i := 0; i < v129; i++ {
+		for i := 0; i < vAlue129; i++ {
 			this.NullableString[int32(r.Int31())] = (*string)(github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v130 := r.Intn(10)
+		vAlue130 := r.Intn(10)
 		this.NonnullString = make(map[int32]string)
-		for i := 0; i < v130; i++ {
+		for i := 0; i < vAlue130; i++ {
 			this.NonnullString[int32(r.Int31())] = (string)(*github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v131 := r.Intn(10)
+		vAlue131 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*[]byte)
-		for i := 0; i < v131; i++ {
+		for i := 0; i < vAlue131; i++ {
 			this.NullableBytes[int32(r.Int31())] = (*[]byte)(github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v132 := r.Intn(10)
+		vAlue132 := r.Intn(10)
 		this.NonnullBytes = make(map[int32][]byte)
-		for i := 0; i < v132; i++ {
+		for i := 0; i < vAlue132; i++ {
 			this.NonnullBytes[int32(r.Int31())] = ([]byte)(*github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
@@ -10284,9 +10284,9 @@ func randUTF8RuneTypes(r randyTypes) rune {
 	return rune(ru + 61)
 }
 func randStringTypes(r randyTypes) string {
-	v133 := r.Intn(100)
-	tmps := make([]rune, v133)
-	for i := 0; i < v133; i++ {
+	vAlue133 := r.Intn(100)
+	tmps := make([]rune, vAlue133)
+	for i := 0; i < vAlue133; i++ {
 		tmps[i] = randUTF8RuneTypes(r)
 	}
 	return string(tmps)
@@ -10308,11 +10308,11 @@ func randFieldTypes(dAtA []byte, r randyTypes, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
-		v134 := r.Int63()
+		vAlue134 := r.Int63()
 		if r.Intn(2) == 0 {
-			v134 *= -1
+			vAlue134 *= -1
 		}
-		dAtA = encodeVarintPopulateTypes(dAtA, uint64(v134))
+		dAtA = encodeVarintPopulateTypes(dAtA, uint64(vAlue134))
 	case 1:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/types/combos/marshaler/types.pb.go
+++ b/test/types/combos/marshaler/types.pb.go
@@ -9326,28 +9326,28 @@ func NewPopulatedProtoTypes(r randyTypes, easy bool) *ProtoTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = types.NewPopulatedBytesValue(r, easy)
 	}
-	v1 := types.NewPopulatedTimestamp(r, easy)
-	this.Timestamp = *v1
-	v2 := types.NewPopulatedDuration(r, easy)
-	this.Duration = *v2
-	v3 := types.NewPopulatedDoubleValue(r, easy)
-	this.NonnullDouble = *v3
-	v4 := types.NewPopulatedFloatValue(r, easy)
-	this.NonnullFloat = *v4
-	v5 := types.NewPopulatedInt64Value(r, easy)
-	this.NonnullInt64 = *v5
-	v6 := types.NewPopulatedUInt64Value(r, easy)
-	this.NonnullUInt64 = *v6
-	v7 := types.NewPopulatedInt32Value(r, easy)
-	this.NonnullInt32 = *v7
-	v8 := types.NewPopulatedUInt32Value(r, easy)
-	this.NonnullUInt32 = *v8
-	v9 := types.NewPopulatedBoolValue(r, easy)
-	this.NonnullBool = *v9
-	v10 := types.NewPopulatedStringValue(r, easy)
-	this.NonnullString = *v10
-	v11 := types.NewPopulatedBytesValue(r, easy)
-	this.NonnullBytes = *v11
+	vAlue1 := types.NewPopulatedTimestamp(r, easy)
+	this.Timestamp = *vAlue1
+	vAlue2 := types.NewPopulatedDuration(r, easy)
+	this.Duration = *vAlue2
+	vAlue3 := types.NewPopulatedDoubleValue(r, easy)
+	this.NonnullDouble = *vAlue3
+	vAlue4 := types.NewPopulatedFloatValue(r, easy)
+	this.NonnullFloat = *vAlue4
+	vAlue5 := types.NewPopulatedInt64Value(r, easy)
+	this.NonnullInt64 = *vAlue5
+	vAlue6 := types.NewPopulatedUInt64Value(r, easy)
+	this.NonnullUInt64 = *vAlue6
+	vAlue7 := types.NewPopulatedInt32Value(r, easy)
+	this.NonnullInt32 = *vAlue7
+	vAlue8 := types.NewPopulatedUInt32Value(r, easy)
+	this.NonnullUInt32 = *vAlue8
+	vAlue9 := types.NewPopulatedBoolValue(r, easy)
+	this.NonnullBool = *vAlue9
+	vAlue10 := types.NewPopulatedStringValue(r, easy)
+	this.NonnullString = *vAlue10
+	vAlue11 := types.NewPopulatedBytesValue(r, easy)
+	this.NonnullBytes = *vAlue11
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -9389,28 +9389,28 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 	}
-	v12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-	this.Timestamp = *v12
-	v13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-	this.Duration = *v13
-	v14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-	this.NonnullDouble = *v14
-	v15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-	this.NonnullFloat = *v15
-	v16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-	this.NonnullInt64 = *v16
-	v17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-	this.NonnullUInt64 = *v17
-	v18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-	this.NonnullInt32 = *v18
-	v19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-	this.NonnullUInt32 = *v19
-	v20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-	this.NonnullBool = *v20
-	v21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-	this.NonnullString = *v21
-	v22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-	this.NonnullBytes = *v22
+	vAlue12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+	this.Timestamp = *vAlue12
+	vAlue13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+	this.Duration = *vAlue13
+	vAlue14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+	this.NonnullDouble = *vAlue14
+	vAlue15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+	this.NonnullFloat = *vAlue15
+	vAlue16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+	this.NonnullInt64 = *vAlue16
+	vAlue17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+	this.NonnullUInt64 = *vAlue17
+	vAlue18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+	this.NonnullInt32 = *vAlue18
+	vAlue19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+	this.NonnullUInt32 = *vAlue19
+	vAlue20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+	this.NonnullBool = *vAlue20
+	vAlue21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+	this.NonnullString = *vAlue21
+	vAlue22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+	this.NonnullBytes = *vAlue22
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -9420,168 +9420,168 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 	this := &RepProtoTypes{}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(5)
-		this.NullableTimestamps = make([]*types.Timestamp, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(5)
+		this.NullableTimestamps = make([]*types.Timestamp, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.NullableTimestamps[i] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(5)
-		this.NullableDurations = make([]*types.Duration, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(5)
+		this.NullableDurations = make([]*types.Duration, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.NullableDurations[i] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(5)
-		this.Timestamps = make([]types.Timestamp, v25)
-		for i := 0; i < v25; i++ {
-			v26 := types.NewPopulatedTimestamp(r, easy)
-			this.Timestamps[i] = *v26
+		vAlue25 := r.Intn(5)
+		this.Timestamps = make([]types.Timestamp, vAlue25)
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := types.NewPopulatedTimestamp(r, easy)
+			this.Timestamps[i] = *vAlue26
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(5)
-		this.Durations = make([]types.Duration, v27)
-		for i := 0; i < v27; i++ {
-			v28 := types.NewPopulatedDuration(r, easy)
-			this.Durations[i] = *v28
+		vAlue27 := r.Intn(5)
+		this.Durations = make([]types.Duration, vAlue27)
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := types.NewPopulatedDuration(r, easy)
+			this.Durations[i] = *vAlue28
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(5)
-		this.NullableDouble = make([]*types.DoubleValue, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(5)
+		this.NullableDouble = make([]*types.DoubleValue, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.NullableDouble[i] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(5)
-		this.NonnullDouble = make([]types.DoubleValue, v30)
-		for i := 0; i < v30; i++ {
-			v31 := types.NewPopulatedDoubleValue(r, easy)
-			this.NonnullDouble[i] = *v31
+		vAlue30 := r.Intn(5)
+		this.NonnullDouble = make([]types.DoubleValue, vAlue30)
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := types.NewPopulatedDoubleValue(r, easy)
+			this.NonnullDouble[i] = *vAlue31
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(5)
-		this.NullableFloat = make([]*types.FloatValue, v32)
-		for i := 0; i < v32; i++ {
+		vAlue32 := r.Intn(5)
+		this.NullableFloat = make([]*types.FloatValue, vAlue32)
+		for i := 0; i < vAlue32; i++ {
 			this.NullableFloat[i] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(5)
-		this.NonnullFloat = make([]types.FloatValue, v33)
-		for i := 0; i < v33; i++ {
-			v34 := types.NewPopulatedFloatValue(r, easy)
-			this.NonnullFloat[i] = *v34
+		vAlue33 := r.Intn(5)
+		this.NonnullFloat = make([]types.FloatValue, vAlue33)
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := types.NewPopulatedFloatValue(r, easy)
+			this.NonnullFloat[i] = *vAlue34
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(5)
-		this.NullableInt64 = make([]*types.Int64Value, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(5)
+		this.NullableInt64 = make([]*types.Int64Value, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.NullableInt64[i] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(5)
-		this.NonnullInt64 = make([]types.Int64Value, v36)
-		for i := 0; i < v36; i++ {
-			v37 := types.NewPopulatedInt64Value(r, easy)
-			this.NonnullInt64[i] = *v37
+		vAlue36 := r.Intn(5)
+		this.NonnullInt64 = make([]types.Int64Value, vAlue36)
+		for i := 0; i < vAlue36; i++ {
+			vAlue37 := types.NewPopulatedInt64Value(r, easy)
+			this.NonnullInt64[i] = *vAlue37
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(5)
-		this.NullableUInt64 = make([]*types.UInt64Value, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(5)
+		this.NullableUInt64 = make([]*types.UInt64Value, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.NullableUInt64[i] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(5)
-		this.NonnullUInt64 = make([]types.UInt64Value, v39)
-		for i := 0; i < v39; i++ {
-			v40 := types.NewPopulatedUInt64Value(r, easy)
-			this.NonnullUInt64[i] = *v40
+		vAlue39 := r.Intn(5)
+		this.NonnullUInt64 = make([]types.UInt64Value, vAlue39)
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := types.NewPopulatedUInt64Value(r, easy)
+			this.NonnullUInt64[i] = *vAlue40
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(5)
-		this.NullableInt32 = make([]*types.Int32Value, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(5)
+		this.NullableInt32 = make([]*types.Int32Value, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.NullableInt32[i] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(5)
-		this.NonnullInt32 = make([]types.Int32Value, v42)
-		for i := 0; i < v42; i++ {
-			v43 := types.NewPopulatedInt32Value(r, easy)
-			this.NonnullInt32[i] = *v43
+		vAlue42 := r.Intn(5)
+		this.NonnullInt32 = make([]types.Int32Value, vAlue42)
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := types.NewPopulatedInt32Value(r, easy)
+			this.NonnullInt32[i] = *vAlue43
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(5)
-		this.NullableUInt32 = make([]*types.UInt32Value, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(5)
+		this.NullableUInt32 = make([]*types.UInt32Value, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.NullableUInt32[i] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(5)
-		this.NonnullUInt32 = make([]types.UInt32Value, v45)
-		for i := 0; i < v45; i++ {
-			v46 := types.NewPopulatedUInt32Value(r, easy)
-			this.NonnullUInt32[i] = *v46
+		vAlue45 := r.Intn(5)
+		this.NonnullUInt32 = make([]types.UInt32Value, vAlue45)
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := types.NewPopulatedUInt32Value(r, easy)
+			this.NonnullUInt32[i] = *vAlue46
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(5)
-		this.NullableBool = make([]*types.BoolValue, v47)
-		for i := 0; i < v47; i++ {
+		vAlue47 := r.Intn(5)
+		this.NullableBool = make([]*types.BoolValue, vAlue47)
+		for i := 0; i < vAlue47; i++ {
 			this.NullableBool[i] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(5)
-		this.NonnullBool = make([]types.BoolValue, v48)
-		for i := 0; i < v48; i++ {
-			v49 := types.NewPopulatedBoolValue(r, easy)
-			this.NonnullBool[i] = *v49
+		vAlue48 := r.Intn(5)
+		this.NonnullBool = make([]types.BoolValue, vAlue48)
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := types.NewPopulatedBoolValue(r, easy)
+			this.NonnullBool[i] = *vAlue49
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(5)
-		this.NullableString = make([]*types.StringValue, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(5)
+		this.NullableString = make([]*types.StringValue, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.NullableString[i] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(5)
-		this.NonnullString = make([]types.StringValue, v51)
-		for i := 0; i < v51; i++ {
-			v52 := types.NewPopulatedStringValue(r, easy)
-			this.NonnullString[i] = *v52
+		vAlue51 := r.Intn(5)
+		this.NonnullString = make([]types.StringValue, vAlue51)
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := types.NewPopulatedStringValue(r, easy)
+			this.NonnullString[i] = *vAlue52
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(5)
-		this.NullableBytes = make([]*types.BytesValue, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(5)
+		this.NullableBytes = make([]*types.BytesValue, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.NullableBytes[i] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(5)
-		this.NonnullBytes = make([]types.BytesValue, v54)
-		for i := 0; i < v54; i++ {
-			v55 := types.NewPopulatedBytesValue(r, easy)
-			this.NonnullBytes[i] = *v55
+		vAlue54 := r.Intn(5)
+		this.NonnullBytes = make([]types.BytesValue, vAlue54)
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := types.NewPopulatedBytesValue(r, easy)
+			this.NonnullBytes[i] = *vAlue55
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -9593,168 +9593,168 @@ func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 	this := &RepStdTypes{}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(5)
-		this.NullableTimestamps = make([]*time.Time, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(5)
+		this.NullableTimestamps = make([]*time.Time, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.NullableTimestamps[i] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(5)
-		this.NullableDurations = make([]*time.Duration, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(5)
+		this.NullableDurations = make([]*time.Duration, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.NullableDurations[i] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(5)
-		this.Timestamps = make([]time.Time, v58)
-		for i := 0; i < v58; i++ {
-			v59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-			this.Timestamps[i] = *v59
+		vAlue58 := r.Intn(5)
+		this.Timestamps = make([]time.Time, vAlue58)
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+			this.Timestamps[i] = *vAlue59
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(5)
-		this.Durations = make([]time.Duration, v60)
-		for i := 0; i < v60; i++ {
-			v61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-			this.Durations[i] = *v61
+		vAlue60 := r.Intn(5)
+		this.Durations = make([]time.Duration, vAlue60)
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+			this.Durations[i] = *vAlue61
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(5)
-		this.NullableDouble = make([]*float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(5)
+		this.NullableDouble = make([]*float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.NullableDouble[i] = github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(5)
-		this.NonnullDouble = make([]float64, v63)
-		for i := 0; i < v63; i++ {
-			v64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-			this.NonnullDouble[i] = *v64
+		vAlue63 := r.Intn(5)
+		this.NonnullDouble = make([]float64, vAlue63)
+		for i := 0; i < vAlue63; i++ {
+			vAlue64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+			this.NonnullDouble[i] = *vAlue64
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(5)
-		this.NullableFloat = make([]*float32, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(5)
+		this.NullableFloat = make([]*float32, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.NullableFloat[i] = github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(5)
-		this.NonnullFloat = make([]float32, v66)
-		for i := 0; i < v66; i++ {
-			v67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-			this.NonnullFloat[i] = *v67
+		vAlue66 := r.Intn(5)
+		this.NonnullFloat = make([]float32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
+			vAlue67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+			this.NonnullFloat[i] = *vAlue67
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(5)
-		this.NullableInt64 = make([]*int64, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(5)
+		this.NullableInt64 = make([]*int64, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.NullableInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(5)
-		this.NonnullInt64 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
-			v70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-			this.NonnullInt64[i] = *v70
+		vAlue69 := r.Intn(5)
+		this.NonnullInt64 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
+			vAlue70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+			this.NonnullInt64[i] = *vAlue70
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(5)
-		this.NullableUInt64 = make([]*uint64, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(5)
+		this.NullableUInt64 = make([]*uint64, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.NullableUInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(5)
-		this.NonnullUInt64 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
-			v73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-			this.NonnullUInt64[i] = *v73
+		vAlue72 := r.Intn(5)
+		this.NonnullUInt64 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
+			vAlue73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+			this.NonnullUInt64[i] = *vAlue73
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(5)
-		this.NullableInt32 = make([]*int32, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(5)
+		this.NullableInt32 = make([]*int32, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.NullableInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(5)
-		this.NonnullInt32 = make([]int32, v75)
-		for i := 0; i < v75; i++ {
-			v76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-			this.NonnullInt32[i] = *v76
+		vAlue75 := r.Intn(5)
+		this.NonnullInt32 = make([]int32, vAlue75)
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+			this.NonnullInt32[i] = *vAlue76
 		}
 	}
 	if r.Intn(5) != 0 {
-		v77 := r.Intn(5)
-		this.NullableUInt32 = make([]*uint32, v77)
-		for i := 0; i < v77; i++ {
+		vAlue77 := r.Intn(5)
+		this.NullableUInt32 = make([]*uint32, vAlue77)
+		for i := 0; i < vAlue77; i++ {
 			this.NullableUInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v78 := r.Intn(5)
-		this.NonnullUInt32 = make([]uint32, v78)
-		for i := 0; i < v78; i++ {
-			v79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-			this.NonnullUInt32[i] = *v79
+		vAlue78 := r.Intn(5)
+		this.NonnullUInt32 = make([]uint32, vAlue78)
+		for i := 0; i < vAlue78; i++ {
+			vAlue79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+			this.NonnullUInt32[i] = *vAlue79
 		}
 	}
 	if r.Intn(5) != 0 {
-		v80 := r.Intn(5)
-		this.NullableBool = make([]*bool, v80)
-		for i := 0; i < v80; i++ {
+		vAlue80 := r.Intn(5)
+		this.NullableBool = make([]*bool, vAlue80)
+		for i := 0; i < vAlue80; i++ {
 			this.NullableBool[i] = github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v81 := r.Intn(5)
-		this.NonnullBool = make([]bool, v81)
-		for i := 0; i < v81; i++ {
-			v82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-			this.NonnullBool[i] = *v82
+		vAlue81 := r.Intn(5)
+		this.NonnullBool = make([]bool, vAlue81)
+		for i := 0; i < vAlue81; i++ {
+			vAlue82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+			this.NonnullBool[i] = *vAlue82
 		}
 	}
 	if r.Intn(5) != 0 {
-		v83 := r.Intn(5)
-		this.NullableString = make([]*string, v83)
-		for i := 0; i < v83; i++ {
+		vAlue83 := r.Intn(5)
+		this.NullableString = make([]*string, vAlue83)
+		for i := 0; i < vAlue83; i++ {
 			this.NullableString[i] = github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v84 := r.Intn(5)
-		this.NonnullString = make([]string, v84)
-		for i := 0; i < v84; i++ {
-			v85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-			this.NonnullString[i] = *v85
+		vAlue84 := r.Intn(5)
+		this.NonnullString = make([]string, vAlue84)
+		for i := 0; i < vAlue84; i++ {
+			vAlue85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+			this.NonnullString[i] = *vAlue85
 		}
 	}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(5)
-		this.NullableBytes = make([]*[]byte, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(5)
+		this.NullableBytes = make([]*[]byte, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.NullableBytes[i] = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(5)
-		this.NonnullBytes = make([][]byte, v87)
-		for i := 0; i < v87; i++ {
-			v88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-			this.NonnullBytes[i] = *v88
+		vAlue87 := r.Intn(5)
+		this.NonnullBytes = make([][]byte, vAlue87)
+		for i := 0; i < vAlue87; i++ {
+			vAlue88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+			this.NonnullBytes[i] = *vAlue88
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -9766,156 +9766,156 @@ func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 	this := &MapProtoTypes{}
 	if r.Intn(5) != 0 {
-		v89 := r.Intn(10)
+		vAlue89 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*types.Timestamp)
-		for i := 0; i < v89; i++ {
+		for i := 0; i < vAlue89; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(10)
+		vAlue90 := r.Intn(10)
 		this.Timestamp = make(map[int32]types.Timestamp)
-		for i := 0; i < v90; i++ {
+		for i := 0; i < vAlue90; i++ {
 			this.Timestamp[int32(r.Int31())] = *types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v91 := r.Intn(10)
+		vAlue91 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*types.Duration)
-		for i := 0; i < v91; i++ {
+		for i := 0; i < vAlue91; i++ {
 			this.NullableDuration[int32(r.Int31())] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
+		vAlue92 := r.Intn(10)
 		this.Duration = make(map[int32]types.Duration)
-		for i := 0; i < v92; i++ {
+		for i := 0; i < vAlue92; i++ {
 			this.Duration[int32(r.Int31())] = *types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
+		vAlue93 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*types.DoubleValue)
-		for i := 0; i < v93; i++ {
+		for i := 0; i < vAlue93; i++ {
 			this.NullableDouble[int32(r.Int31())] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(10)
+		vAlue94 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]types.DoubleValue)
-		for i := 0; i < v94; i++ {
+		for i := 0; i < vAlue94; i++ {
 			this.NonnullDouble[int32(r.Int31())] = *types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v95 := r.Intn(10)
+		vAlue95 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*types.FloatValue)
-		for i := 0; i < v95; i++ {
+		for i := 0; i < vAlue95; i++ {
 			this.NullableFloat[int32(r.Int31())] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
+		vAlue96 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]types.FloatValue)
-		for i := 0; i < v96; i++ {
+		for i := 0; i < vAlue96; i++ {
 			this.NonnullFloat[int32(r.Int31())] = *types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
+		vAlue97 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*types.Int64Value)
-		for i := 0; i < v97; i++ {
+		for i := 0; i < vAlue97; i++ {
 			this.NullableInt64[int32(r.Int31())] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
+		vAlue98 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]types.Int64Value)
-		for i := 0; i < v98; i++ {
+		for i := 0; i < vAlue98; i++ {
 			this.NonnullInt64[int32(r.Int31())] = *types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v99 := r.Intn(10)
+		vAlue99 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*types.UInt64Value)
-		for i := 0; i < v99; i++ {
+		for i := 0; i < vAlue99; i++ {
 			this.NullableUInt64[int32(r.Int31())] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
+		vAlue100 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]types.UInt64Value)
-		for i := 0; i < v100; i++ {
+		for i := 0; i < vAlue100; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = *types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
+		vAlue101 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*types.Int32Value)
-		for i := 0; i < v101; i++ {
+		for i := 0; i < vAlue101; i++ {
 			this.NullableInt32[int32(r.Int31())] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(10)
+		vAlue102 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]types.Int32Value)
-		for i := 0; i < v102; i++ {
+		for i := 0; i < vAlue102; i++ {
 			this.NonnullInt32[int32(r.Int31())] = *types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(10)
+		vAlue103 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*types.UInt32Value)
-		for i := 0; i < v103; i++ {
+		for i := 0; i < vAlue103; i++ {
 			this.NullableUInt32[int32(r.Int31())] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
+		vAlue104 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]types.UInt32Value)
-		for i := 0; i < v104; i++ {
+		for i := 0; i < vAlue104; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = *types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
+		vAlue105 := r.Intn(10)
 		this.NullableBool = make(map[int32]*types.BoolValue)
-		for i := 0; i < v105; i++ {
+		for i := 0; i < vAlue105; i++ {
 			this.NullableBool[int32(r.Int31())] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(10)
+		vAlue106 := r.Intn(10)
 		this.NonnullBool = make(map[int32]types.BoolValue)
-		for i := 0; i < v106; i++ {
+		for i := 0; i < vAlue106; i++ {
 			this.NonnullBool[int32(r.Int31())] = *types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
+		vAlue107 := r.Intn(10)
 		this.NullableString = make(map[int32]*types.StringValue)
-		for i := 0; i < v107; i++ {
+		for i := 0; i < vAlue107; i++ {
 			this.NullableString[int32(r.Int31())] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
+		vAlue108 := r.Intn(10)
 		this.NonnullString = make(map[int32]types.StringValue)
-		for i := 0; i < v108; i++ {
+		for i := 0; i < vAlue108; i++ {
 			this.NonnullString[int32(r.Int31())] = *types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
+		vAlue109 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*types.BytesValue)
-		for i := 0; i < v109; i++ {
+		for i := 0; i < vAlue109; i++ {
 			this.NullableBytes[int32(r.Int31())] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v110 := r.Intn(10)
+		vAlue110 := r.Intn(10)
 		this.NonnullBytes = make(map[int32]types.BytesValue)
-		for i := 0; i < v110; i++ {
+		for i := 0; i < vAlue110; i++ {
 			this.NonnullBytes[int32(r.Int31())] = *types.NewPopulatedBytesValue(r, easy)
 		}
 	}
@@ -9928,156 +9928,156 @@ func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 func NewPopulatedMapStdTypes(r randyTypes, easy bool) *MapStdTypes {
 	this := &MapStdTypes{}
 	if r.Intn(5) != 0 {
-		v111 := r.Intn(10)
+		vAlue111 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*time.Time)
-		for i := 0; i < v111; i++ {
+		for i := 0; i < vAlue111; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v112 := r.Intn(10)
+		vAlue112 := r.Intn(10)
 		this.Timestamp = make(map[int32]time.Time)
-		for i := 0; i < v112; i++ {
+		for i := 0; i < vAlue112; i++ {
 			this.Timestamp[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v113 := r.Intn(10)
+		vAlue113 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*time.Duration)
-		for i := 0; i < v113; i++ {
+		for i := 0; i < vAlue113; i++ {
 			this.NullableDuration[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(10)
+		vAlue114 := r.Intn(10)
 		this.Duration = make(map[int32]time.Duration)
-		for i := 0; i < v114; i++ {
+		for i := 0; i < vAlue114; i++ {
 			this.Duration[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v115 := r.Intn(10)
+		vAlue115 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*float64)
-		for i := 0; i < v115; i++ {
+		for i := 0; i < vAlue115; i++ {
 			this.NullableDouble[int32(r.Int31())] = (*float64)(github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(10)
+		vAlue116 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]float64)
-		for i := 0; i < v116; i++ {
+		for i := 0; i < vAlue116; i++ {
 			this.NonnullDouble[int32(r.Int31())] = (float64)(*github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v117 := r.Intn(10)
+		vAlue117 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*float32)
-		for i := 0; i < v117; i++ {
+		for i := 0; i < vAlue117; i++ {
 			this.NullableFloat[int32(r.Int31())] = (*float32)(github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v118 := r.Intn(10)
+		vAlue118 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]float32)
-		for i := 0; i < v118; i++ {
+		for i := 0; i < vAlue118; i++ {
 			this.NonnullFloat[int32(r.Int31())] = (float32)(*github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
+		vAlue119 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*int64)
-		for i := 0; i < v119; i++ {
+		for i := 0; i < vAlue119; i++ {
 			this.NullableInt64[int32(r.Int31())] = (*int64)(github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v120 := r.Intn(10)
+		vAlue120 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]int64)
-		for i := 0; i < v120; i++ {
+		for i := 0; i < vAlue120; i++ {
 			this.NonnullInt64[int32(r.Int31())] = (int64)(*github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
+		vAlue121 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*uint64)
-		for i := 0; i < v121; i++ {
+		for i := 0; i < vAlue121; i++ {
 			this.NullableUInt64[int32(r.Int31())] = (*uint64)(github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v122 := r.Intn(10)
+		vAlue122 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]uint64)
-		for i := 0; i < v122; i++ {
+		for i := 0; i < vAlue122; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = (uint64)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
+		vAlue123 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*int32)
-		for i := 0; i < v123; i++ {
+		for i := 0; i < vAlue123; i++ {
 			this.NullableInt32[int32(r.Int31())] = (*int32)(github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v124 := r.Intn(10)
+		vAlue124 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]int32)
-		for i := 0; i < v124; i++ {
+		for i := 0; i < vAlue124; i++ {
 			this.NonnullInt32[int32(r.Int31())] = (int32)(*github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
+		vAlue125 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*uint32)
-		for i := 0; i < v125; i++ {
+		for i := 0; i < vAlue125; i++ {
 			this.NullableUInt32[int32(r.Int31())] = (*uint32)(github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v126 := r.Intn(10)
+		vAlue126 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]uint32)
-		for i := 0; i < v126; i++ {
+		for i := 0; i < vAlue126; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = (uint32)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v127 := r.Intn(10)
+		vAlue127 := r.Intn(10)
 		this.NullableBool = make(map[int32]*bool)
-		for i := 0; i < v127; i++ {
+		for i := 0; i < vAlue127; i++ {
 			this.NullableBool[int32(r.Int31())] = (*bool)(github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v128 := r.Intn(10)
+		vAlue128 := r.Intn(10)
 		this.NonnullBool = make(map[int32]bool)
-		for i := 0; i < v128; i++ {
+		for i := 0; i < vAlue128; i++ {
 			this.NonnullBool[int32(r.Int31())] = (bool)(*github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v129 := r.Intn(10)
+		vAlue129 := r.Intn(10)
 		this.NullableString = make(map[int32]*string)
-		for i := 0; i < v129; i++ {
+		for i := 0; i < vAlue129; i++ {
 			this.NullableString[int32(r.Int31())] = (*string)(github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v130 := r.Intn(10)
+		vAlue130 := r.Intn(10)
 		this.NonnullString = make(map[int32]string)
-		for i := 0; i < v130; i++ {
+		for i := 0; i < vAlue130; i++ {
 			this.NonnullString[int32(r.Int31())] = (string)(*github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v131 := r.Intn(10)
+		vAlue131 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*[]byte)
-		for i := 0; i < v131; i++ {
+		for i := 0; i < vAlue131; i++ {
 			this.NullableBytes[int32(r.Int31())] = (*[]byte)(github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v132 := r.Intn(10)
+		vAlue132 := r.Intn(10)
 		this.NonnullBytes = make(map[int32][]byte)
-		for i := 0; i < v132; i++ {
+		for i := 0; i < vAlue132; i++ {
 			this.NonnullBytes[int32(r.Int31())] = ([]byte)(*github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
@@ -10283,9 +10283,9 @@ func randUTF8RuneTypes(r randyTypes) rune {
 	return rune(ru + 61)
 }
 func randStringTypes(r randyTypes) string {
-	v133 := r.Intn(100)
-	tmps := make([]rune, v133)
-	for i := 0; i < v133; i++ {
+	vAlue133 := r.Intn(100)
+	tmps := make([]rune, vAlue133)
+	for i := 0; i < vAlue133; i++ {
 		tmps[i] = randUTF8RuneTypes(r)
 	}
 	return string(tmps)
@@ -10307,11 +10307,11 @@ func randFieldTypes(dAtA []byte, r randyTypes, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
-		v134 := r.Int63()
+		vAlue134 := r.Int63()
 		if r.Intn(2) == 0 {
-			v134 *= -1
+			vAlue134 *= -1
 		}
-		dAtA = encodeVarintPopulateTypes(dAtA, uint64(v134))
+		dAtA = encodeVarintPopulateTypes(dAtA, uint64(vAlue134))
 	case 1:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/types/combos/neither/types.pb.go
+++ b/test/types/combos/neither/types.pb.go
@@ -6323,28 +6323,28 @@ func NewPopulatedProtoTypes(r randyTypes, easy bool) *ProtoTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = types.NewPopulatedBytesValue(r, easy)
 	}
-	v1 := types.NewPopulatedTimestamp(r, easy)
-	this.Timestamp = *v1
-	v2 := types.NewPopulatedDuration(r, easy)
-	this.Duration = *v2
-	v3 := types.NewPopulatedDoubleValue(r, easy)
-	this.NonnullDouble = *v3
-	v4 := types.NewPopulatedFloatValue(r, easy)
-	this.NonnullFloat = *v4
-	v5 := types.NewPopulatedInt64Value(r, easy)
-	this.NonnullInt64 = *v5
-	v6 := types.NewPopulatedUInt64Value(r, easy)
-	this.NonnullUInt64 = *v6
-	v7 := types.NewPopulatedInt32Value(r, easy)
-	this.NonnullInt32 = *v7
-	v8 := types.NewPopulatedUInt32Value(r, easy)
-	this.NonnullUInt32 = *v8
-	v9 := types.NewPopulatedBoolValue(r, easy)
-	this.NonnullBool = *v9
-	v10 := types.NewPopulatedStringValue(r, easy)
-	this.NonnullString = *v10
-	v11 := types.NewPopulatedBytesValue(r, easy)
-	this.NonnullBytes = *v11
+	vAlue1 := types.NewPopulatedTimestamp(r, easy)
+	this.Timestamp = *vAlue1
+	vAlue2 := types.NewPopulatedDuration(r, easy)
+	this.Duration = *vAlue2
+	vAlue3 := types.NewPopulatedDoubleValue(r, easy)
+	this.NonnullDouble = *vAlue3
+	vAlue4 := types.NewPopulatedFloatValue(r, easy)
+	this.NonnullFloat = *vAlue4
+	vAlue5 := types.NewPopulatedInt64Value(r, easy)
+	this.NonnullInt64 = *vAlue5
+	vAlue6 := types.NewPopulatedUInt64Value(r, easy)
+	this.NonnullUInt64 = *vAlue6
+	vAlue7 := types.NewPopulatedInt32Value(r, easy)
+	this.NonnullInt32 = *vAlue7
+	vAlue8 := types.NewPopulatedUInt32Value(r, easy)
+	this.NonnullUInt32 = *vAlue8
+	vAlue9 := types.NewPopulatedBoolValue(r, easy)
+	this.NonnullBool = *vAlue9
+	vAlue10 := types.NewPopulatedStringValue(r, easy)
+	this.NonnullString = *vAlue10
+	vAlue11 := types.NewPopulatedBytesValue(r, easy)
+	this.NonnullBytes = *vAlue11
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -6386,28 +6386,28 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 	}
-	v12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-	this.Timestamp = *v12
-	v13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-	this.Duration = *v13
-	v14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-	this.NonnullDouble = *v14
-	v15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-	this.NonnullFloat = *v15
-	v16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-	this.NonnullInt64 = *v16
-	v17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-	this.NonnullUInt64 = *v17
-	v18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-	this.NonnullInt32 = *v18
-	v19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-	this.NonnullUInt32 = *v19
-	v20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-	this.NonnullBool = *v20
-	v21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-	this.NonnullString = *v21
-	v22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-	this.NonnullBytes = *v22
+	vAlue12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+	this.Timestamp = *vAlue12
+	vAlue13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+	this.Duration = *vAlue13
+	vAlue14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+	this.NonnullDouble = *vAlue14
+	vAlue15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+	this.NonnullFloat = *vAlue15
+	vAlue16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+	this.NonnullInt64 = *vAlue16
+	vAlue17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+	this.NonnullUInt64 = *vAlue17
+	vAlue18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+	this.NonnullInt32 = *vAlue18
+	vAlue19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+	this.NonnullUInt32 = *vAlue19
+	vAlue20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+	this.NonnullBool = *vAlue20
+	vAlue21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+	this.NonnullString = *vAlue21
+	vAlue22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+	this.NonnullBytes = *vAlue22
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -6417,168 +6417,168 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 	this := &RepProtoTypes{}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(5)
-		this.NullableTimestamps = make([]*types.Timestamp, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(5)
+		this.NullableTimestamps = make([]*types.Timestamp, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.NullableTimestamps[i] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(5)
-		this.NullableDurations = make([]*types.Duration, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(5)
+		this.NullableDurations = make([]*types.Duration, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.NullableDurations[i] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(5)
-		this.Timestamps = make([]types.Timestamp, v25)
-		for i := 0; i < v25; i++ {
-			v26 := types.NewPopulatedTimestamp(r, easy)
-			this.Timestamps[i] = *v26
+		vAlue25 := r.Intn(5)
+		this.Timestamps = make([]types.Timestamp, vAlue25)
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := types.NewPopulatedTimestamp(r, easy)
+			this.Timestamps[i] = *vAlue26
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(5)
-		this.Durations = make([]types.Duration, v27)
-		for i := 0; i < v27; i++ {
-			v28 := types.NewPopulatedDuration(r, easy)
-			this.Durations[i] = *v28
+		vAlue27 := r.Intn(5)
+		this.Durations = make([]types.Duration, vAlue27)
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := types.NewPopulatedDuration(r, easy)
+			this.Durations[i] = *vAlue28
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(5)
-		this.NullableDouble = make([]*types.DoubleValue, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(5)
+		this.NullableDouble = make([]*types.DoubleValue, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.NullableDouble[i] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(5)
-		this.NonnullDouble = make([]types.DoubleValue, v30)
-		for i := 0; i < v30; i++ {
-			v31 := types.NewPopulatedDoubleValue(r, easy)
-			this.NonnullDouble[i] = *v31
+		vAlue30 := r.Intn(5)
+		this.NonnullDouble = make([]types.DoubleValue, vAlue30)
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := types.NewPopulatedDoubleValue(r, easy)
+			this.NonnullDouble[i] = *vAlue31
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(5)
-		this.NullableFloat = make([]*types.FloatValue, v32)
-		for i := 0; i < v32; i++ {
+		vAlue32 := r.Intn(5)
+		this.NullableFloat = make([]*types.FloatValue, vAlue32)
+		for i := 0; i < vAlue32; i++ {
 			this.NullableFloat[i] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(5)
-		this.NonnullFloat = make([]types.FloatValue, v33)
-		for i := 0; i < v33; i++ {
-			v34 := types.NewPopulatedFloatValue(r, easy)
-			this.NonnullFloat[i] = *v34
+		vAlue33 := r.Intn(5)
+		this.NonnullFloat = make([]types.FloatValue, vAlue33)
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := types.NewPopulatedFloatValue(r, easy)
+			this.NonnullFloat[i] = *vAlue34
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(5)
-		this.NullableInt64 = make([]*types.Int64Value, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(5)
+		this.NullableInt64 = make([]*types.Int64Value, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.NullableInt64[i] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(5)
-		this.NonnullInt64 = make([]types.Int64Value, v36)
-		for i := 0; i < v36; i++ {
-			v37 := types.NewPopulatedInt64Value(r, easy)
-			this.NonnullInt64[i] = *v37
+		vAlue36 := r.Intn(5)
+		this.NonnullInt64 = make([]types.Int64Value, vAlue36)
+		for i := 0; i < vAlue36; i++ {
+			vAlue37 := types.NewPopulatedInt64Value(r, easy)
+			this.NonnullInt64[i] = *vAlue37
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(5)
-		this.NullableUInt64 = make([]*types.UInt64Value, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(5)
+		this.NullableUInt64 = make([]*types.UInt64Value, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.NullableUInt64[i] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(5)
-		this.NonnullUInt64 = make([]types.UInt64Value, v39)
-		for i := 0; i < v39; i++ {
-			v40 := types.NewPopulatedUInt64Value(r, easy)
-			this.NonnullUInt64[i] = *v40
+		vAlue39 := r.Intn(5)
+		this.NonnullUInt64 = make([]types.UInt64Value, vAlue39)
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := types.NewPopulatedUInt64Value(r, easy)
+			this.NonnullUInt64[i] = *vAlue40
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(5)
-		this.NullableInt32 = make([]*types.Int32Value, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(5)
+		this.NullableInt32 = make([]*types.Int32Value, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.NullableInt32[i] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(5)
-		this.NonnullInt32 = make([]types.Int32Value, v42)
-		for i := 0; i < v42; i++ {
-			v43 := types.NewPopulatedInt32Value(r, easy)
-			this.NonnullInt32[i] = *v43
+		vAlue42 := r.Intn(5)
+		this.NonnullInt32 = make([]types.Int32Value, vAlue42)
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := types.NewPopulatedInt32Value(r, easy)
+			this.NonnullInt32[i] = *vAlue43
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(5)
-		this.NullableUInt32 = make([]*types.UInt32Value, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(5)
+		this.NullableUInt32 = make([]*types.UInt32Value, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.NullableUInt32[i] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(5)
-		this.NonnullUInt32 = make([]types.UInt32Value, v45)
-		for i := 0; i < v45; i++ {
-			v46 := types.NewPopulatedUInt32Value(r, easy)
-			this.NonnullUInt32[i] = *v46
+		vAlue45 := r.Intn(5)
+		this.NonnullUInt32 = make([]types.UInt32Value, vAlue45)
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := types.NewPopulatedUInt32Value(r, easy)
+			this.NonnullUInt32[i] = *vAlue46
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(5)
-		this.NullableBool = make([]*types.BoolValue, v47)
-		for i := 0; i < v47; i++ {
+		vAlue47 := r.Intn(5)
+		this.NullableBool = make([]*types.BoolValue, vAlue47)
+		for i := 0; i < vAlue47; i++ {
 			this.NullableBool[i] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(5)
-		this.NonnullBool = make([]types.BoolValue, v48)
-		for i := 0; i < v48; i++ {
-			v49 := types.NewPopulatedBoolValue(r, easy)
-			this.NonnullBool[i] = *v49
+		vAlue48 := r.Intn(5)
+		this.NonnullBool = make([]types.BoolValue, vAlue48)
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := types.NewPopulatedBoolValue(r, easy)
+			this.NonnullBool[i] = *vAlue49
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(5)
-		this.NullableString = make([]*types.StringValue, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(5)
+		this.NullableString = make([]*types.StringValue, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.NullableString[i] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(5)
-		this.NonnullString = make([]types.StringValue, v51)
-		for i := 0; i < v51; i++ {
-			v52 := types.NewPopulatedStringValue(r, easy)
-			this.NonnullString[i] = *v52
+		vAlue51 := r.Intn(5)
+		this.NonnullString = make([]types.StringValue, vAlue51)
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := types.NewPopulatedStringValue(r, easy)
+			this.NonnullString[i] = *vAlue52
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(5)
-		this.NullableBytes = make([]*types.BytesValue, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(5)
+		this.NullableBytes = make([]*types.BytesValue, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.NullableBytes[i] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(5)
-		this.NonnullBytes = make([]types.BytesValue, v54)
-		for i := 0; i < v54; i++ {
-			v55 := types.NewPopulatedBytesValue(r, easy)
-			this.NonnullBytes[i] = *v55
+		vAlue54 := r.Intn(5)
+		this.NonnullBytes = make([]types.BytesValue, vAlue54)
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := types.NewPopulatedBytesValue(r, easy)
+			this.NonnullBytes[i] = *vAlue55
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -6590,168 +6590,168 @@ func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 	this := &RepStdTypes{}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(5)
-		this.NullableTimestamps = make([]*time.Time, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(5)
+		this.NullableTimestamps = make([]*time.Time, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.NullableTimestamps[i] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(5)
-		this.NullableDurations = make([]*time.Duration, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(5)
+		this.NullableDurations = make([]*time.Duration, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.NullableDurations[i] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(5)
-		this.Timestamps = make([]time.Time, v58)
-		for i := 0; i < v58; i++ {
-			v59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-			this.Timestamps[i] = *v59
+		vAlue58 := r.Intn(5)
+		this.Timestamps = make([]time.Time, vAlue58)
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+			this.Timestamps[i] = *vAlue59
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(5)
-		this.Durations = make([]time.Duration, v60)
-		for i := 0; i < v60; i++ {
-			v61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-			this.Durations[i] = *v61
+		vAlue60 := r.Intn(5)
+		this.Durations = make([]time.Duration, vAlue60)
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+			this.Durations[i] = *vAlue61
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(5)
-		this.NullableDouble = make([]*float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(5)
+		this.NullableDouble = make([]*float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.NullableDouble[i] = github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(5)
-		this.NonnullDouble = make([]float64, v63)
-		for i := 0; i < v63; i++ {
-			v64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-			this.NonnullDouble[i] = *v64
+		vAlue63 := r.Intn(5)
+		this.NonnullDouble = make([]float64, vAlue63)
+		for i := 0; i < vAlue63; i++ {
+			vAlue64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+			this.NonnullDouble[i] = *vAlue64
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(5)
-		this.NullableFloat = make([]*float32, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(5)
+		this.NullableFloat = make([]*float32, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.NullableFloat[i] = github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(5)
-		this.NonnullFloat = make([]float32, v66)
-		for i := 0; i < v66; i++ {
-			v67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-			this.NonnullFloat[i] = *v67
+		vAlue66 := r.Intn(5)
+		this.NonnullFloat = make([]float32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
+			vAlue67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+			this.NonnullFloat[i] = *vAlue67
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(5)
-		this.NullableInt64 = make([]*int64, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(5)
+		this.NullableInt64 = make([]*int64, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.NullableInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(5)
-		this.NonnullInt64 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
-			v70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-			this.NonnullInt64[i] = *v70
+		vAlue69 := r.Intn(5)
+		this.NonnullInt64 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
+			vAlue70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+			this.NonnullInt64[i] = *vAlue70
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(5)
-		this.NullableUInt64 = make([]*uint64, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(5)
+		this.NullableUInt64 = make([]*uint64, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.NullableUInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(5)
-		this.NonnullUInt64 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
-			v73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-			this.NonnullUInt64[i] = *v73
+		vAlue72 := r.Intn(5)
+		this.NonnullUInt64 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
+			vAlue73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+			this.NonnullUInt64[i] = *vAlue73
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(5)
-		this.NullableInt32 = make([]*int32, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(5)
+		this.NullableInt32 = make([]*int32, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.NullableInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(5)
-		this.NonnullInt32 = make([]int32, v75)
-		for i := 0; i < v75; i++ {
-			v76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-			this.NonnullInt32[i] = *v76
+		vAlue75 := r.Intn(5)
+		this.NonnullInt32 = make([]int32, vAlue75)
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+			this.NonnullInt32[i] = *vAlue76
 		}
 	}
 	if r.Intn(5) != 0 {
-		v77 := r.Intn(5)
-		this.NullableUInt32 = make([]*uint32, v77)
-		for i := 0; i < v77; i++ {
+		vAlue77 := r.Intn(5)
+		this.NullableUInt32 = make([]*uint32, vAlue77)
+		for i := 0; i < vAlue77; i++ {
 			this.NullableUInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v78 := r.Intn(5)
-		this.NonnullUInt32 = make([]uint32, v78)
-		for i := 0; i < v78; i++ {
-			v79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-			this.NonnullUInt32[i] = *v79
+		vAlue78 := r.Intn(5)
+		this.NonnullUInt32 = make([]uint32, vAlue78)
+		for i := 0; i < vAlue78; i++ {
+			vAlue79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+			this.NonnullUInt32[i] = *vAlue79
 		}
 	}
 	if r.Intn(5) != 0 {
-		v80 := r.Intn(5)
-		this.NullableBool = make([]*bool, v80)
-		for i := 0; i < v80; i++ {
+		vAlue80 := r.Intn(5)
+		this.NullableBool = make([]*bool, vAlue80)
+		for i := 0; i < vAlue80; i++ {
 			this.NullableBool[i] = github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v81 := r.Intn(5)
-		this.NonnullBool = make([]bool, v81)
-		for i := 0; i < v81; i++ {
-			v82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-			this.NonnullBool[i] = *v82
+		vAlue81 := r.Intn(5)
+		this.NonnullBool = make([]bool, vAlue81)
+		for i := 0; i < vAlue81; i++ {
+			vAlue82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+			this.NonnullBool[i] = *vAlue82
 		}
 	}
 	if r.Intn(5) != 0 {
-		v83 := r.Intn(5)
-		this.NullableString = make([]*string, v83)
-		for i := 0; i < v83; i++ {
+		vAlue83 := r.Intn(5)
+		this.NullableString = make([]*string, vAlue83)
+		for i := 0; i < vAlue83; i++ {
 			this.NullableString[i] = github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v84 := r.Intn(5)
-		this.NonnullString = make([]string, v84)
-		for i := 0; i < v84; i++ {
-			v85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-			this.NonnullString[i] = *v85
+		vAlue84 := r.Intn(5)
+		this.NonnullString = make([]string, vAlue84)
+		for i := 0; i < vAlue84; i++ {
+			vAlue85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+			this.NonnullString[i] = *vAlue85
 		}
 	}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(5)
-		this.NullableBytes = make([]*[]byte, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(5)
+		this.NullableBytes = make([]*[]byte, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.NullableBytes[i] = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(5)
-		this.NonnullBytes = make([][]byte, v87)
-		for i := 0; i < v87; i++ {
-			v88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-			this.NonnullBytes[i] = *v88
+		vAlue87 := r.Intn(5)
+		this.NonnullBytes = make([][]byte, vAlue87)
+		for i := 0; i < vAlue87; i++ {
+			vAlue88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+			this.NonnullBytes[i] = *vAlue88
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -6763,156 +6763,156 @@ func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 	this := &MapProtoTypes{}
 	if r.Intn(5) != 0 {
-		v89 := r.Intn(10)
+		vAlue89 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*types.Timestamp)
-		for i := 0; i < v89; i++ {
+		for i := 0; i < vAlue89; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(10)
+		vAlue90 := r.Intn(10)
 		this.Timestamp = make(map[int32]types.Timestamp)
-		for i := 0; i < v90; i++ {
+		for i := 0; i < vAlue90; i++ {
 			this.Timestamp[int32(r.Int31())] = *types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v91 := r.Intn(10)
+		vAlue91 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*types.Duration)
-		for i := 0; i < v91; i++ {
+		for i := 0; i < vAlue91; i++ {
 			this.NullableDuration[int32(r.Int31())] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
+		vAlue92 := r.Intn(10)
 		this.Duration = make(map[int32]types.Duration)
-		for i := 0; i < v92; i++ {
+		for i := 0; i < vAlue92; i++ {
 			this.Duration[int32(r.Int31())] = *types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
+		vAlue93 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*types.DoubleValue)
-		for i := 0; i < v93; i++ {
+		for i := 0; i < vAlue93; i++ {
 			this.NullableDouble[int32(r.Int31())] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(10)
+		vAlue94 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]types.DoubleValue)
-		for i := 0; i < v94; i++ {
+		for i := 0; i < vAlue94; i++ {
 			this.NonnullDouble[int32(r.Int31())] = *types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v95 := r.Intn(10)
+		vAlue95 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*types.FloatValue)
-		for i := 0; i < v95; i++ {
+		for i := 0; i < vAlue95; i++ {
 			this.NullableFloat[int32(r.Int31())] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
+		vAlue96 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]types.FloatValue)
-		for i := 0; i < v96; i++ {
+		for i := 0; i < vAlue96; i++ {
 			this.NonnullFloat[int32(r.Int31())] = *types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
+		vAlue97 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*types.Int64Value)
-		for i := 0; i < v97; i++ {
+		for i := 0; i < vAlue97; i++ {
 			this.NullableInt64[int32(r.Int31())] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
+		vAlue98 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]types.Int64Value)
-		for i := 0; i < v98; i++ {
+		for i := 0; i < vAlue98; i++ {
 			this.NonnullInt64[int32(r.Int31())] = *types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v99 := r.Intn(10)
+		vAlue99 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*types.UInt64Value)
-		for i := 0; i < v99; i++ {
+		for i := 0; i < vAlue99; i++ {
 			this.NullableUInt64[int32(r.Int31())] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
+		vAlue100 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]types.UInt64Value)
-		for i := 0; i < v100; i++ {
+		for i := 0; i < vAlue100; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = *types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
+		vAlue101 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*types.Int32Value)
-		for i := 0; i < v101; i++ {
+		for i := 0; i < vAlue101; i++ {
 			this.NullableInt32[int32(r.Int31())] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(10)
+		vAlue102 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]types.Int32Value)
-		for i := 0; i < v102; i++ {
+		for i := 0; i < vAlue102; i++ {
 			this.NonnullInt32[int32(r.Int31())] = *types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(10)
+		vAlue103 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*types.UInt32Value)
-		for i := 0; i < v103; i++ {
+		for i := 0; i < vAlue103; i++ {
 			this.NullableUInt32[int32(r.Int31())] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
+		vAlue104 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]types.UInt32Value)
-		for i := 0; i < v104; i++ {
+		for i := 0; i < vAlue104; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = *types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
+		vAlue105 := r.Intn(10)
 		this.NullableBool = make(map[int32]*types.BoolValue)
-		for i := 0; i < v105; i++ {
+		for i := 0; i < vAlue105; i++ {
 			this.NullableBool[int32(r.Int31())] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(10)
+		vAlue106 := r.Intn(10)
 		this.NonnullBool = make(map[int32]types.BoolValue)
-		for i := 0; i < v106; i++ {
+		for i := 0; i < vAlue106; i++ {
 			this.NonnullBool[int32(r.Int31())] = *types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
+		vAlue107 := r.Intn(10)
 		this.NullableString = make(map[int32]*types.StringValue)
-		for i := 0; i < v107; i++ {
+		for i := 0; i < vAlue107; i++ {
 			this.NullableString[int32(r.Int31())] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
+		vAlue108 := r.Intn(10)
 		this.NonnullString = make(map[int32]types.StringValue)
-		for i := 0; i < v108; i++ {
+		for i := 0; i < vAlue108; i++ {
 			this.NonnullString[int32(r.Int31())] = *types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
+		vAlue109 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*types.BytesValue)
-		for i := 0; i < v109; i++ {
+		for i := 0; i < vAlue109; i++ {
 			this.NullableBytes[int32(r.Int31())] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v110 := r.Intn(10)
+		vAlue110 := r.Intn(10)
 		this.NonnullBytes = make(map[int32]types.BytesValue)
-		for i := 0; i < v110; i++ {
+		for i := 0; i < vAlue110; i++ {
 			this.NonnullBytes[int32(r.Int31())] = *types.NewPopulatedBytesValue(r, easy)
 		}
 	}
@@ -6925,156 +6925,156 @@ func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 func NewPopulatedMapStdTypes(r randyTypes, easy bool) *MapStdTypes {
 	this := &MapStdTypes{}
 	if r.Intn(5) != 0 {
-		v111 := r.Intn(10)
+		vAlue111 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*time.Time)
-		for i := 0; i < v111; i++ {
+		for i := 0; i < vAlue111; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v112 := r.Intn(10)
+		vAlue112 := r.Intn(10)
 		this.Timestamp = make(map[int32]time.Time)
-		for i := 0; i < v112; i++ {
+		for i := 0; i < vAlue112; i++ {
 			this.Timestamp[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v113 := r.Intn(10)
+		vAlue113 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*time.Duration)
-		for i := 0; i < v113; i++ {
+		for i := 0; i < vAlue113; i++ {
 			this.NullableDuration[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(10)
+		vAlue114 := r.Intn(10)
 		this.Duration = make(map[int32]time.Duration)
-		for i := 0; i < v114; i++ {
+		for i := 0; i < vAlue114; i++ {
 			this.Duration[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v115 := r.Intn(10)
+		vAlue115 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*float64)
-		for i := 0; i < v115; i++ {
+		for i := 0; i < vAlue115; i++ {
 			this.NullableDouble[int32(r.Int31())] = (*float64)(github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(10)
+		vAlue116 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]float64)
-		for i := 0; i < v116; i++ {
+		for i := 0; i < vAlue116; i++ {
 			this.NonnullDouble[int32(r.Int31())] = (float64)(*github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v117 := r.Intn(10)
+		vAlue117 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*float32)
-		for i := 0; i < v117; i++ {
+		for i := 0; i < vAlue117; i++ {
 			this.NullableFloat[int32(r.Int31())] = (*float32)(github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v118 := r.Intn(10)
+		vAlue118 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]float32)
-		for i := 0; i < v118; i++ {
+		for i := 0; i < vAlue118; i++ {
 			this.NonnullFloat[int32(r.Int31())] = (float32)(*github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
+		vAlue119 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*int64)
-		for i := 0; i < v119; i++ {
+		for i := 0; i < vAlue119; i++ {
 			this.NullableInt64[int32(r.Int31())] = (*int64)(github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v120 := r.Intn(10)
+		vAlue120 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]int64)
-		for i := 0; i < v120; i++ {
+		for i := 0; i < vAlue120; i++ {
 			this.NonnullInt64[int32(r.Int31())] = (int64)(*github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
+		vAlue121 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*uint64)
-		for i := 0; i < v121; i++ {
+		for i := 0; i < vAlue121; i++ {
 			this.NullableUInt64[int32(r.Int31())] = (*uint64)(github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v122 := r.Intn(10)
+		vAlue122 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]uint64)
-		for i := 0; i < v122; i++ {
+		for i := 0; i < vAlue122; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = (uint64)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
+		vAlue123 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*int32)
-		for i := 0; i < v123; i++ {
+		for i := 0; i < vAlue123; i++ {
 			this.NullableInt32[int32(r.Int31())] = (*int32)(github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v124 := r.Intn(10)
+		vAlue124 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]int32)
-		for i := 0; i < v124; i++ {
+		for i := 0; i < vAlue124; i++ {
 			this.NonnullInt32[int32(r.Int31())] = (int32)(*github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
+		vAlue125 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*uint32)
-		for i := 0; i < v125; i++ {
+		for i := 0; i < vAlue125; i++ {
 			this.NullableUInt32[int32(r.Int31())] = (*uint32)(github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v126 := r.Intn(10)
+		vAlue126 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]uint32)
-		for i := 0; i < v126; i++ {
+		for i := 0; i < vAlue126; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = (uint32)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v127 := r.Intn(10)
+		vAlue127 := r.Intn(10)
 		this.NullableBool = make(map[int32]*bool)
-		for i := 0; i < v127; i++ {
+		for i := 0; i < vAlue127; i++ {
 			this.NullableBool[int32(r.Int31())] = (*bool)(github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v128 := r.Intn(10)
+		vAlue128 := r.Intn(10)
 		this.NonnullBool = make(map[int32]bool)
-		for i := 0; i < v128; i++ {
+		for i := 0; i < vAlue128; i++ {
 			this.NonnullBool[int32(r.Int31())] = (bool)(*github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v129 := r.Intn(10)
+		vAlue129 := r.Intn(10)
 		this.NullableString = make(map[int32]*string)
-		for i := 0; i < v129; i++ {
+		for i := 0; i < vAlue129; i++ {
 			this.NullableString[int32(r.Int31())] = (*string)(github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v130 := r.Intn(10)
+		vAlue130 := r.Intn(10)
 		this.NonnullString = make(map[int32]string)
-		for i := 0; i < v130; i++ {
+		for i := 0; i < vAlue130; i++ {
 			this.NonnullString[int32(r.Int31())] = (string)(*github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v131 := r.Intn(10)
+		vAlue131 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*[]byte)
-		for i := 0; i < v131; i++ {
+		for i := 0; i < vAlue131; i++ {
 			this.NullableBytes[int32(r.Int31())] = (*[]byte)(github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v132 := r.Intn(10)
+		vAlue132 := r.Intn(10)
 		this.NonnullBytes = make(map[int32][]byte)
-		for i := 0; i < v132; i++ {
+		for i := 0; i < vAlue132; i++ {
 			this.NonnullBytes[int32(r.Int31())] = ([]byte)(*github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
@@ -7280,9 +7280,9 @@ func randUTF8RuneTypes(r randyTypes) rune {
 	return rune(ru + 61)
 }
 func randStringTypes(r randyTypes) string {
-	v133 := r.Intn(100)
-	tmps := make([]rune, v133)
-	for i := 0; i < v133; i++ {
+	vAlue133 := r.Intn(100)
+	tmps := make([]rune, vAlue133)
+	for i := 0; i < vAlue133; i++ {
 		tmps[i] = randUTF8RuneTypes(r)
 	}
 	return string(tmps)
@@ -7304,11 +7304,11 @@ func randFieldTypes(dAtA []byte, r randyTypes, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
-		v134 := r.Int63()
+		vAlue134 := r.Int63()
 		if r.Intn(2) == 0 {
-			v134 *= -1
+			vAlue134 *= -1
 		}
-		dAtA = encodeVarintPopulateTypes(dAtA, uint64(v134))
+		dAtA = encodeVarintPopulateTypes(dAtA, uint64(vAlue134))
 	case 1:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/types/combos/unmarshaler/types.pb.go
+++ b/test/types/combos/unmarshaler/types.pb.go
@@ -6324,28 +6324,28 @@ func NewPopulatedProtoTypes(r randyTypes, easy bool) *ProtoTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = types.NewPopulatedBytesValue(r, easy)
 	}
-	v1 := types.NewPopulatedTimestamp(r, easy)
-	this.Timestamp = *v1
-	v2 := types.NewPopulatedDuration(r, easy)
-	this.Duration = *v2
-	v3 := types.NewPopulatedDoubleValue(r, easy)
-	this.NonnullDouble = *v3
-	v4 := types.NewPopulatedFloatValue(r, easy)
-	this.NonnullFloat = *v4
-	v5 := types.NewPopulatedInt64Value(r, easy)
-	this.NonnullInt64 = *v5
-	v6 := types.NewPopulatedUInt64Value(r, easy)
-	this.NonnullUInt64 = *v6
-	v7 := types.NewPopulatedInt32Value(r, easy)
-	this.NonnullInt32 = *v7
-	v8 := types.NewPopulatedUInt32Value(r, easy)
-	this.NonnullUInt32 = *v8
-	v9 := types.NewPopulatedBoolValue(r, easy)
-	this.NonnullBool = *v9
-	v10 := types.NewPopulatedStringValue(r, easy)
-	this.NonnullString = *v10
-	v11 := types.NewPopulatedBytesValue(r, easy)
-	this.NonnullBytes = *v11
+	vAlue1 := types.NewPopulatedTimestamp(r, easy)
+	this.Timestamp = *vAlue1
+	vAlue2 := types.NewPopulatedDuration(r, easy)
+	this.Duration = *vAlue2
+	vAlue3 := types.NewPopulatedDoubleValue(r, easy)
+	this.NonnullDouble = *vAlue3
+	vAlue4 := types.NewPopulatedFloatValue(r, easy)
+	this.NonnullFloat = *vAlue4
+	vAlue5 := types.NewPopulatedInt64Value(r, easy)
+	this.NonnullInt64 = *vAlue5
+	vAlue6 := types.NewPopulatedUInt64Value(r, easy)
+	this.NonnullUInt64 = *vAlue6
+	vAlue7 := types.NewPopulatedInt32Value(r, easy)
+	this.NonnullInt32 = *vAlue7
+	vAlue8 := types.NewPopulatedUInt32Value(r, easy)
+	this.NonnullUInt32 = *vAlue8
+	vAlue9 := types.NewPopulatedBoolValue(r, easy)
+	this.NonnullBool = *vAlue9
+	vAlue10 := types.NewPopulatedStringValue(r, easy)
+	this.NonnullString = *vAlue10
+	vAlue11 := types.NewPopulatedBytesValue(r, easy)
+	this.NonnullBytes = *vAlue11
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -6387,28 +6387,28 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 	if r.Intn(5) != 0 {
 		this.NullableBytes = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 	}
-	v12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-	this.Timestamp = *v12
-	v13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-	this.Duration = *v13
-	v14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-	this.NonnullDouble = *v14
-	v15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-	this.NonnullFloat = *v15
-	v16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-	this.NonnullInt64 = *v16
-	v17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-	this.NonnullUInt64 = *v17
-	v18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-	this.NonnullInt32 = *v18
-	v19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-	this.NonnullUInt32 = *v19
-	v20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-	this.NonnullBool = *v20
-	v21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-	this.NonnullString = *v21
-	v22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-	this.NonnullBytes = *v22
+	vAlue12 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+	this.Timestamp = *vAlue12
+	vAlue13 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+	this.Duration = *vAlue13
+	vAlue14 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+	this.NonnullDouble = *vAlue14
+	vAlue15 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+	this.NonnullFloat = *vAlue15
+	vAlue16 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+	this.NonnullInt64 = *vAlue16
+	vAlue17 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+	this.NonnullUInt64 = *vAlue17
+	vAlue18 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+	this.NonnullInt32 = *vAlue18
+	vAlue19 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+	this.NonnullUInt32 = *vAlue19
+	vAlue20 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+	this.NonnullBool = *vAlue20
+	vAlue21 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+	this.NonnullString = *vAlue21
+	vAlue22 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+	this.NonnullBytes = *vAlue22
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedTypes(r, 23)
 	}
@@ -6418,168 +6418,168 @@ func NewPopulatedStdTypes(r randyTypes, easy bool) *StdTypes {
 func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 	this := &RepProtoTypes{}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(5)
-		this.NullableTimestamps = make([]*types.Timestamp, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(5)
+		this.NullableTimestamps = make([]*types.Timestamp, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.NullableTimestamps[i] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(5)
-		this.NullableDurations = make([]*types.Duration, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(5)
+		this.NullableDurations = make([]*types.Duration, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.NullableDurations[i] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(5)
-		this.Timestamps = make([]types.Timestamp, v25)
-		for i := 0; i < v25; i++ {
-			v26 := types.NewPopulatedTimestamp(r, easy)
-			this.Timestamps[i] = *v26
+		vAlue25 := r.Intn(5)
+		this.Timestamps = make([]types.Timestamp, vAlue25)
+		for i := 0; i < vAlue25; i++ {
+			vAlue26 := types.NewPopulatedTimestamp(r, easy)
+			this.Timestamps[i] = *vAlue26
 		}
 	}
 	if r.Intn(5) != 0 {
-		v27 := r.Intn(5)
-		this.Durations = make([]types.Duration, v27)
-		for i := 0; i < v27; i++ {
-			v28 := types.NewPopulatedDuration(r, easy)
-			this.Durations[i] = *v28
+		vAlue27 := r.Intn(5)
+		this.Durations = make([]types.Duration, vAlue27)
+		for i := 0; i < vAlue27; i++ {
+			vAlue28 := types.NewPopulatedDuration(r, easy)
+			this.Durations[i] = *vAlue28
 		}
 	}
 	if r.Intn(5) != 0 {
-		v29 := r.Intn(5)
-		this.NullableDouble = make([]*types.DoubleValue, v29)
-		for i := 0; i < v29; i++ {
+		vAlue29 := r.Intn(5)
+		this.NullableDouble = make([]*types.DoubleValue, vAlue29)
+		for i := 0; i < vAlue29; i++ {
 			this.NullableDouble[i] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v30 := r.Intn(5)
-		this.NonnullDouble = make([]types.DoubleValue, v30)
-		for i := 0; i < v30; i++ {
-			v31 := types.NewPopulatedDoubleValue(r, easy)
-			this.NonnullDouble[i] = *v31
+		vAlue30 := r.Intn(5)
+		this.NonnullDouble = make([]types.DoubleValue, vAlue30)
+		for i := 0; i < vAlue30; i++ {
+			vAlue31 := types.NewPopulatedDoubleValue(r, easy)
+			this.NonnullDouble[i] = *vAlue31
 		}
 	}
 	if r.Intn(5) != 0 {
-		v32 := r.Intn(5)
-		this.NullableFloat = make([]*types.FloatValue, v32)
-		for i := 0; i < v32; i++ {
+		vAlue32 := r.Intn(5)
+		this.NullableFloat = make([]*types.FloatValue, vAlue32)
+		for i := 0; i < vAlue32; i++ {
 			this.NullableFloat[i] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v33 := r.Intn(5)
-		this.NonnullFloat = make([]types.FloatValue, v33)
-		for i := 0; i < v33; i++ {
-			v34 := types.NewPopulatedFloatValue(r, easy)
-			this.NonnullFloat[i] = *v34
+		vAlue33 := r.Intn(5)
+		this.NonnullFloat = make([]types.FloatValue, vAlue33)
+		for i := 0; i < vAlue33; i++ {
+			vAlue34 := types.NewPopulatedFloatValue(r, easy)
+			this.NonnullFloat[i] = *vAlue34
 		}
 	}
 	if r.Intn(5) != 0 {
-		v35 := r.Intn(5)
-		this.NullableInt64 = make([]*types.Int64Value, v35)
-		for i := 0; i < v35; i++ {
+		vAlue35 := r.Intn(5)
+		this.NullableInt64 = make([]*types.Int64Value, vAlue35)
+		for i := 0; i < vAlue35; i++ {
 			this.NullableInt64[i] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v36 := r.Intn(5)
-		this.NonnullInt64 = make([]types.Int64Value, v36)
-		for i := 0; i < v36; i++ {
-			v37 := types.NewPopulatedInt64Value(r, easy)
-			this.NonnullInt64[i] = *v37
+		vAlue36 := r.Intn(5)
+		this.NonnullInt64 = make([]types.Int64Value, vAlue36)
+		for i := 0; i < vAlue36; i++ {
+			vAlue37 := types.NewPopulatedInt64Value(r, easy)
+			this.NonnullInt64[i] = *vAlue37
 		}
 	}
 	if r.Intn(5) != 0 {
-		v38 := r.Intn(5)
-		this.NullableUInt64 = make([]*types.UInt64Value, v38)
-		for i := 0; i < v38; i++ {
+		vAlue38 := r.Intn(5)
+		this.NullableUInt64 = make([]*types.UInt64Value, vAlue38)
+		for i := 0; i < vAlue38; i++ {
 			this.NullableUInt64[i] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v39 := r.Intn(5)
-		this.NonnullUInt64 = make([]types.UInt64Value, v39)
-		for i := 0; i < v39; i++ {
-			v40 := types.NewPopulatedUInt64Value(r, easy)
-			this.NonnullUInt64[i] = *v40
+		vAlue39 := r.Intn(5)
+		this.NonnullUInt64 = make([]types.UInt64Value, vAlue39)
+		for i := 0; i < vAlue39; i++ {
+			vAlue40 := types.NewPopulatedUInt64Value(r, easy)
+			this.NonnullUInt64[i] = *vAlue40
 		}
 	}
 	if r.Intn(5) != 0 {
-		v41 := r.Intn(5)
-		this.NullableInt32 = make([]*types.Int32Value, v41)
-		for i := 0; i < v41; i++ {
+		vAlue41 := r.Intn(5)
+		this.NullableInt32 = make([]*types.Int32Value, vAlue41)
+		for i := 0; i < vAlue41; i++ {
 			this.NullableInt32[i] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v42 := r.Intn(5)
-		this.NonnullInt32 = make([]types.Int32Value, v42)
-		for i := 0; i < v42; i++ {
-			v43 := types.NewPopulatedInt32Value(r, easy)
-			this.NonnullInt32[i] = *v43
+		vAlue42 := r.Intn(5)
+		this.NonnullInt32 = make([]types.Int32Value, vAlue42)
+		for i := 0; i < vAlue42; i++ {
+			vAlue43 := types.NewPopulatedInt32Value(r, easy)
+			this.NonnullInt32[i] = *vAlue43
 		}
 	}
 	if r.Intn(5) != 0 {
-		v44 := r.Intn(5)
-		this.NullableUInt32 = make([]*types.UInt32Value, v44)
-		for i := 0; i < v44; i++ {
+		vAlue44 := r.Intn(5)
+		this.NullableUInt32 = make([]*types.UInt32Value, vAlue44)
+		for i := 0; i < vAlue44; i++ {
 			this.NullableUInt32[i] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v45 := r.Intn(5)
-		this.NonnullUInt32 = make([]types.UInt32Value, v45)
-		for i := 0; i < v45; i++ {
-			v46 := types.NewPopulatedUInt32Value(r, easy)
-			this.NonnullUInt32[i] = *v46
+		vAlue45 := r.Intn(5)
+		this.NonnullUInt32 = make([]types.UInt32Value, vAlue45)
+		for i := 0; i < vAlue45; i++ {
+			vAlue46 := types.NewPopulatedUInt32Value(r, easy)
+			this.NonnullUInt32[i] = *vAlue46
 		}
 	}
 	if r.Intn(5) != 0 {
-		v47 := r.Intn(5)
-		this.NullableBool = make([]*types.BoolValue, v47)
-		for i := 0; i < v47; i++ {
+		vAlue47 := r.Intn(5)
+		this.NullableBool = make([]*types.BoolValue, vAlue47)
+		for i := 0; i < vAlue47; i++ {
 			this.NullableBool[i] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v48 := r.Intn(5)
-		this.NonnullBool = make([]types.BoolValue, v48)
-		for i := 0; i < v48; i++ {
-			v49 := types.NewPopulatedBoolValue(r, easy)
-			this.NonnullBool[i] = *v49
+		vAlue48 := r.Intn(5)
+		this.NonnullBool = make([]types.BoolValue, vAlue48)
+		for i := 0; i < vAlue48; i++ {
+			vAlue49 := types.NewPopulatedBoolValue(r, easy)
+			this.NonnullBool[i] = *vAlue49
 		}
 	}
 	if r.Intn(5) != 0 {
-		v50 := r.Intn(5)
-		this.NullableString = make([]*types.StringValue, v50)
-		for i := 0; i < v50; i++ {
+		vAlue50 := r.Intn(5)
+		this.NullableString = make([]*types.StringValue, vAlue50)
+		for i := 0; i < vAlue50; i++ {
 			this.NullableString[i] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v51 := r.Intn(5)
-		this.NonnullString = make([]types.StringValue, v51)
-		for i := 0; i < v51; i++ {
-			v52 := types.NewPopulatedStringValue(r, easy)
-			this.NonnullString[i] = *v52
+		vAlue51 := r.Intn(5)
+		this.NonnullString = make([]types.StringValue, vAlue51)
+		for i := 0; i < vAlue51; i++ {
+			vAlue52 := types.NewPopulatedStringValue(r, easy)
+			this.NonnullString[i] = *vAlue52
 		}
 	}
 	if r.Intn(5) != 0 {
-		v53 := r.Intn(5)
-		this.NullableBytes = make([]*types.BytesValue, v53)
-		for i := 0; i < v53; i++ {
+		vAlue53 := r.Intn(5)
+		this.NullableBytes = make([]*types.BytesValue, vAlue53)
+		for i := 0; i < vAlue53; i++ {
 			this.NullableBytes[i] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v54 := r.Intn(5)
-		this.NonnullBytes = make([]types.BytesValue, v54)
-		for i := 0; i < v54; i++ {
-			v55 := types.NewPopulatedBytesValue(r, easy)
-			this.NonnullBytes[i] = *v55
+		vAlue54 := r.Intn(5)
+		this.NonnullBytes = make([]types.BytesValue, vAlue54)
+		for i := 0; i < vAlue54; i++ {
+			vAlue55 := types.NewPopulatedBytesValue(r, easy)
+			this.NonnullBytes[i] = *vAlue55
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -6591,168 +6591,168 @@ func NewPopulatedRepProtoTypes(r randyTypes, easy bool) *RepProtoTypes {
 func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 	this := &RepStdTypes{}
 	if r.Intn(5) != 0 {
-		v56 := r.Intn(5)
-		this.NullableTimestamps = make([]*time.Time, v56)
-		for i := 0; i < v56; i++ {
+		vAlue56 := r.Intn(5)
+		this.NullableTimestamps = make([]*time.Time, vAlue56)
+		for i := 0; i < vAlue56; i++ {
 			this.NullableTimestamps[i] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v57 := r.Intn(5)
-		this.NullableDurations = make([]*time.Duration, v57)
-		for i := 0; i < v57; i++ {
+		vAlue57 := r.Intn(5)
+		this.NullableDurations = make([]*time.Duration, vAlue57)
+		for i := 0; i < vAlue57; i++ {
 			this.NullableDurations[i] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v58 := r.Intn(5)
-		this.Timestamps = make([]time.Time, v58)
-		for i := 0; i < v58; i++ {
-			v59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
-			this.Timestamps[i] = *v59
+		vAlue58 := r.Intn(5)
+		this.Timestamps = make([]time.Time, vAlue58)
+		for i := 0; i < vAlue58; i++ {
+			vAlue59 := github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
+			this.Timestamps[i] = *vAlue59
 		}
 	}
 	if r.Intn(5) != 0 {
-		v60 := r.Intn(5)
-		this.Durations = make([]time.Duration, v60)
-		for i := 0; i < v60; i++ {
-			v61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
-			this.Durations[i] = *v61
+		vAlue60 := r.Intn(5)
+		this.Durations = make([]time.Duration, vAlue60)
+		for i := 0; i < vAlue60; i++ {
+			vAlue61 := github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
+			this.Durations[i] = *vAlue61
 		}
 	}
 	if r.Intn(5) != 0 {
-		v62 := r.Intn(5)
-		this.NullableDouble = make([]*float64, v62)
-		for i := 0; i < v62; i++ {
+		vAlue62 := r.Intn(5)
+		this.NullableDouble = make([]*float64, vAlue62)
+		for i := 0; i < vAlue62; i++ {
 			this.NullableDouble[i] = github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v63 := r.Intn(5)
-		this.NonnullDouble = make([]float64, v63)
-		for i := 0; i < v63; i++ {
-			v64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
-			this.NonnullDouble[i] = *v64
+		vAlue63 := r.Intn(5)
+		this.NonnullDouble = make([]float64, vAlue63)
+		for i := 0; i < vAlue63; i++ {
+			vAlue64 := github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy)
+			this.NonnullDouble[i] = *vAlue64
 		}
 	}
 	if r.Intn(5) != 0 {
-		v65 := r.Intn(5)
-		this.NullableFloat = make([]*float32, v65)
-		for i := 0; i < v65; i++ {
+		vAlue65 := r.Intn(5)
+		this.NullableFloat = make([]*float32, vAlue65)
+		for i := 0; i < vAlue65; i++ {
 			this.NullableFloat[i] = github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v66 := r.Intn(5)
-		this.NonnullFloat = make([]float32, v66)
-		for i := 0; i < v66; i++ {
-			v67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
-			this.NonnullFloat[i] = *v67
+		vAlue66 := r.Intn(5)
+		this.NonnullFloat = make([]float32, vAlue66)
+		for i := 0; i < vAlue66; i++ {
+			vAlue67 := github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy)
+			this.NonnullFloat[i] = *vAlue67
 		}
 	}
 	if r.Intn(5) != 0 {
-		v68 := r.Intn(5)
-		this.NullableInt64 = make([]*int64, v68)
-		for i := 0; i < v68; i++ {
+		vAlue68 := r.Intn(5)
+		this.NullableInt64 = make([]*int64, vAlue68)
+		for i := 0; i < vAlue68; i++ {
 			this.NullableInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v69 := r.Intn(5)
-		this.NonnullInt64 = make([]int64, v69)
-		for i := 0; i < v69; i++ {
-			v70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
-			this.NonnullInt64[i] = *v70
+		vAlue69 := r.Intn(5)
+		this.NonnullInt64 = make([]int64, vAlue69)
+		for i := 0; i < vAlue69; i++ {
+			vAlue70 := github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy)
+			this.NonnullInt64[i] = *vAlue70
 		}
 	}
 	if r.Intn(5) != 0 {
-		v71 := r.Intn(5)
-		this.NullableUInt64 = make([]*uint64, v71)
-		for i := 0; i < v71; i++ {
+		vAlue71 := r.Intn(5)
+		this.NullableUInt64 = make([]*uint64, vAlue71)
+		for i := 0; i < vAlue71; i++ {
 			this.NullableUInt64[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v72 := r.Intn(5)
-		this.NonnullUInt64 = make([]uint64, v72)
-		for i := 0; i < v72; i++ {
-			v73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
-			this.NonnullUInt64[i] = *v73
+		vAlue72 := r.Intn(5)
+		this.NonnullUInt64 = make([]uint64, vAlue72)
+		for i := 0; i < vAlue72; i++ {
+			vAlue73 := github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy)
+			this.NonnullUInt64[i] = *vAlue73
 		}
 	}
 	if r.Intn(5) != 0 {
-		v74 := r.Intn(5)
-		this.NullableInt32 = make([]*int32, v74)
-		for i := 0; i < v74; i++ {
+		vAlue74 := r.Intn(5)
+		this.NullableInt32 = make([]*int32, vAlue74)
+		for i := 0; i < vAlue74; i++ {
 			this.NullableInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v75 := r.Intn(5)
-		this.NonnullInt32 = make([]int32, v75)
-		for i := 0; i < v75; i++ {
-			v76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
-			this.NonnullInt32[i] = *v76
+		vAlue75 := r.Intn(5)
+		this.NonnullInt32 = make([]int32, vAlue75)
+		for i := 0; i < vAlue75; i++ {
+			vAlue76 := github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy)
+			this.NonnullInt32[i] = *vAlue76
 		}
 	}
 	if r.Intn(5) != 0 {
-		v77 := r.Intn(5)
-		this.NullableUInt32 = make([]*uint32, v77)
-		for i := 0; i < v77; i++ {
+		vAlue77 := r.Intn(5)
+		this.NullableUInt32 = make([]*uint32, vAlue77)
+		for i := 0; i < vAlue77; i++ {
 			this.NullableUInt32[i] = github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v78 := r.Intn(5)
-		this.NonnullUInt32 = make([]uint32, v78)
-		for i := 0; i < v78; i++ {
-			v79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
-			this.NonnullUInt32[i] = *v79
+		vAlue78 := r.Intn(5)
+		this.NonnullUInt32 = make([]uint32, vAlue78)
+		for i := 0; i < vAlue78; i++ {
+			vAlue79 := github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy)
+			this.NonnullUInt32[i] = *vAlue79
 		}
 	}
 	if r.Intn(5) != 0 {
-		v80 := r.Intn(5)
-		this.NullableBool = make([]*bool, v80)
-		for i := 0; i < v80; i++ {
+		vAlue80 := r.Intn(5)
+		this.NullableBool = make([]*bool, vAlue80)
+		for i := 0; i < vAlue80; i++ {
 			this.NullableBool[i] = github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v81 := r.Intn(5)
-		this.NonnullBool = make([]bool, v81)
-		for i := 0; i < v81; i++ {
-			v82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
-			this.NonnullBool[i] = *v82
+		vAlue81 := r.Intn(5)
+		this.NonnullBool = make([]bool, vAlue81)
+		for i := 0; i < vAlue81; i++ {
+			vAlue82 := github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy)
+			this.NonnullBool[i] = *vAlue82
 		}
 	}
 	if r.Intn(5) != 0 {
-		v83 := r.Intn(5)
-		this.NullableString = make([]*string, v83)
-		for i := 0; i < v83; i++ {
+		vAlue83 := r.Intn(5)
+		this.NullableString = make([]*string, vAlue83)
+		for i := 0; i < vAlue83; i++ {
 			this.NullableString[i] = github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v84 := r.Intn(5)
-		this.NonnullString = make([]string, v84)
-		for i := 0; i < v84; i++ {
-			v85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
-			this.NonnullString[i] = *v85
+		vAlue84 := r.Intn(5)
+		this.NonnullString = make([]string, vAlue84)
+		for i := 0; i < vAlue84; i++ {
+			vAlue85 := github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy)
+			this.NonnullString[i] = *vAlue85
 		}
 	}
 	if r.Intn(5) != 0 {
-		v86 := r.Intn(5)
-		this.NullableBytes = make([]*[]byte, v86)
-		for i := 0; i < v86; i++ {
+		vAlue86 := r.Intn(5)
+		this.NullableBytes = make([]*[]byte, vAlue86)
+		for i := 0; i < vAlue86; i++ {
 			this.NullableBytes[i] = github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v87 := r.Intn(5)
-		this.NonnullBytes = make([][]byte, v87)
-		for i := 0; i < v87; i++ {
-			v88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
-			this.NonnullBytes[i] = *v88
+		vAlue87 := r.Intn(5)
+		this.NonnullBytes = make([][]byte, vAlue87)
+		for i := 0; i < vAlue87; i++ {
+			vAlue88 := github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy)
+			this.NonnullBytes[i] = *vAlue88
 		}
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -6764,156 +6764,156 @@ func NewPopulatedRepStdTypes(r randyTypes, easy bool) *RepStdTypes {
 func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 	this := &MapProtoTypes{}
 	if r.Intn(5) != 0 {
-		v89 := r.Intn(10)
+		vAlue89 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*types.Timestamp)
-		for i := 0; i < v89; i++ {
+		for i := 0; i < vAlue89; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v90 := r.Intn(10)
+		vAlue90 := r.Intn(10)
 		this.Timestamp = make(map[int32]types.Timestamp)
-		for i := 0; i < v90; i++ {
+		for i := 0; i < vAlue90; i++ {
 			this.Timestamp[int32(r.Int31())] = *types.NewPopulatedTimestamp(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v91 := r.Intn(10)
+		vAlue91 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*types.Duration)
-		for i := 0; i < v91; i++ {
+		for i := 0; i < vAlue91; i++ {
 			this.NullableDuration[int32(r.Int31())] = types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v92 := r.Intn(10)
+		vAlue92 := r.Intn(10)
 		this.Duration = make(map[int32]types.Duration)
-		for i := 0; i < v92; i++ {
+		for i := 0; i < vAlue92; i++ {
 			this.Duration[int32(r.Int31())] = *types.NewPopulatedDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v93 := r.Intn(10)
+		vAlue93 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*types.DoubleValue)
-		for i := 0; i < v93; i++ {
+		for i := 0; i < vAlue93; i++ {
 			this.NullableDouble[int32(r.Int31())] = types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v94 := r.Intn(10)
+		vAlue94 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]types.DoubleValue)
-		for i := 0; i < v94; i++ {
+		for i := 0; i < vAlue94; i++ {
 			this.NonnullDouble[int32(r.Int31())] = *types.NewPopulatedDoubleValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v95 := r.Intn(10)
+		vAlue95 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*types.FloatValue)
-		for i := 0; i < v95; i++ {
+		for i := 0; i < vAlue95; i++ {
 			this.NullableFloat[int32(r.Int31())] = types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v96 := r.Intn(10)
+		vAlue96 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]types.FloatValue)
-		for i := 0; i < v96; i++ {
+		for i := 0; i < vAlue96; i++ {
 			this.NonnullFloat[int32(r.Int31())] = *types.NewPopulatedFloatValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v97 := r.Intn(10)
+		vAlue97 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*types.Int64Value)
-		for i := 0; i < v97; i++ {
+		for i := 0; i < vAlue97; i++ {
 			this.NullableInt64[int32(r.Int31())] = types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v98 := r.Intn(10)
+		vAlue98 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]types.Int64Value)
-		for i := 0; i < v98; i++ {
+		for i := 0; i < vAlue98; i++ {
 			this.NonnullInt64[int32(r.Int31())] = *types.NewPopulatedInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v99 := r.Intn(10)
+		vAlue99 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*types.UInt64Value)
-		for i := 0; i < v99; i++ {
+		for i := 0; i < vAlue99; i++ {
 			this.NullableUInt64[int32(r.Int31())] = types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v100 := r.Intn(10)
+		vAlue100 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]types.UInt64Value)
-		for i := 0; i < v100; i++ {
+		for i := 0; i < vAlue100; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = *types.NewPopulatedUInt64Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v101 := r.Intn(10)
+		vAlue101 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*types.Int32Value)
-		for i := 0; i < v101; i++ {
+		for i := 0; i < vAlue101; i++ {
 			this.NullableInt32[int32(r.Int31())] = types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v102 := r.Intn(10)
+		vAlue102 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]types.Int32Value)
-		for i := 0; i < v102; i++ {
+		for i := 0; i < vAlue102; i++ {
 			this.NonnullInt32[int32(r.Int31())] = *types.NewPopulatedInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v103 := r.Intn(10)
+		vAlue103 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*types.UInt32Value)
-		for i := 0; i < v103; i++ {
+		for i := 0; i < vAlue103; i++ {
 			this.NullableUInt32[int32(r.Int31())] = types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v104 := r.Intn(10)
+		vAlue104 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]types.UInt32Value)
-		for i := 0; i < v104; i++ {
+		for i := 0; i < vAlue104; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = *types.NewPopulatedUInt32Value(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v105 := r.Intn(10)
+		vAlue105 := r.Intn(10)
 		this.NullableBool = make(map[int32]*types.BoolValue)
-		for i := 0; i < v105; i++ {
+		for i := 0; i < vAlue105; i++ {
 			this.NullableBool[int32(r.Int31())] = types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v106 := r.Intn(10)
+		vAlue106 := r.Intn(10)
 		this.NonnullBool = make(map[int32]types.BoolValue)
-		for i := 0; i < v106; i++ {
+		for i := 0; i < vAlue106; i++ {
 			this.NonnullBool[int32(r.Int31())] = *types.NewPopulatedBoolValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v107 := r.Intn(10)
+		vAlue107 := r.Intn(10)
 		this.NullableString = make(map[int32]*types.StringValue)
-		for i := 0; i < v107; i++ {
+		for i := 0; i < vAlue107; i++ {
 			this.NullableString[int32(r.Int31())] = types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v108 := r.Intn(10)
+		vAlue108 := r.Intn(10)
 		this.NonnullString = make(map[int32]types.StringValue)
-		for i := 0; i < v108; i++ {
+		for i := 0; i < vAlue108; i++ {
 			this.NonnullString[int32(r.Int31())] = *types.NewPopulatedStringValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v109 := r.Intn(10)
+		vAlue109 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*types.BytesValue)
-		for i := 0; i < v109; i++ {
+		for i := 0; i < vAlue109; i++ {
 			this.NullableBytes[int32(r.Int31())] = types.NewPopulatedBytesValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v110 := r.Intn(10)
+		vAlue110 := r.Intn(10)
 		this.NonnullBytes = make(map[int32]types.BytesValue)
-		for i := 0; i < v110; i++ {
+		for i := 0; i < vAlue110; i++ {
 			this.NonnullBytes[int32(r.Int31())] = *types.NewPopulatedBytesValue(r, easy)
 		}
 	}
@@ -6926,156 +6926,156 @@ func NewPopulatedMapProtoTypes(r randyTypes, easy bool) *MapProtoTypes {
 func NewPopulatedMapStdTypes(r randyTypes, easy bool) *MapStdTypes {
 	this := &MapStdTypes{}
 	if r.Intn(5) != 0 {
-		v111 := r.Intn(10)
+		vAlue111 := r.Intn(10)
 		this.NullableTimestamp = make(map[int32]*time.Time)
-		for i := 0; i < v111; i++ {
+		for i := 0; i < vAlue111; i++ {
 			this.NullableTimestamp[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v112 := r.Intn(10)
+		vAlue112 := r.Intn(10)
 		this.Timestamp = make(map[int32]time.Time)
-		for i := 0; i < v112; i++ {
+		for i := 0; i < vAlue112; i++ {
 			this.Timestamp[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdTime(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v113 := r.Intn(10)
+		vAlue113 := r.Intn(10)
 		this.NullableDuration = make(map[int32]*time.Duration)
-		for i := 0; i < v113; i++ {
+		for i := 0; i < vAlue113; i++ {
 			this.NullableDuration[int32(r.Int31())] = github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v114 := r.Intn(10)
+		vAlue114 := r.Intn(10)
 		this.Duration = make(map[int32]time.Duration)
-		for i := 0; i < v114; i++ {
+		for i := 0; i < vAlue114; i++ {
 			this.Duration[int32(r.Int31())] = *github_com_gogo_protobuf_types.NewPopulatedStdDuration(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v115 := r.Intn(10)
+		vAlue115 := r.Intn(10)
 		this.NullableDouble = make(map[int32]*float64)
-		for i := 0; i < v115; i++ {
+		for i := 0; i < vAlue115; i++ {
 			this.NullableDouble[int32(r.Int31())] = (*float64)(github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v116 := r.Intn(10)
+		vAlue116 := r.Intn(10)
 		this.NonnullDouble = make(map[int32]float64)
-		for i := 0; i < v116; i++ {
+		for i := 0; i < vAlue116; i++ {
 			this.NonnullDouble[int32(r.Int31())] = (float64)(*github_com_gogo_protobuf_types.NewPopulatedStdDouble(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v117 := r.Intn(10)
+		vAlue117 := r.Intn(10)
 		this.NullableFloat = make(map[int32]*float32)
-		for i := 0; i < v117; i++ {
+		for i := 0; i < vAlue117; i++ {
 			this.NullableFloat[int32(r.Int31())] = (*float32)(github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v118 := r.Intn(10)
+		vAlue118 := r.Intn(10)
 		this.NonnullFloat = make(map[int32]float32)
-		for i := 0; i < v118; i++ {
+		for i := 0; i < vAlue118; i++ {
 			this.NonnullFloat[int32(r.Int31())] = (float32)(*github_com_gogo_protobuf_types.NewPopulatedStdFloat(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v119 := r.Intn(10)
+		vAlue119 := r.Intn(10)
 		this.NullableInt64 = make(map[int32]*int64)
-		for i := 0; i < v119; i++ {
+		for i := 0; i < vAlue119; i++ {
 			this.NullableInt64[int32(r.Int31())] = (*int64)(github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v120 := r.Intn(10)
+		vAlue120 := r.Intn(10)
 		this.NonnullInt64 = make(map[int32]int64)
-		for i := 0; i < v120; i++ {
+		for i := 0; i < vAlue120; i++ {
 			this.NonnullInt64[int32(r.Int31())] = (int64)(*github_com_gogo_protobuf_types.NewPopulatedStdInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v121 := r.Intn(10)
+		vAlue121 := r.Intn(10)
 		this.NullableUInt64 = make(map[int32]*uint64)
-		for i := 0; i < v121; i++ {
+		for i := 0; i < vAlue121; i++ {
 			this.NullableUInt64[int32(r.Int31())] = (*uint64)(github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v122 := r.Intn(10)
+		vAlue122 := r.Intn(10)
 		this.NonnullUInt64 = make(map[int32]uint64)
-		for i := 0; i < v122; i++ {
+		for i := 0; i < vAlue122; i++ {
 			this.NonnullUInt64[int32(r.Int31())] = (uint64)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt64(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v123 := r.Intn(10)
+		vAlue123 := r.Intn(10)
 		this.NullableInt32 = make(map[int32]*int32)
-		for i := 0; i < v123; i++ {
+		for i := 0; i < vAlue123; i++ {
 			this.NullableInt32[int32(r.Int31())] = (*int32)(github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v124 := r.Intn(10)
+		vAlue124 := r.Intn(10)
 		this.NonnullInt32 = make(map[int32]int32)
-		for i := 0; i < v124; i++ {
+		for i := 0; i < vAlue124; i++ {
 			this.NonnullInt32[int32(r.Int31())] = (int32)(*github_com_gogo_protobuf_types.NewPopulatedStdInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v125 := r.Intn(10)
+		vAlue125 := r.Intn(10)
 		this.NullableUInt32 = make(map[int32]*uint32)
-		for i := 0; i < v125; i++ {
+		for i := 0; i < vAlue125; i++ {
 			this.NullableUInt32[int32(r.Int31())] = (*uint32)(github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v126 := r.Intn(10)
+		vAlue126 := r.Intn(10)
 		this.NonnullUInt32 = make(map[int32]uint32)
-		for i := 0; i < v126; i++ {
+		for i := 0; i < vAlue126; i++ {
 			this.NonnullUInt32[int32(r.Int31())] = (uint32)(*github_com_gogo_protobuf_types.NewPopulatedStdUInt32(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v127 := r.Intn(10)
+		vAlue127 := r.Intn(10)
 		this.NullableBool = make(map[int32]*bool)
-		for i := 0; i < v127; i++ {
+		for i := 0; i < vAlue127; i++ {
 			this.NullableBool[int32(r.Int31())] = (*bool)(github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v128 := r.Intn(10)
+		vAlue128 := r.Intn(10)
 		this.NonnullBool = make(map[int32]bool)
-		for i := 0; i < v128; i++ {
+		for i := 0; i < vAlue128; i++ {
 			this.NonnullBool[int32(r.Int31())] = (bool)(*github_com_gogo_protobuf_types.NewPopulatedStdBool(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v129 := r.Intn(10)
+		vAlue129 := r.Intn(10)
 		this.NullableString = make(map[int32]*string)
-		for i := 0; i < v129; i++ {
+		for i := 0; i < vAlue129; i++ {
 			this.NullableString[int32(r.Int31())] = (*string)(github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v130 := r.Intn(10)
+		vAlue130 := r.Intn(10)
 		this.NonnullString = make(map[int32]string)
-		for i := 0; i < v130; i++ {
+		for i := 0; i < vAlue130; i++ {
 			this.NonnullString[int32(r.Int31())] = (string)(*github_com_gogo_protobuf_types.NewPopulatedStdString(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v131 := r.Intn(10)
+		vAlue131 := r.Intn(10)
 		this.NullableBytes = make(map[int32]*[]byte)
-		for i := 0; i < v131; i++ {
+		for i := 0; i < vAlue131; i++ {
 			this.NullableBytes[int32(r.Int31())] = (*[]byte)(github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v132 := r.Intn(10)
+		vAlue132 := r.Intn(10)
 		this.NonnullBytes = make(map[int32][]byte)
-		for i := 0; i < v132; i++ {
+		for i := 0; i < vAlue132; i++ {
 			this.NonnullBytes[int32(r.Int31())] = ([]byte)(*github_com_gogo_protobuf_types.NewPopulatedStdBytes(r, easy))
 		}
 	}
@@ -7281,9 +7281,9 @@ func randUTF8RuneTypes(r randyTypes) rune {
 	return rune(ru + 61)
 }
 func randStringTypes(r randyTypes) string {
-	v133 := r.Intn(100)
-	tmps := make([]rune, v133)
-	for i := 0; i < v133; i++ {
+	vAlue133 := r.Intn(100)
+	tmps := make([]rune, vAlue133)
+	for i := 0; i < vAlue133; i++ {
 		tmps[i] = randUTF8RuneTypes(r)
 	}
 	return string(tmps)
@@ -7305,11 +7305,11 @@ func randFieldTypes(dAtA []byte, r randyTypes, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
-		v134 := r.Int63()
+		vAlue134 := r.Int63()
 		if r.Intn(2) == 0 {
-			v134 *= -1
+			vAlue134 *= -1
 		}
-		dAtA = encodeVarintPopulateTypes(dAtA, uint64(v134))
+		dAtA = encodeVarintPopulateTypes(dAtA, uint64(vAlue134))
 	case 1:
 		dAtA = encodeVarintPopulateTypes(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/unmarshalmerge/unmarshalmerge.pb.go
+++ b/test/unmarshalmerge/unmarshalmerge.pb.go
@@ -745,11 +745,11 @@ func NewPopulatedBig(r randyUnmarshalmerge, easy bool) *Big {
 		this.Sub = NewPopulatedSub(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v1 := int64(r.Int63())
+		vAlue1 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Number = &v1
+		this.Number = &vAlue1
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedUnmarshalmerge(r, 3)
@@ -763,11 +763,11 @@ func NewPopulatedBigUnsafe(r randyUnmarshalmerge, easy bool) *BigUnsafe {
 		this.Sub = NewPopulatedSub(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v2 := int64(r.Int63())
+		vAlue2 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Number = &v2
+		this.Number = &vAlue2
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedUnmarshalmerge(r, 3)
@@ -778,11 +778,11 @@ func NewPopulatedBigUnsafe(r randyUnmarshalmerge, easy bool) *BigUnsafe {
 func NewPopulatedSub(r randyUnmarshalmerge, easy bool) *Sub {
 	this := &Sub{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.SubNumber = &v3
+		this.SubNumber = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedUnmarshalmerge(r, 2)
@@ -846,9 +846,9 @@ func randUTF8RuneUnmarshalmerge(r randyUnmarshalmerge) rune {
 	return rune(ru + 61)
 }
 func randStringUnmarshalmerge(r randyUnmarshalmerge) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	vAlue4 := r.Intn(100)
+	tmps := make([]rune, vAlue4)
+	for i := 0; i < vAlue4; i++ {
 		tmps[i] = randUTF8RuneUnmarshalmerge(r)
 	}
 	return string(tmps)
@@ -870,11 +870,11 @@ func randFieldUnmarshalmerge(dAtA []byte, r randyUnmarshalmerge, fieldNumber int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateUnmarshalmerge(dAtA, uint64(key))
-		v5 := r.Int63()
+		vAlue5 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			vAlue5 *= -1
 		}
-		dAtA = encodeVarintPopulateUnmarshalmerge(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateUnmarshalmerge(dAtA, uint64(vAlue5))
 	case 1:
 		dAtA = encodeVarintPopulateUnmarshalmerge(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/unrecognized/unrecognized.pb.go
+++ b/test/unrecognized/unrecognized.pb.go
@@ -2494,18 +2494,18 @@ func encodeVarintUnrecognized(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedA(r randyUnrecognized, easy bool) *A {
 	this := &A{}
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(5)
-		this.B = make([]*B, v1)
-		for i := 0; i < v1; i++ {
+		vAlue1 := r.Intn(5)
+		this.B = make([]*B, vAlue1)
+		for i := 0; i < vAlue1; i++ {
 			this.B[i] = NewPopulatedB(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := int64(r.Int63())
+		vAlue2 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field1 = &v2
+		this.Field1 = &vAlue2
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -2532,11 +2532,11 @@ func NewPopulatedB(r randyUnrecognized, easy bool) *B {
 func NewPopulatedD(r randyUnrecognized, easy bool) *D {
 	this := &D{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field1 = &v3
+		this.Field1 = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedUnrecognized(r, 2)
@@ -2547,45 +2547,45 @@ func NewPopulatedD(r randyUnrecognized, easy bool) *D {
 func NewPopulatedC(r randyUnrecognized, easy bool) *C {
 	this := &C{}
 	if r.Intn(5) != 0 {
-		v4 := float64(r.Float64())
+		vAlue4 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field2 = &v4
+		this.Field2 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
-		v5 := string(randStringUnrecognized(r))
-		this.Field3 = &v5
+		vAlue5 := string(randStringUnrecognized(r))
+		this.Field3 = &vAlue5
 	}
 	if r.Intn(5) != 0 {
-		v6 := float64(r.Float64())
+		vAlue6 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		this.Field4 = &v6
+		this.Field4 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(10)
-		this.Field5 = make([][]byte, v7)
-		for i := 0; i < v7; i++ {
-			v8 := r.Intn(100)
-			this.Field5[i] = make([]byte, v8)
-			for j := 0; j < v8; j++ {
+		vAlue7 := r.Intn(10)
+		this.Field5 = make([][]byte, vAlue7)
+		for i := 0; i < vAlue7; i++ {
+			vAlue8 := r.Intn(100)
+			this.Field5[i] = make([]byte, vAlue8)
+			for j := 0; j < vAlue8; j++ {
 				this.Field5[i][j] = byte(r.Intn(256))
 			}
 		}
 	}
 	if r.Intn(5) != 0 {
-		v9 := int64(r.Int63())
+		vAlue9 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		this.Field6 = &v9
+		this.Field6 = &vAlue9
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
-		this.Field7 = make([]float32, v10)
-		for i := 0; i < v10; i++ {
+		vAlue10 := r.Intn(10)
+		this.Field7 = make([]float32, vAlue10)
+		for i := 0; i < vAlue10; i++ {
 			this.Field7[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -2601,9 +2601,9 @@ func NewPopulatedC(r randyUnrecognized, easy bool) *C {
 func NewPopulatedU(r randyUnrecognized, easy bool) *U {
 	this := &U{}
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
-		this.Field2 = make([]float64, v11)
-		for i := 0; i < v11; i++ {
+		vAlue11 := r.Intn(10)
+		this.Field2 = make([]float64, vAlue11)
+		for i := 0; i < vAlue11; i++ {
 			this.Field2[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -2611,8 +2611,8 @@ func NewPopulatedU(r randyUnrecognized, easy bool) *U {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := uint32(r.Uint32())
-		this.Field3 = &v12
+		vAlue12 := uint32(r.Uint32())
+		this.Field3 = &vAlue12
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -2622,9 +2622,9 @@ func NewPopulatedU(r randyUnrecognized, easy bool) *U {
 func NewPopulatedUnoM(r randyUnrecognized, easy bool) *UnoM {
 	this := &UnoM{}
 	if r.Intn(5) != 0 {
-		v13 := r.Intn(10)
-		this.Field2 = make([]float64, v13)
-		for i := 0; i < v13; i++ {
+		vAlue13 := r.Intn(10)
+		this.Field2 = make([]float64, vAlue13)
+		for i := 0; i < vAlue13; i++ {
 			this.Field2[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -2632,8 +2632,8 @@ func NewPopulatedUnoM(r randyUnrecognized, easy bool) *UnoM {
 		}
 	}
 	if r.Intn(5) != 0 {
-		v14 := uint32(r.Uint32())
-		this.Field3 = &v14
+		vAlue14 := uint32(r.Uint32())
+		this.Field3 = &vAlue14
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -2643,18 +2643,18 @@ func NewPopulatedUnoM(r randyUnrecognized, easy bool) *UnoM {
 func NewPopulatedOldA(r randyUnrecognized, easy bool) *OldA {
 	this := &OldA{}
 	if r.Intn(5) != 0 {
-		v15 := r.Intn(5)
-		this.B = make([]*OldB, v15)
-		for i := 0; i < v15; i++ {
+		vAlue15 := r.Intn(5)
+		this.B = make([]*OldB, vAlue15)
+		for i := 0; i < vAlue15; i++ {
 			this.B[i] = NewPopulatedOldB(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v16 := int64(r.Int63())
+		vAlue16 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v16 *= -1
+			vAlue16 *= -1
 		}
-		this.Field1 = &v16
+		this.Field1 = &vAlue16
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -2678,34 +2678,34 @@ func NewPopulatedOldB(r randyUnrecognized, easy bool) *OldB {
 func NewPopulatedOldC(r randyUnrecognized, easy bool) *OldC {
 	this := &OldC{}
 	if r.Intn(5) != 0 {
-		v17 := int64(r.Int63())
+		vAlue17 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v17 *= -1
+			vAlue17 *= -1
 		}
-		this.Field1 = &v17
+		this.Field1 = &vAlue17
 	}
 	if r.Intn(5) != 0 {
-		v18 := float64(r.Float64())
+		vAlue18 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v18 *= -1
+			vAlue18 *= -1
 		}
-		this.Field2 = &v18
+		this.Field2 = &vAlue18
 	}
 	if r.Intn(5) != 0 {
-		v19 := string(randStringUnrecognized(r))
-		this.Field3 = &v19
+		vAlue19 := string(randStringUnrecognized(r))
+		this.Field3 = &vAlue19
 	}
 	if r.Intn(5) != 0 {
-		v20 := int64(r.Int63())
+		vAlue20 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v20 *= -1
+			vAlue20 *= -1
 		}
-		this.Field6 = &v20
+		this.Field6 = &vAlue20
 	}
 	if r.Intn(5) != 0 {
-		v21 := r.Intn(10)
-		this.Field7 = make([]float32, v21)
-		for i := 0; i < v21; i++ {
+		vAlue21 := r.Intn(10)
+		this.Field7 = make([]float32, vAlue21)
+		for i := 0; i < vAlue21; i++ {
 			this.Field7[i] = float32(r.Float32())
 			if r.Intn(2) == 0 {
 				this.Field7[i] *= -1
@@ -2721,13 +2721,13 @@ func NewPopulatedOldC(r randyUnrecognized, easy bool) *OldC {
 func NewPopulatedOldU(r randyUnrecognized, easy bool) *OldU {
 	this := &OldU{}
 	if r.Intn(5) != 0 {
-		v22 := string(randStringUnrecognized(r))
-		this.Field1 = &v22
+		vAlue22 := string(randStringUnrecognized(r))
+		this.Field1 = &vAlue22
 	}
 	if r.Intn(5) != 0 {
-		v23 := r.Intn(10)
-		this.Field2 = make([]float64, v23)
-		for i := 0; i < v23; i++ {
+		vAlue23 := r.Intn(10)
+		this.Field2 = make([]float64, vAlue23)
+		for i := 0; i < vAlue23; i++ {
 			this.Field2[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -2743,13 +2743,13 @@ func NewPopulatedOldU(r randyUnrecognized, easy bool) *OldU {
 func NewPopulatedOldUnoM(r randyUnrecognized, easy bool) *OldUnoM {
 	this := &OldUnoM{}
 	if r.Intn(5) != 0 {
-		v24 := string(randStringUnrecognized(r))
-		this.Field1 = &v24
+		vAlue24 := string(randStringUnrecognized(r))
+		this.Field1 = &vAlue24
 	}
 	if r.Intn(5) != 0 {
-		v25 := r.Intn(10)
-		this.Field2 = make([]float64, v25)
-		for i := 0; i < v25; i++ {
+		vAlue25 := r.Intn(10)
+		this.Field2 = make([]float64, vAlue25)
+		for i := 0; i < vAlue25; i++ {
 			this.Field2[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -2781,9 +2781,9 @@ func randUTF8RuneUnrecognized(r randyUnrecognized) rune {
 	return rune(ru + 61)
 }
 func randStringUnrecognized(r randyUnrecognized) string {
-	v26 := r.Intn(100)
-	tmps := make([]rune, v26)
-	for i := 0; i < v26; i++ {
+	vAlue26 := r.Intn(100)
+	tmps := make([]rune, vAlue26)
+	for i := 0; i < vAlue26; i++ {
 		tmps[i] = randUTF8RuneUnrecognized(r)
 	}
 	return string(tmps)
@@ -2805,11 +2805,11 @@ func randFieldUnrecognized(dAtA []byte, r randyUnrecognized, fieldNumber int, wi
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateUnrecognized(dAtA, uint64(key))
-		v27 := r.Int63()
+		vAlue27 := r.Int63()
 		if r.Intn(2) == 0 {
-			v27 *= -1
+			vAlue27 *= -1
 		}
-		dAtA = encodeVarintPopulateUnrecognized(dAtA, uint64(v27))
+		dAtA = encodeVarintPopulateUnrecognized(dAtA, uint64(vAlue27))
 	case 1:
 		dAtA = encodeVarintPopulateUnrecognized(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/unrecognizedgroup/unrecognizedgroup.pb.go
+++ b/test/unrecognizedgroup/unrecognizedgroup.pb.go
@@ -1192,16 +1192,16 @@ func encodeVarintUnrecognizedgroup(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedNewNoGroup(r randyUnrecognizedgroup, easy bool) *NewNoGroup {
 	this := &NewNoGroup{}
 	if r.Intn(5) != 0 {
-		v1 := int64(r.Int63())
+		vAlue1 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Field1 = &v1
+		this.Field1 = &vAlue1
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(10)
-		this.Field3 = make([]float64, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(10)
+		this.Field3 = make([]float64, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Field3[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -1220,11 +1220,11 @@ func NewPopulatedNewNoGroup(r randyUnrecognizedgroup, easy bool) *NewNoGroup {
 func NewPopulatedA(r randyUnrecognizedgroup, easy bool) *A {
 	this := &A{}
 	if r.Intn(5) != 0 {
-		v3 := int64(r.Int63())
+		vAlue3 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.AField = &v3
+		this.AField = &vAlue3
 	}
 	if !easy && r.Intn(10) != 0 {
 		this.XXX_unrecognized = randUnrecognizedUnrecognizedgroup(r, 2)
@@ -1235,19 +1235,19 @@ func NewPopulatedA(r randyUnrecognizedgroup, easy bool) *A {
 func NewPopulatedOldWithGroup(r randyUnrecognizedgroup, easy bool) *OldWithGroup {
 	this := &OldWithGroup{}
 	if r.Intn(5) != 0 {
-		v4 := int64(r.Int63())
+		vAlue4 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field1 = &v4
+		this.Field1 = &vAlue4
 	}
 	if r.Intn(5) != 0 {
 		this.Group1 = NewPopulatedOldWithGroup_Group1(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(10)
-		this.Field3 = make([]float64, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(10)
+		this.Field3 = make([]float64, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.Field3[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -1266,23 +1266,23 @@ func NewPopulatedOldWithGroup(r randyUnrecognizedgroup, easy bool) *OldWithGroup
 func NewPopulatedOldWithGroup_Group1(r randyUnrecognizedgroup, easy bool) *OldWithGroup_Group1 {
 	this := &OldWithGroup_Group1{}
 	if r.Intn(5) != 0 {
-		v6 := int64(r.Int63())
+		vAlue6 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		this.Field1 = &v6
+		this.Field1 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := int32(r.Int31())
+		vAlue7 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v7 *= -1
+			vAlue7 *= -1
 		}
-		this.Field2 = &v7
+		this.Field2 = &vAlue7
 	}
 	if r.Intn(5) != 0 {
-		v8 := r.Intn(10)
-		this.Field3 = make([]float64, v8)
-		for i := 0; i < v8; i++ {
+		vAlue8 := r.Intn(10)
+		this.Field3 = make([]float64, vAlue8)
+		for i := 0; i < vAlue8; i++ {
 			this.Field3[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field3[i] *= -1
@@ -1298,16 +1298,16 @@ func NewPopulatedOldWithGroup_Group1(r randyUnrecognizedgroup, easy bool) *OldWi
 func NewPopulatedOldWithGroup_Group2(r randyUnrecognizedgroup, easy bool) *OldWithGroup_Group2 {
 	this := &OldWithGroup_Group2{}
 	if r.Intn(5) != 0 {
-		v9 := int64(r.Int63())
+		vAlue9 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		this.Field1 = &v9
+		this.Field1 = &vAlue9
 	}
 	if r.Intn(5) != 0 {
-		v10 := r.Intn(10)
-		this.Field2 = make([]float64, v10)
-		for i := 0; i < v10; i++ {
+		vAlue10 := r.Intn(10)
+		this.Field2 = make([]float64, vAlue10)
+		for i := 0; i < vAlue10; i++ {
 			this.Field2[i] = float64(r.Float64())
 			if r.Intn(2) == 0 {
 				this.Field2[i] *= -1
@@ -1339,9 +1339,9 @@ func randUTF8RuneUnrecognizedgroup(r randyUnrecognizedgroup) rune {
 	return rune(ru + 61)
 }
 func randStringUnrecognizedgroup(r randyUnrecognizedgroup) string {
-	v11 := r.Intn(100)
-	tmps := make([]rune, v11)
-	for i := 0; i < v11; i++ {
+	vAlue11 := r.Intn(100)
+	tmps := make([]rune, vAlue11)
+	for i := 0; i < vAlue11; i++ {
 		tmps[i] = randUTF8RuneUnrecognizedgroup(r)
 	}
 	return string(tmps)
@@ -1363,11 +1363,11 @@ func randFieldUnrecognizedgroup(dAtA []byte, r randyUnrecognizedgroup, fieldNumb
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateUnrecognizedgroup(dAtA, uint64(key))
-		v12 := r.Int63()
+		vAlue12 := r.Int63()
 		if r.Intn(2) == 0 {
-			v12 *= -1
+			vAlue12 *= -1
 		}
-		dAtA = encodeVarintPopulateUnrecognizedgroup(dAtA, uint64(v12))
+		dAtA = encodeVarintPopulateUnrecognizedgroup(dAtA, uint64(vAlue12))
 	case 1:
 		dAtA = encodeVarintPopulateUnrecognizedgroup(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/test/xxxfields/xxxfields.pb.go
+++ b/test/xxxfields/xxxfields.pb.go
@@ -736,46 +736,46 @@ func (this *StructWithoutSizeCache) Equal(that interface{}) bool {
 func NewPopulatedNativeWithSizeCache(r randyXxxfields, easy bool) *NativeWithSizeCache {
 	this := &NativeWithSizeCache{}
 	if r.Intn(5) != 0 {
-		v1 := float64(r.Float64())
+		vAlue1 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v1 *= -1
+			vAlue1 *= -1
 		}
-		this.Field1 = &v1
+		this.Field1 = &vAlue1
 	}
 	if r.Intn(5) != 0 {
-		v2 := float32(r.Float32())
+		vAlue2 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		this.Field2 = &v2
+		this.Field2 = &vAlue2
 	}
 	if r.Intn(5) != 0 {
-		v3 := int32(r.Int31())
+		vAlue3 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		this.Field3 = &v3
+		this.Field3 = &vAlue3
 	}
 	if r.Intn(5) != 0 {
-		v4 := int64(r.Int63())
+		vAlue4 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		this.Field4 = &v4
+		this.Field4 = &vAlue4
 	}
 	this.Field11 = uint64(uint64(r.Uint32()))
 	if r.Intn(5) != 0 {
-		v5 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v5
+		vAlue5 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue5
 	}
 	if r.Intn(5) != 0 {
-		v6 := string(randStringXxxfields(r))
-		this.Field14 = &v6
+		vAlue6 := string(randStringXxxfields(r))
+		this.Field14 = &vAlue6
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(100)
-		this.Field15 = make([]byte, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -794,32 +794,32 @@ func NewPopulatedStructWithSizeCache(r randyXxxfields, easy bool) *StructWithSiz
 	if r.Intn(2) == 0 {
 		this.Field2 *= -1
 	}
-	v8 := NewPopulatedNativeWithSizeCache(r, easy)
-	this.Field3 = *v8
+	vAlue8 := NewPopulatedNativeWithSizeCache(r, easy)
+	this.Field3 = *vAlue8
 	if r.Intn(5) != 0 {
-		v9 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v9
+		vAlue9 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue9
 	}
 	this.Field7 = int32(r.Int31())
 	if r.Intn(2) == 0 {
 		this.Field7 *= -1
 	}
-	v10 := NewPopulatedNativeWithoutSizeCache(r, easy)
-	this.Field8 = *v10
+	vAlue10 := NewPopulatedNativeWithoutSizeCache(r, easy)
+	this.Field8 = *vAlue10
 	if r.Intn(5) != 0 {
-		v11 := r.Intn(10)
-		this.Field13 = make([]bool, v11)
-		for i := 0; i < v11; i++ {
+		vAlue11 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue11)
+		for i := 0; i < vAlue11; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v12 := string(randStringXxxfields(r))
-		this.Field14 = &v12
+		vAlue12 := string(randStringXxxfields(r))
+		this.Field14 = &vAlue12
 	}
-	v13 := r.Intn(100)
-	this.Field15 = make([]byte, v13)
-	for i := 0; i < v13; i++ {
+	vAlue13 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue13)
+	for i := 0; i < vAlue13; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -830,46 +830,46 @@ func NewPopulatedStructWithSizeCache(r randyXxxfields, easy bool) *StructWithSiz
 func NewPopulatedNativeWithoutSizeCache(r randyXxxfields, easy bool) *NativeWithoutSizeCache {
 	this := &NativeWithoutSizeCache{}
 	if r.Intn(5) != 0 {
-		v14 := float64(r.Float64())
+		vAlue14 := float64(r.Float64())
 		if r.Intn(2) == 0 {
-			v14 *= -1
+			vAlue14 *= -1
 		}
-		this.Field1 = &v14
+		this.Field1 = &vAlue14
 	}
 	if r.Intn(5) != 0 {
-		v15 := float32(r.Float32())
+		vAlue15 := float32(r.Float32())
 		if r.Intn(2) == 0 {
-			v15 *= -1
+			vAlue15 *= -1
 		}
-		this.Field2 = &v15
+		this.Field2 = &vAlue15
 	}
 	if r.Intn(5) != 0 {
-		v16 := int32(r.Int31())
+		vAlue16 := int32(r.Int31())
 		if r.Intn(2) == 0 {
-			v16 *= -1
+			vAlue16 *= -1
 		}
-		this.Field3 = &v16
+		this.Field3 = &vAlue16
 	}
 	if r.Intn(5) != 0 {
-		v17 := int64(r.Int63())
+		vAlue17 := int64(r.Int63())
 		if r.Intn(2) == 0 {
-			v17 *= -1
+			vAlue17 *= -1
 		}
-		this.Field4 = &v17
+		this.Field4 = &vAlue17
 	}
 	this.Field11 = uint64(uint64(r.Uint32()))
 	if r.Intn(5) != 0 {
-		v18 := bool(bool(r.Intn(2) == 0))
-		this.Field13 = &v18
+		vAlue18 := bool(bool(r.Intn(2) == 0))
+		this.Field13 = &vAlue18
 	}
 	if r.Intn(5) != 0 {
-		v19 := string(randStringXxxfields(r))
-		this.Field14 = &v19
+		vAlue19 := string(randStringXxxfields(r))
+		this.Field14 = &vAlue19
 	}
 	if r.Intn(5) != 0 {
-		v20 := r.Intn(100)
-		this.Field15 = make([]byte, v20)
-		for i := 0; i < v20; i++ {
+		vAlue20 := r.Intn(100)
+		this.Field15 = make([]byte, vAlue20)
+		for i := 0; i < vAlue20; i++ {
 			this.Field15[i] = byte(r.Intn(256))
 		}
 	}
@@ -888,32 +888,32 @@ func NewPopulatedStructWithoutSizeCache(r randyXxxfields, easy bool) *StructWith
 	if r.Intn(2) == 0 {
 		this.Field2 *= -1
 	}
-	v21 := NewPopulatedNativeWithSizeCache(r, easy)
-	this.Field3 = *v21
+	vAlue21 := NewPopulatedNativeWithSizeCache(r, easy)
+	this.Field3 = *vAlue21
 	if r.Intn(5) != 0 {
-		v22 := uint64(uint64(r.Uint32()))
-		this.Field6 = &v22
+		vAlue22 := uint64(uint64(r.Uint32()))
+		this.Field6 = &vAlue22
 	}
 	this.Field7 = int32(r.Int31())
 	if r.Intn(2) == 0 {
 		this.Field7 *= -1
 	}
-	v23 := NewPopulatedNativeWithoutSizeCache(r, easy)
-	this.Field8 = *v23
+	vAlue23 := NewPopulatedNativeWithoutSizeCache(r, easy)
+	this.Field8 = *vAlue23
 	if r.Intn(5) != 0 {
-		v24 := r.Intn(10)
-		this.Field13 = make([]bool, v24)
-		for i := 0; i < v24; i++ {
+		vAlue24 := r.Intn(10)
+		this.Field13 = make([]bool, vAlue24)
+		for i := 0; i < vAlue24; i++ {
 			this.Field13[i] = bool(bool(r.Intn(2) == 0))
 		}
 	}
 	if r.Intn(5) != 0 {
-		v25 := string(randStringXxxfields(r))
-		this.Field14 = &v25
+		vAlue25 := string(randStringXxxfields(r))
+		this.Field14 = &vAlue25
 	}
-	v26 := r.Intn(100)
-	this.Field15 = make([]byte, v26)
-	for i := 0; i < v26; i++ {
+	vAlue26 := r.Intn(100)
+	this.Field15 = make([]byte, vAlue26)
+	for i := 0; i < vAlue26; i++ {
 		this.Field15[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -940,9 +940,9 @@ func randUTF8RuneXxxfields(r randyXxxfields) rune {
 	return rune(ru + 61)
 }
 func randStringXxxfields(r randyXxxfields) string {
-	v27 := r.Intn(100)
-	tmps := make([]rune, v27)
-	for i := 0; i < v27; i++ {
+	vAlue27 := r.Intn(100)
+	tmps := make([]rune, vAlue27)
+	for i := 0; i < vAlue27; i++ {
 		tmps[i] = randUTF8RuneXxxfields(r)
 	}
 	return string(tmps)
@@ -964,11 +964,11 @@ func randFieldXxxfields(dAtA []byte, r randyXxxfields, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateXxxfields(dAtA, uint64(key))
-		v28 := r.Int63()
+		vAlue28 := r.Int63()
 		if r.Intn(2) == 0 {
-			v28 *= -1
+			vAlue28 *= -1
 		}
-		dAtA = encodeVarintPopulateXxxfields(dAtA, uint64(v28))
+		dAtA = encodeVarintPopulateXxxfields(dAtA, uint64(vAlue28))
 	case 1:
 		dAtA = encodeVarintPopulateXxxfields(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/any.pb.go
+++ b/types/any.pb.go
@@ -362,9 +362,9 @@ func encodeVarintAny(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedAny(r randyAny, easy bool) *Any {
 	this := &Any{}
 	this.TypeUrl = string(randStringAny(r))
-	v1 := r.Intn(100)
-	this.Value = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Value = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Value[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -392,9 +392,9 @@ func randUTF8RuneAny(r randyAny) rune {
 	return rune(ru + 61)
 }
 func randStringAny(r randyAny) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneAny(r)
 	}
 	return string(tmps)
@@ -416,11 +416,11 @@ func randFieldAny(dAtA []byte, r randyAny, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateAny(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateAny(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateAny(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateAny(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/api.pb.go
+++ b/types/api.pb.go
@@ -1103,16 +1103,16 @@ func NewPopulatedApi(r randyApi, easy bool) *Api {
 	this := &Api{}
 	this.Name = string(randStringApi(r))
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(5)
-		this.Methods = make([]*Method, v1)
-		for i := 0; i < v1; i++ {
+		vAlue1 := r.Intn(5)
+		this.Methods = make([]*Method, vAlue1)
+		for i := 0; i < vAlue1; i++ {
 			this.Methods[i] = NewPopulatedMethod(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v2 := r.Intn(5)
-		this.Options = make([]*Option, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(5)
+		this.Options = make([]*Option, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Options[i] = NewPopulatedOption(r, easy)
 		}
 	}
@@ -1121,9 +1121,9 @@ func NewPopulatedApi(r randyApi, easy bool) *Api {
 		this.SourceContext = NewPopulatedSourceContext(r, easy)
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(5)
-		this.Mixins = make([]*Mixin, v3)
-		for i := 0; i < v3; i++ {
+		vAlue3 := r.Intn(5)
+		this.Mixins = make([]*Mixin, vAlue3)
+		for i := 0; i < vAlue3; i++ {
 			this.Mixins[i] = NewPopulatedMixin(r, easy)
 		}
 	}
@@ -1142,9 +1142,9 @@ func NewPopulatedMethod(r randyApi, easy bool) *Method {
 	this.ResponseTypeUrl = string(randStringApi(r))
 	this.ResponseStreaming = bool(bool(r.Intn(2) == 0))
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(5)
-		this.Options = make([]*Option, v4)
-		for i := 0; i < v4; i++ {
+		vAlue4 := r.Intn(5)
+		this.Options = make([]*Option, vAlue4)
+		for i := 0; i < vAlue4; i++ {
 			this.Options[i] = NewPopulatedOption(r, easy)
 		}
 	}
@@ -1184,9 +1184,9 @@ func randUTF8RuneApi(r randyApi) rune {
 	return rune(ru + 61)
 }
 func randStringApi(r randyApi) string {
-	v5 := r.Intn(100)
-	tmps := make([]rune, v5)
-	for i := 0; i < v5; i++ {
+	vAlue5 := r.Intn(100)
+	tmps := make([]rune, vAlue5)
+	for i := 0; i < vAlue5; i++ {
 		tmps[i] = randUTF8RuneApi(r)
 	}
 	return string(tmps)
@@ -1208,11 +1208,11 @@ func randFieldApi(dAtA []byte, r randyApi, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateApi(dAtA, uint64(key))
-		v6 := r.Int63()
+		vAlue6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v6 *= -1
+			vAlue6 *= -1
 		}
-		dAtA = encodeVarintPopulateApi(dAtA, uint64(v6))
+		dAtA = encodeVarintPopulateApi(dAtA, uint64(vAlue6))
 	case 1:
 		dAtA = encodeVarintPopulateApi(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/empty.pb.go
+++ b/types/empty.pb.go
@@ -236,9 +236,9 @@ func randUTF8RuneEmpty(r randyEmpty) rune {
 	return rune(ru + 61)
 }
 func randStringEmpty(r randyEmpty) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneEmpty(r)
 	}
 	return string(tmps)
@@ -260,11 +260,11 @@ func randFieldEmpty(dAtA []byte, r randyEmpty, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateEmpty(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateEmpty(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateEmpty(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateEmpty(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/field_mask.pb.go
+++ b/types/field_mask.pb.go
@@ -443,9 +443,9 @@ func encodeVarintFieldMask(dAtA []byte, offset int, v uint64) int {
 }
 func NewPopulatedFieldMask(r randyFieldMask, easy bool) *FieldMask {
 	this := &FieldMask{}
-	v1 := r.Intn(10)
-	this.Paths = make([]string, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(10)
+	this.Paths = make([]string, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Paths[i] = string(randStringFieldMask(r))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -473,9 +473,9 @@ func randUTF8RuneFieldMask(r randyFieldMask) rune {
 	return rune(ru + 61)
 }
 func randStringFieldMask(r randyFieldMask) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneFieldMask(r)
 	}
 	return string(tmps)
@@ -497,11 +497,11 @@ func randFieldFieldMask(dAtA []byte, r randyFieldMask, fieldNumber int, wire int
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateFieldMask(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateFieldMask(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateFieldMask(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateFieldMask(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/source_context.pb.go
+++ b/types/source_context.pb.go
@@ -261,9 +261,9 @@ func randUTF8RuneSourceContext(r randySourceContext) rune {
 	return rune(ru + 61)
 }
 func randStringSourceContext(r randySourceContext) string {
-	v1 := r.Intn(100)
-	tmps := make([]rune, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	tmps := make([]rune, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		tmps[i] = randUTF8RuneSourceContext(r)
 	}
 	return string(tmps)
@@ -285,11 +285,11 @@ func randFieldSourceContext(dAtA []byte, r randySourceContext, fieldNumber int, 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateSourceContext(dAtA, uint64(key))
-		v2 := r.Int63()
+		vAlue2 := r.Int63()
 		if r.Intn(2) == 0 {
-			v2 *= -1
+			vAlue2 *= -1
 		}
-		dAtA = encodeVarintPopulateSourceContext(dAtA, uint64(v2))
+		dAtA = encodeVarintPopulateSourceContext(dAtA, uint64(vAlue2))
 	case 1:
 		dAtA = encodeVarintPopulateSourceContext(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/struct.pb.go
+++ b/types/struct.pb.go
@@ -1319,9 +1319,9 @@ func encodeVarintStruct(dAtA []byte, offset int, v uint64) int {
 func NewPopulatedStruct(r randyStruct, easy bool) *Struct {
 	this := &Struct{}
 	if r.Intn(5) == 0 {
-		v1 := r.Intn(10)
+		vAlue1 := r.Intn(10)
 		this.Fields = make(map[string]*Value)
-		for i := 0; i < v1; i++ {
+		for i := 0; i < vAlue1; i++ {
 			this.Fields[randStringStruct(r)] = NewPopulatedValue(r, easy)
 		}
 	}
@@ -1390,9 +1390,9 @@ func NewPopulatedValue_ListValue(r randyStruct, easy bool) *Value_ListValue {
 func NewPopulatedListValue(r randyStruct, easy bool) *ListValue {
 	this := &ListValue{}
 	if r.Intn(5) == 0 {
-		v2 := r.Intn(5)
-		this.Values = make([]*Value, v2)
-		for i := 0; i < v2; i++ {
+		vAlue2 := r.Intn(5)
+		this.Values = make([]*Value, vAlue2)
+		for i := 0; i < vAlue2; i++ {
 			this.Values[i] = NewPopulatedValue(r, easy)
 		}
 	}
@@ -1421,9 +1421,9 @@ func randUTF8RuneStruct(r randyStruct) rune {
 	return rune(ru + 61)
 }
 func randStringStruct(r randyStruct) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	vAlue3 := r.Intn(100)
+	tmps := make([]rune, vAlue3)
+	for i := 0; i < vAlue3; i++ {
 		tmps[i] = randUTF8RuneStruct(r)
 	}
 	return string(tmps)
@@ -1445,11 +1445,11 @@ func randFieldStruct(dAtA []byte, r randyStruct, fieldNumber int, wire int) []by
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateStruct(dAtA, uint64(key))
-		v4 := r.Int63()
+		vAlue4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			vAlue4 *= -1
 		}
-		dAtA = encodeVarintPopulateStruct(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateStruct(dAtA, uint64(vAlue4))
 	case 1:
 		dAtA = encodeVarintPopulateStruct(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/type.pb.go
+++ b/types/type.pb.go
@@ -1782,21 +1782,21 @@ func NewPopulatedType(r randyType, easy bool) *Type {
 	this := &Type{}
 	this.Name = string(randStringType(r))
 	if r.Intn(5) != 0 {
-		v1 := r.Intn(5)
-		this.Fields = make([]*Field, v1)
-		for i := 0; i < v1; i++ {
+		vAlue1 := r.Intn(5)
+		this.Fields = make([]*Field, vAlue1)
+		for i := 0; i < vAlue1; i++ {
 			this.Fields[i] = NewPopulatedField(r, easy)
 		}
 	}
-	v2 := r.Intn(10)
-	this.Oneofs = make([]string, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(10)
+	this.Oneofs = make([]string, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		this.Oneofs[i] = string(randStringType(r))
 	}
 	if r.Intn(5) != 0 {
-		v3 := r.Intn(5)
-		this.Options = make([]*Option, v3)
-		for i := 0; i < v3; i++ {
+		vAlue3 := r.Intn(5)
+		this.Options = make([]*Option, vAlue3)
+		for i := 0; i < vAlue3; i++ {
 			this.Options[i] = NewPopulatedOption(r, easy)
 		}
 	}
@@ -1826,9 +1826,9 @@ func NewPopulatedField(r randyType, easy bool) *Field {
 	}
 	this.Packed = bool(bool(r.Intn(2) == 0))
 	if r.Intn(5) != 0 {
-		v4 := r.Intn(5)
-		this.Options = make([]*Option, v4)
-		for i := 0; i < v4; i++ {
+		vAlue4 := r.Intn(5)
+		this.Options = make([]*Option, vAlue4)
+		for i := 0; i < vAlue4; i++ {
 			this.Options[i] = NewPopulatedOption(r, easy)
 		}
 	}
@@ -1844,16 +1844,16 @@ func NewPopulatedEnum(r randyType, easy bool) *Enum {
 	this := &Enum{}
 	this.Name = string(randStringType(r))
 	if r.Intn(5) != 0 {
-		v5 := r.Intn(5)
-		this.Enumvalue = make([]*EnumValue, v5)
-		for i := 0; i < v5; i++ {
+		vAlue5 := r.Intn(5)
+		this.Enumvalue = make([]*EnumValue, vAlue5)
+		for i := 0; i < vAlue5; i++ {
 			this.Enumvalue[i] = NewPopulatedEnumValue(r, easy)
 		}
 	}
 	if r.Intn(5) != 0 {
-		v6 := r.Intn(5)
-		this.Options = make([]*Option, v6)
-		for i := 0; i < v6; i++ {
+		vAlue6 := r.Intn(5)
+		this.Options = make([]*Option, vAlue6)
+		for i := 0; i < vAlue6; i++ {
 			this.Options[i] = NewPopulatedOption(r, easy)
 		}
 	}
@@ -1875,9 +1875,9 @@ func NewPopulatedEnumValue(r randyType, easy bool) *EnumValue {
 		this.Number *= -1
 	}
 	if r.Intn(5) != 0 {
-		v7 := r.Intn(5)
-		this.Options = make([]*Option, v7)
-		for i := 0; i < v7; i++ {
+		vAlue7 := r.Intn(5)
+		this.Options = make([]*Option, vAlue7)
+		for i := 0; i < vAlue7; i++ {
 			this.Options[i] = NewPopulatedOption(r, easy)
 		}
 	}
@@ -1918,9 +1918,9 @@ func randUTF8RuneType(r randyType) rune {
 	return rune(ru + 61)
 }
 func randStringType(r randyType) string {
-	v8 := r.Intn(100)
-	tmps := make([]rune, v8)
-	for i := 0; i < v8; i++ {
+	vAlue8 := r.Intn(100)
+	tmps := make([]rune, vAlue8)
+	for i := 0; i < vAlue8; i++ {
 		tmps[i] = randUTF8RuneType(r)
 	}
 	return string(tmps)
@@ -1942,11 +1942,11 @@ func randFieldType(dAtA []byte, r randyType, fieldNumber int, wire int) []byte {
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateType(dAtA, uint64(key))
-		v9 := r.Int63()
+		vAlue9 := r.Int63()
 		if r.Intn(2) == 0 {
-			v9 *= -1
+			vAlue9 *= -1
 		}
-		dAtA = encodeVarintPopulateType(dAtA, uint64(v9))
+		dAtA = encodeVarintPopulateType(dAtA, uint64(vAlue9))
 	case 1:
 		dAtA = encodeVarintPopulateType(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))

--- a/types/wrappers.pb.go
+++ b/types/wrappers.pb.go
@@ -1641,9 +1641,9 @@ func NewPopulatedStringValue(r randyWrappers, easy bool) *StringValue {
 
 func NewPopulatedBytesValue(r randyWrappers, easy bool) *BytesValue {
 	this := &BytesValue{}
-	v1 := r.Intn(100)
-	this.Value = make([]byte, v1)
-	for i := 0; i < v1; i++ {
+	vAlue1 := r.Intn(100)
+	this.Value = make([]byte, vAlue1)
+	for i := 0; i < vAlue1; i++ {
 		this.Value[i] = byte(r.Intn(256))
 	}
 	if !easy && r.Intn(10) != 0 {
@@ -1671,9 +1671,9 @@ func randUTF8RuneWrappers(r randyWrappers) rune {
 	return rune(ru + 61)
 }
 func randStringWrappers(r randyWrappers) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	vAlue2 := r.Intn(100)
+	tmps := make([]rune, vAlue2)
+	for i := 0; i < vAlue2; i++ {
 		tmps[i] = randUTF8RuneWrappers(r)
 	}
 	return string(tmps)
@@ -1695,11 +1695,11 @@ func randFieldWrappers(dAtA []byte, r randyWrappers, fieldNumber int, wire int) 
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateWrappers(dAtA, uint64(key))
-		v3 := r.Int63()
+		vAlue3 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			vAlue3 *= -1
 		}
-		dAtA = encodeVarintPopulateWrappers(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateWrappers(dAtA, uint64(vAlue3))
 	case 1:
 		dAtA = encodeVarintPopulateWrappers(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))


### PR DESCRIPTION
The populate plugin generates local variables in the format `v1`,` v2`, `v3` etc. which are extremely likely to populate with package names that contains version identifier, a [rather popular paradigm](https://github.com/googleapis/googleapis/blob/master/google/pubsub/v1/pubsub.proto).