### PR TITLE
Pin versions for dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,12 +149,12 @@ tests:
 	(cd test/stdtypes && make test)
 
 vet:
-	go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+	GO111MODULE=on go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@release-branch.go1.15
 	go vet ./...
 	go vet -vettool=$(shell which shadow) ./...
 
 errcheck:
-	go get github.com/kisielk/errcheck
+	GO111MODULE=on go get github.com/kisielk/errcheck@v1.2.0
 	errcheck ./test/...
 
 drone:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogo/protobuf
 go 1.15
 
 require (
-	github.com/kisielk/errcheck v1.5.0 // indirect
+	github.com/kisielk/errcheck v1.2.0 // indirect
 	github.com/kisielk/gotool v1.0.0 // indirect
-	golang.org/x/tools v0.0.0-20210106214847-113979e3529a // indirect
+	golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563 h1:NIou6eNFigscvKJmsbyez16S2cIS6idossORlFtSt2E=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 h1:HHeAlu5H9b71C+Fx0K+1dGgVFN1DM1/wz4aoGOA5qS8=
+golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f h1:tuwaIjfUa6eI6REiNueIxvNm1popyPUnqWga83S7U0o=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=


### PR DESCRIPTION
The indirect dependencies in `go.mod`, specifically  `golang.org/x/tools` and `github.com/kisielk/errcheck`, are not really used anywhere in the code. `go mod tidy` also removes these lines. They are only used in the `Makefile` using `go get`.

Currently, no version is specified while using `go get`. This means that go will try to fetch the latest version and this version can deviate from the version in `go.mod`. To avoid this, the PR updates the Makefile to explicitly `go get` the versions specified in `go.mod`.

Additionally, this PR also updates the versions to match the versions in `v1.3.1` i.e. avoids the version bumps made in https://github.com/gogo/protobuf/pull/717:
- `github.com/kisielk/errcheck` to `v1.2.0`
- `golang.org/x/tools` to [`release-branch.go1.15`](https://github.com/golang/tools/tree/release-branch.go1.15)

Context - bumping gogo/protobuf from v1.3.1 to v1.3.2 in kubernetes requires bumping x/tools as well, which we'd like to avoid in k8s (xref https://github.com/kubernetes/client-go/issues/927)

cc @awalterschulze 