### PR TITLE
Fixed order of imports, make stable generation result

### DIFF
--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -1413,7 +1413,15 @@ func (g *Generator) generateImports() {
 	} else {
 		g.PrintImport(GoPackageName(g.Pkg["proto"]), GoImportPath(g.ImportPrefix)+GoImportPath("github.com/golang/protobuf/proto"))
 	}
-	for importPath, packageName := range imports {
+	importsOrder := make([]GoImportPath, 0, len(imports))
+	for importPath := range imports {
+		importsOrder = append(importsOrder, importPath)
+	}
+	sort.Slice(importsOrder, func(i, j int) bool {
+		return importsOrder[i] < importsOrder[j]
+	})
+	for _, importPath := range importsOrder {
+		packageName := imports[importPath]
 		g.P(packageName, " ", GoImportPath(g.ImportPrefix)+importPath)
 	}
 	// Custom gogo imports


### PR DESCRIPTION
It's connected with https://github.com/mwitkow/go-proto-validators/issues/62
Iteration order for map keys is not determinated
https://stackoverflow.com/questions/9619479/go-what-determines-the-iteration-order-for-map-keys