### PR TITLE
Go 1.15: Convert int to string using rune()

### DIFF
--- a/proto/text_parser.go
+++ b/proto/text_parser.go
@@ -318,7 +318,7 @@ func unescape(s string) (ch string, tail string, err error) {
 		if i > utf8.MaxRune {
 			return "", "", fmt.Errorf(`\%c%s is not a valid Unicode code point`, r, ss)
 		}
-		return string(i), s, nil
+		return string(rune(i)), s, nil
 	}
 	return "", "", fmt.Errorf(`unknown escape \%c`, r)
 }


### PR DESCRIPTION
See https://github.com/golang/go/issues/32479

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>