### PR TITLE
Add file propery to edit internal state tags

### DIFF
--- a/gogoproto/gogo.pb.go
+++ b/gogoproto/gogo.pb.go
@@ -606,7 +606,6 @@ var E_GoprotoUnkeyed = &proto.ExtensionDesc{
 	Filename:      "gogo.proto",
 }
 
-
 var E_Nullable = &proto.ExtensionDesc{
 	ExtendedType:  (*descriptor.FieldOptions)(nil),
 	ExtensionType: (*bool)(nil),

--- a/gogoproto/gogo.pb.go
+++ b/gogoproto/gogo.pb.go
@@ -363,6 +363,15 @@ var E_GoprotoUnkeyedAll = &proto.ExtensionDesc{
 	Filename:      "gogo.proto",
 }
 
+var E_IgnoreInternalStructFieldTags = &proto.ExtensionDesc{
+	ExtendedType:  (*descriptor.FileOptions)(nil),
+	ExtensionType: ([]string)(nil),
+	Field:         64036,
+	Name:          "gogoproto.ignore_internal_struct_field_tags",
+	Tag:           "bytes,63036,rep,name=ignore_internal_struct_field_tags",
+	Filename:      "gogoproto/gogo.proto",
+}
+
 var E_GoprotoGetters = &proto.ExtensionDesc{
 	ExtendedType:  (*descriptor.MessageOptions)(nil),
 	ExtensionType: (*bool)(nil),
@@ -596,6 +605,7 @@ var E_GoprotoUnkeyed = &proto.ExtensionDesc{
 	Tag:           "varint,64035,opt,name=goproto_unkeyed",
 	Filename:      "gogo.proto",
 }
+
 
 var E_Nullable = &proto.ExtensionDesc{
 	ExtendedType:  (*descriptor.FieldOptions)(nil),

--- a/gogoproto/gogo.pb.go
+++ b/gogoproto/gogo.pb.go
@@ -363,12 +363,12 @@ var E_GoprotoUnkeyedAll = &proto.ExtensionDesc{
 	Filename:      "gogo.proto",
 }
 
-var E_IgnoreInternalStructFieldTags = &proto.ExtensionDesc{
+var E_InternalStructFieldTags = &proto.ExtensionDesc{
 	ExtendedType:  (*descriptor.FileOptions)(nil),
 	ExtensionType: (*string)(nil),
 	Field:         64036,
-	Name:          "gogoproto.ignore_internal_struct_field_tags",
-	Tag:           "bytes,63036,rep,name=ignore_internal_struct_field_tags",
+	Name:          "gogoproto.internal_struct_field_tags",
+	Tag:           "bytes,63036,rep,name=internal_struct_field_tags",
 	Filename:      "gogoproto/gogo.proto",
 }
 

--- a/gogoproto/gogo.pb.go
+++ b/gogoproto/gogo.pb.go
@@ -365,7 +365,7 @@ var E_GoprotoUnkeyedAll = &proto.ExtensionDesc{
 
 var E_IgnoreInternalStructFieldTags = &proto.ExtensionDesc{
 	ExtendedType:  (*descriptor.FileOptions)(nil),
-	ExtensionType: ([]string)(nil),
+	ExtensionType: (*string)(nil),
 	Field:         64036,
 	Name:          "gogoproto.ignore_internal_struct_field_tags",
 	Tag:           "bytes,63036,rep,name=ignore_internal_struct_field_tags",

--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -88,7 +88,7 @@ extend google.protobuf.FileOptions {
 	optional bool goproto_sizecache_all = 63034;
 	optional bool goproto_unkeyed_all = 63035;
 
-	repeated string ignore_internal_struct_field_tags = 63036;
+	optional string ignore_internal_struct_field_tags = 63036;
 }
 
 extend google.protobuf.MessageOptions {

--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -88,7 +88,7 @@ extend google.protobuf.FileOptions {
 	optional bool goproto_sizecache_all = 63034;
 	optional bool goproto_unkeyed_all = 63035;
 
-	optional string ignore_internal_struct_field_tags = 63036;
+	optional string internal_struct_field_tags = 63036;
 }
 
 extend google.protobuf.MessageOptions {

--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -87,6 +87,8 @@ extend google.protobuf.FileOptions {
 
 	optional bool goproto_sizecache_all = 63034;
 	optional bool goproto_unkeyed_all = 63035;
+
+	repeated string ignore_internal_struct_field_tags = 63036;
 }
 
 extend google.protobuf.MessageOptions {
@@ -124,6 +126,7 @@ extend google.protobuf.MessageOptions {
 
 	optional bool goproto_sizecache = 64034;
 	optional bool goproto_unkeyed = 64035;
+
 }
 
 extend google.protobuf.FieldOptions {

--- a/gogoproto/helper.go
+++ b/gogoproto/helper.go
@@ -287,6 +287,18 @@ func GetMoreTags(field *google_protobuf.FieldDescriptorProto) *string {
 	}
 	return nil
 }
+func GetIgnoreInternalStructFieldTags(file *google_protobuf.FileDescriptorProto, message *google_protobuf.DescriptorProto) []*string {
+	if file == nil {
+		return nil
+	}
+	if file.Options != nil {
+		v, err := proto.GetExtension(file.Options, E_IgnoreInternalStructFieldTags)
+		if err == nil && v.([]*string) != nil {
+			return (v.([]*string))
+		}
+	}
+	return nil
+}
 
 type EnableFunc func(file *google_protobuf.FileDescriptorProto, message *google_protobuf.DescriptorProto) bool
 

--- a/gogoproto/helper.go
+++ b/gogoproto/helper.go
@@ -287,14 +287,14 @@ func GetMoreTags(field *google_protobuf.FieldDescriptorProto) *string {
 	}
 	return nil
 }
-func GetIgnoreInternalStructFieldTags(file *google_protobuf.FileDescriptorProto, message *google_protobuf.DescriptorProto) []*string {
+func GetInternalStructFieldTags(file *google_protobuf.FileDescriptorProto) *string {
 	if file == nil {
 		return nil
 	}
 	if file.Options != nil {
 		v, err := proto.GetExtension(file.Options, E_IgnoreInternalStructFieldTags)
-		if err == nil && v.([]*string) != nil {
-			return (v.([]*string))
+		if err == nil && v.(*string) != nil {
+			return (v.(*string))
 		}
 	}
 	return nil

--- a/gogoproto/helper.go
+++ b/gogoproto/helper.go
@@ -292,7 +292,7 @@ func GetInternalStructFieldTags(file *google_protobuf.FileDescriptorProto) *stri
 		return nil
 	}
 	if file.Options != nil {
-		v, err := proto.GetExtension(file.Options, E_IgnoreInternalStructFieldTags)
+		v, err := proto.GetExtension(file.Options, E_InternalStructFieldTags)
 		if err == nil && v.(*string) != nil {
 			return (v.(*string))
 		}

--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -2494,8 +2494,17 @@ func (g *Generator) generateGet(mc *msgCtx, protoField *descriptor.FieldDescript
 
 // generateInternalStructFields just adds the XXX_<something> fields to the message struct.
 func (g *Generator) generateInternalStructFields(mc *msgCtx, topLevelFields []topLevelField) {
+	ignoreInternalStructFieldTags := gogoproto.GetIgnoreInternalStructFieldTags(g.file.FileDescriptorProto, mc.message.DescriptorProto)
+
+	resolvedIgnoredTags := ""
+	if len(ignoreInternalStructFieldTags) > 0 {
+		for _, el := range ignoreInternalStructFieldTags {
+			resolvedIgnoredTags = "," + (*el) + "\"-\""
+		}
+	}
+
 	if gogoproto.HasUnkeyed(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
-		g.P("XXX_NoUnkeyedLiteral\tstruct{} `json:\"-\"`") // prevent unkeyed struct literals
+		g.P("XXX_NoUnkeyedLiteral\tstruct{} `json:\"-\"`" + resolvedIgnoredTags) // prevent unkeyed struct literals
 	}
 	if len(mc.message.ExtensionRange) > 0 {
 		if gogoproto.HasExtensionsMap(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
@@ -2503,16 +2512,16 @@ func (g *Generator) generateInternalStructFields(mc *msgCtx, topLevelFields []to
 			if opts := mc.message.Options; opts != nil && opts.GetMessageSetWireFormat() {
 				messageset = "protobuf_messageset:\"1\" "
 			}
-			g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, "json:\"-\"`")
+			g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, "json:\"-\"`"+resolvedIgnoredTags)
 		} else {
-			g.P("XXX_extensions\t\t[]byte `protobuf:\"bytes,0,opt\" json:\"-\"`")
+			g.P("XXX_extensions\t\t[]byte `protobuf:\"bytes,0,opt\" json:\"-\"`" + resolvedIgnoredTags)
 		}
 	}
 	if gogoproto.HasUnrecognized(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
-		g.P("XXX_unrecognized\t[]byte `json:\"-\"`")
+		g.P("XXX_unrecognized\t[]byte `json:\"-\"`" + resolvedIgnoredTags)
 	}
 	if gogoproto.HasSizecache(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
-		g.P("XXX_sizecache\tint32 `json:\"-\"`")
+		g.P("XXX_sizecache\tint32 `json:\"-\"`" + resolvedIgnoredTags)
 	}
 }
 

--- a/protoc-gen-gogo/generator/generator.go
+++ b/protoc-gen-gogo/generator/generator.go
@@ -2494,17 +2494,15 @@ func (g *Generator) generateGet(mc *msgCtx, protoField *descriptor.FieldDescript
 
 // generateInternalStructFields just adds the XXX_<something> fields to the message struct.
 func (g *Generator) generateInternalStructFields(mc *msgCtx, topLevelFields []topLevelField) {
-	ignoreInternalStructFieldTags := gogoproto.GetIgnoreInternalStructFieldTags(g.file.FileDescriptorProto, mc.message.DescriptorProto)
+	internalStructFieldTags := gogoproto.GetInternalStructFieldTags(g.file.FileDescriptorProto)
 
-	resolvedIgnoredTags := ""
-	if len(ignoreInternalStructFieldTags) > 0 {
-		for _, el := range ignoreInternalStructFieldTags {
-			resolvedIgnoredTags = "," + (*el) + "\"-\""
-		}
+	resolvedInternaltags := ""
+	if internalStructFieldTags != nil {
+		resolvedInternaltags = ", " + *internalStructFieldTags
 	}
 
 	if gogoproto.HasUnkeyed(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
-		g.P("XXX_NoUnkeyedLiteral\tstruct{} `json:\"-\"`" + resolvedIgnoredTags) // prevent unkeyed struct literals
+		g.P("XXX_NoUnkeyedLiteral\tstruct{} `json:\"-\"`" + resolvedInternaltags) // prevent unkeyed struct literals
 	}
 	if len(mc.message.ExtensionRange) > 0 {
 		if gogoproto.HasExtensionsMap(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
@@ -2512,16 +2510,16 @@ func (g *Generator) generateInternalStructFields(mc *msgCtx, topLevelFields []to
 			if opts := mc.message.Options; opts != nil && opts.GetMessageSetWireFormat() {
 				messageset = "protobuf_messageset:\"1\" "
 			}
-			g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, "json:\"-\"`"+resolvedIgnoredTags)
+			g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, "json:\"-\"`"+resolvedInternaltags)
 		} else {
-			g.P("XXX_extensions\t\t[]byte `protobuf:\"bytes,0,opt\" json:\"-\"`" + resolvedIgnoredTags)
+			g.P("XXX_extensions\t\t[]byte `protobuf:\"bytes,0,opt\" json:\"-\"`" + resolvedInternaltags)
 		}
 	}
 	if gogoproto.HasUnrecognized(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
-		g.P("XXX_unrecognized\t[]byte `json:\"-\"`" + resolvedIgnoredTags)
+		g.P("XXX_unrecognized\t[]byte `json:\"-\"`" + resolvedInternaltags)
 	}
 	if gogoproto.HasSizecache(g.file.FileDescriptorProto, mc.message.DescriptorProto) {
-		g.P("XXX_sizecache\tint32 `json:\"-\"`" + resolvedIgnoredTags)
+		g.P("XXX_sizecache\tint32 `json:\"-\"`" + resolvedInternaltags)
 	}
 }
 


### PR DESCRIPTION
resolve #647 


When adding some `moreTags`  as defined in https://github.com/gogo/protobuf/blob/master/test/tags/tags.proto, you get all the internal states generated as well. To avoid this one would need a new tag `tag:"-"`. This pull request tries to solve this problem by allowing a global internal tags field

