### PR TITLE
chore: fix typo in equals.go docs

### DIFF
--- a/proto/equal.go
+++ b/proto/equal.go
@@ -41,28 +41,28 @@ import (
 )
 
 /*
-Equal returns true iff protocol buffers a and b are equal.
+Equal returns true if protocol buffers a and b are equal.
 The arguments must both be pointers to protocol buffer structs.
 
 Equality is defined in this way:
-  - Two messages are equal iff they are the same type,
+  - Two messages are equal if they are the same type,
     corresponding fields are equal, unknown field sets
     are equal, and extensions sets are equal.
-  - Two set scalar fields are equal iff their values are equal.
+  - Two set scalar fields are equal if their values are equal.
     If the fields are of a floating-point type, remember that
     NaN != x for all x, including NaN. If the message is defined
     in a proto3 .proto file, fields are not "set"; specifically,
     zero length proto3 "bytes" fields are equal (nil == {}).
-  - Two repeated fields are equal iff their lengths are the same,
+  - Two repeated fields are equal if their lengths are the same,
     and their corresponding elements are equal. Note a "bytes" field,
     although represented by []byte, is not a repeated field and the
     rule for the scalar fields described above applies.
   - Two unset fields are equal.
   - Two unknown field sets are equal if their current
     encoded state is equal.
-  - Two extension sets are equal iff they have corresponding
+  - Two extension sets are equal if they have corresponding
     elements that are pairwise equal.
-  - Two map fields are equal iff their lengths are the same,
+  - Two map fields are equal if their lengths are the same,
     and they contain the same set of elements. Zero-length map
     fields are equal.
   - Every other combination of things are not equal.


### PR DESCRIPTION
typo in equals.go file 

`iff`-> `if` 

Super minor change but I have to look at it every day 😃 