### PR TITLE
Sort import for plugin outputs

### DIFF
--- a/protoc-gen-gogo/generator/helper.go
+++ b/protoc-gen-gogo/generator/helper.go
@@ -30,6 +30,7 @@ package generator
 
 import (
 	"bytes"
+	"go/ast"
 	"go/parser"
 	"go/printer"
 	"go/token"
@@ -375,13 +376,14 @@ func (g *Generator) generatePlugin(file *FileDescriptor, p Plugin) {
 	// Reformat generated code.
 	contents := string(g.Buffer.Bytes())
 	fset := token.NewFileSet()
-	ast, err := parser.ParseFile(fset, "", g, parser.ParseComments)
+	fileAST, err := parser.ParseFile(fset, "", g, parser.ParseComments)
 	if err != nil {
 		g.Fail("bad Go source code was generated:", contents, err.Error())
 		return
 	}
+	ast.SortImports(fset, fileAST)
 	g.Reset()
-	err = (&printer.Config{Mode: printer.TabIndent | printer.UseSpaces, Tabwidth: 8}).Fprint(g, fset, ast)
+	err = (&printer.Config{Mode: printer.TabIndent | printer.UseSpaces, Tabwidth: 8}).Fprint(g, fset, fileAST)
 	if err != nil {
 		g.Fail("generated Go source code could not be reformatted:", err.Error())
 	}


### PR DESCRIPTION
If generatePlugin() function is used to generate Go code, imports are not ordered. Because imports are technically a map inside a Generator and iteration order over a map is not deterministic, it results to import ordering in the resulting generated file be non-deterministic too.
This creates a problem for build tools that extensively use remote cache based on hashes of input targets, like Bazel.
The change adds sorting through AST. Ideally, generatePlugin() function should reuse the code for Generate() function, that already has this sorting among other things.