### PR TITLE
Support for merging messages implementing Merger which are embedded by value

### DIFF
--- a/proto/clone.go
+++ b/proto/clone.go
@@ -138,13 +138,17 @@ func mergeStruct(out, in reflect.Value) {
 // viaPtr indicates whether the values were indirected through a pointer (implying proto2).
 // prop is set if this is a struct field (it may be nil).
 func mergeAny(out, in reflect.Value, viaPtr bool, prop *Properties) {
-	if in.Type() == protoMessageType {
-		if !in.IsNil() {
-			if out.IsNil() {
-				out.Set(reflect.ValueOf(Clone(in.Interface().(Message))))
-			} else {
-				Merge(out.Interface().(Message), in.Interface().(Message))
+	if in.Type() == protoMessageType || (in.CanAddr() && in.Addr().Type().Implements(protoMessageType)) {
+		if in.Kind() == reflect.Ptr {
+			if !in.IsNil() {
+				if out.IsNil() {
+					out.Set(reflect.ValueOf(Clone(in.Interface().(Message))))
+				} else {
+					Merge(out.Interface().(Message), in.Interface().(Message))
+				}
 			}
+		} else {
+			Merge(out.Addr().Interface().(Message), in.Addr().Interface().(Message))
 		}
 		return
 	}


### PR DESCRIPTION
This PR fixes a small issue with Clone to enable support for proto.Merger for types that are embedded as values.
Example of such scenario is overriding the type of the generated protobuf attribite to use a type from the Go's standard library - e.g. time.Time:
```protobuf
message MyResource {
    // ...
    // Created defines the creation timestamp.
    google.protobuf.Timestamp Created = 1 [
        (gogoproto.stdtime) = true,
        (gogoproto.nullable) = false,
        (gogoproto.jsontag) = "created"
    ];
    // ...
}
```
which results in the following type:
```go
type MyResource struct {
	// ...
	// Created defines the creation timestamp.
	Created *time.Time `protobuf:"bytes,1,opt,name=Created,stdtime" json:"created,omitempty"`
```
Values of such type cannot be `Clone`d as time.Time has unexported fields.
Additionally, if MyResource implements `proto.Merger` it is not used.

I'm not entirely sure this is the correct repository for this change as iiuc the proto/ code is partially based on [another](https://github.com/golang/protobuf/) repository which, in turn, is using yet another [one](github.com/protocolbuffers/protobuf-go). I'd appreciate it if you let me know whether this change is better addressed in one of these repositories instead.