### PR TITLE
Fixed GetMessage Helper Method

### DIFF
--- a/protoc-gen-gogo/descriptor/helper.go
+++ b/protoc-gen-gogo/descriptor/helper.go
@@ -152,9 +152,12 @@ func (file *FileDescriptorProto) GetMessage(typeName string) *DescriptorProto {
 		if msg.GetName() == typeName {
 			return msg
 		}
-		nes := file.GetNestedMessage(msg, strings.TrimPrefix(typeName, msg.GetName()+"."))
-		if nes != nil {
-			return nes
+		prefix := msg.GetName() + "."
+		if strings.HasPrefix(typeName, prefix) {
+			nes := file.GetNestedMessage(msg, strings.TrimPrefix(typeName, prefix))
+			if nes != nil {
+				return nes
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
**Issue**

Consider following proto file content

```
message Bike {
  MetaInfo meta_info = 1;
  message MetaInfo {
    string manufacturer = 1;
  }
}

message Car {
    MetaInfo meta_info = 1;
    message MetaInfo {
      string manufacturer = 1;
      int32 seating_capactiy = 2;
    }
}
```

If  [GetMessage](https://github.com/gogo/protobuf/blob/master/protoc-gen-gogo/descriptor/helper.go#L150) helper method is called with argument `Car.MetaInfo`.  

In the existing version, it will iterate over the top-level message `Bike` first, remove the `Bike.` prefix, and try to find `MetaInfo` in Nested Messages of `Bike` which it would be able to find but it is incorrect as caller asked for `Car.MetaInfo` not `Bike.MetaInfo`.

**Fix**

Added a check to search for nested message only if prefix match with provided typeName.
 
